### PR TITLE
[JENKINS-33256] Untrusted PRs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <jenkins.version>1.609.3</jenkins.version>
-        <workflow.version>1.15-SNAPSHOT</workflow.version>
+        <workflow.version>1.15</workflow.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 
     <properties>
         <jenkins.version>1.609.3</jenkins.version>
+        <workflow.version>1.15-SNAPSHOT</workflow.version>
     </properties>
 
     <scm>
@@ -61,6 +62,19 @@
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
             <version>1.14.0</version>
+        </dependency>
+        <!-- Currently just here for interactive testing via hpi:run: -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-aggregator</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-multibranch</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.71</version>
+            <version>1.72</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>1.0</version>
+            <version>1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -272,7 +272,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         }
         listener.getLogger().format("%n  %d branches were processed%n", branches);
 
-        if (repo.isPrivate()) {
             listener.getLogger().format("%n  Getting remote pull requests...%n");
             int pullrequests = 0;
             for (GHPullRequest ghPullRequest : repo.getPullRequests(GHIssueState.OPEN)) {
@@ -311,9 +310,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                 pullrequests++;
             }
             listener.getLogger().format("%n  %d pull requests were processed%n", pullrequests);
-        } else {
-            listener.getLogger().format("%n  Skipping pull requests for public repositories%n");
-        }
 
     }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -378,7 +378,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         if (head instanceof PullRequestSCMHead) {
             int number = ((PullRequestSCMHead) head).getNumber();
             ref = repo.getRef("pull/" + number + "/merge");
-            // TODO if we already had the GHPullRequest.user.login in a field in the PullRequestSCMHead, we could pass that directly and save an API call
+            // getPullRequests makes an extra API call, but we need its current .base.sha
             String trustedBase = trustedReplacement(repo, repo.getPullRequest(number));
             if (trustedBase != null) {
                 return new UntrustedPullRequestSCMRevision(head, ref.getObject().getSha(), trustedBase);

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -300,6 +300,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                 }
                 String trustedBase = trustedReplacement(repo, ghPullRequest);
                 if (trustedBase != null) {
+                    listener.getLogger().format("    (not from a trusted source)%n");
                     head = new PullRequestSCMHead(number, trustedBase);
                 }
                 SCMRevision hash = new SCMRevisionImpl(head, ghPullRequest.getHead().getSha());

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
@@ -38,9 +38,9 @@ public final class PullRequestSCMHead extends SCMHead {
 
     private static final long serialVersionUID = 1;
 
-    public final @CheckForNull SCMRevision trustedBase;
+    public final @CheckForNull String trustedBase;
 
-    public PullRequestSCMHead(int number, @CheckForNull SCMRevision trustedBase) {
+    public PullRequestSCMHead(int number, @CheckForNull String trustedBase) {
         super(PR_BRANCH_PREFIX + number);
         this.trustedBase = trustedBase;
     }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
@@ -24,7 +24,9 @@
 
 package org.jenkinsci.plugins.github_branch_source;
 
+import javax.annotation.CheckForNull;
 import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
 
 /**
  * Head corresponding to a pull request.
@@ -36,8 +38,11 @@ public final class PullRequestSCMHead extends SCMHead {
 
     private static final long serialVersionUID = 1;
 
-    public PullRequestSCMHead(int number) {
+    public final @CheckForNull SCMRevision trustedBase;
+
+    public PullRequestSCMHead(int number, @CheckForNull SCMRevision trustedBase) {
         super(PR_BRANCH_PREFIX + number);
+        this.trustedBase = trustedBase;
     }
 
     public int getNumber() {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/UntrustedPullRequestSCMRevision.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/UntrustedPullRequestSCMRevision.java
@@ -24,24 +24,19 @@
 
 package org.jenkinsci.plugins.github_branch_source;
 
+import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.scm.api.SCMHead;
 
 /**
- * Head corresponding to a pull request.
- * Named like {@code PR-123}.
+ * Revision of a pull request which should load sensitive files from the base branch.
  */
-public final class PullRequestSCMHead extends SCMHead {
+class UntrustedPullRequestSCMRevision extends AbstractGitSCMSource.SCMRevisionImpl {
+    
+    final String baseHash;
 
-    private static final String PR_BRANCH_PREFIX = "PR-";
-
-    private static final long serialVersionUID = 1;
-
-    public PullRequestSCMHead(int number) {
-        super(PR_BRANCH_PREFIX + number);
-    }
-
-    public int getNumber() {
-        return Integer.parseInt(getName().substring(PR_BRANCH_PREFIX.length()));
+    UntrustedPullRequestSCMRevision(SCMHead head, String hash, String baseHash) {
+        super(head, hash);
+        this.baseHash = baseHash;
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/UntrustedPullRequestSCMRevision.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/UntrustedPullRequestSCMRevision.java
@@ -39,4 +39,14 @@ class UntrustedPullRequestSCMRevision extends AbstractGitSCMSource.SCMRevisionIm
         this.baseHash = baseHash;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o) && baseHash.equals(((UntrustedPullRequestSCMRevision) o).baseHash);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode(); // good enough
+    }
+
 }


### PR DESCRIPTION
[JENKINS-33256](https://issues.jenkins-ci.org/browse/JENKINS-33256)

Downstream of https://github.com/jenkinsci/scm-api-plugin/pull/5 and (implicitly) https://github.com/jenkinsci/workflow-plugin/pull/244.

- [X] implementation sketch
- [x] finish implementation
- [x] verify that base commit is really in the target branch even for “stacked” PRs
- [X] get a PR on [`PR-demo`](https://github.com/cloudbeers/PR-demo) modifying `Jenkinsfile` from an [outsider](https://github.com/orgs/cloudbeers/people): https://github.com/cloudbeers/PR-demo/pull/6
- [x] interactive test

@reviewbybees esp. @stephenc, @recena