### PR TITLE
Fix repositories and pluginRepositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,4 +52,16 @@
             <version>1.14.0-alpha-1</version>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
Fixing parent pom resolution by adding `repositories` and `pluginRepositories` in pom.

```
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project org.jenkins-ci.plugins:github-branch-source:0.1-beta-2-SNAPSHOT (/Users/amuniz/workspace/github-branch-source-plugin/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for org.jenkins-ci.plugins:github-branch-source:0.1-beta-2-SNAPSHOT: Could not find artifact org.jenkins-ci.plugins:plugin:pom:1.609.2 in central (https://repo.maven.apache.org/maven2) and 'parent.relativePath' points at no local POM @ line 4, column 13 -> [Help 2]
```

@reviewbybees 