### PR TITLE
GitHub Plugin upgraded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
-            <version>1.14.0-alpha-1</version>
+            <version>1.14.0</version>
         </dependency>
     </dependencies>
     <repositories>


### PR DESCRIPTION
We need to upgrade this dependency because this issue [JENKINS-30626](https://issues.jenkins-ci.org/browse/JENKINS-30626) [was included](https://github.com/jenkinsci/github-plugin/commit/03b1c879698eb76c8348b7e8b3514f1c9fb7ad41) in `github-plugin:1.14.0-alpha-2`. Next release was `github-plugin:1.14.0`

@reviewbybees especially, @jglick 