### PR TITLE
Upgraded Jenkins baseline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </licenses>
 
     <properties>
-        <jenkins.version>1.609.2</jenkins.version>
+        <jenkins.version>1.609.3</jenkins.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
This upgrading is not technically needed but it is helpful because Pipeline Plugin requires as of `1.14`, `Jenkins 1.609.3`, and there is a relationship very common between both plugins.

@reviewbybees specially @jglick 