### PR TITLE
[JENKINS-33306] Stack trace printed when repo:status privilege missing

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
@@ -92,29 +92,38 @@ public class GitHubBuildStatusNotification {
                     } catch (IllegalStateException ise) {
                         url = "http://unconfigured-jenkins-location/" + build.getUrl();
                     }
-                    Result result = build.getResult();
-                    String revisionToNotify = resolveHeadCommit(repo, revision);
-                    if (Result.SUCCESS.equals(result)) {
-                        createCommitStatus(repo, revisionToNotify, GHCommitState.SUCCESS, url, Messages.GitHubBuildStatusNotification_CoomitStatus_Good());
-                    } else if (Result.UNSTABLE.equals(result)) {
-                        createCommitStatus(repo, revisionToNotify, GHCommitState.FAILURE, url, Messages.GitHubBuildStatusNotification_CommitStatus_Unstable());
-                    } else if (Result.FAILURE.equals(result)) {
-                        createCommitStatus(repo, revisionToNotify, GHCommitState./* TODO or ERROR? */FAILURE, url, Messages.GitHubBuildStatusNotification_CommitStatus_Failure());
-                    } else if (result != null) { // ABORTED etc.
-                        createCommitStatus(repo, revisionToNotify, GHCommitState.ERROR, url, Messages.GitHubBuildStatusNotification_CommitStatus_Other());
-                    } else {
-                        createCommitStatus(repo, revisionToNotify, GHCommitState.PENDING, url, Messages.GitHubBuildStatusNotification_CommitStatus_Pending());
-                    }
-                    if (result != null) {
-                        listener.getLogger().format("%n" + Messages.GitHubBuildStatusNotification_CommitStatusSet() + "%n%n");
+                    boolean ignoreError = false;
+                    try {
+                        Result result = build.getResult();
+                        String revisionToNotify = resolveHeadCommit(repo, revision);
+                        if (Result.SUCCESS.equals(result)) {
+                            createCommitStatus(repo, revisionToNotify, GHCommitState.SUCCESS, url, Messages.GitHubBuildStatusNotification_CoomitStatus_Good());
+                        } else if (Result.UNSTABLE.equals(result)) {
+                            createCommitStatus(repo, revisionToNotify, GHCommitState.FAILURE, url, Messages.GitHubBuildStatusNotification_CommitStatus_Unstable());
+                        } else if (Result.FAILURE.equals(result)) {
+                            createCommitStatus(repo, revisionToNotify, GHCommitState.FAILURE, url, Messages.GitHubBuildStatusNotification_CommitStatus_Failure());
+                        } else if (result != null) { // ABORTED etc.
+                            createCommitStatus(repo, revisionToNotify, GHCommitState.ERROR, url, Messages.GitHubBuildStatusNotification_CommitStatus_Other());
+                        } else {
+                            ignoreError = true;
+                            createCommitStatus(repo, revisionToNotify, GHCommitState.PENDING, url, Messages.GitHubBuildStatusNotification_CommitStatus_Pending());
+                        }
+                        if (result != null) {
+                            listener.getLogger().format("%n" + Messages.GitHubBuildStatusNotification_CommitStatusSet() + "%n%n");
+                        }
+                    } catch (FileNotFoundException fnfe) {
+                        if (!ignoreError) {
+                            listener.getLogger().format("%nCould not update commit status, please check if your scan " +
+                                    "credentials belong to a member of the organization or a collaborator of the " +
+                                    "repository and repo:status scope is selected%n%n");
+                            LOGGER.log(Level.FINE, null, fnfe);
+                        }
                     }
                 }
             }
-        } catch (FileNotFoundException fnfe) {
-            listener.getLogger().format("%nCould not update commit status, please check if your scan credentials belong to a member of the organization or a collaborator of the repository%n%n");
         } catch (IOException ioe) {
             listener.getLogger().format("%nCould not update commit status. Message: %s%n%n", ioe.getMessage());
-            LOGGER.log(Level.WARNING, "Could not update commit status", ioe);
+            LOGGER.log(Level.FINE, "Could not update commit status", ioe);
         }
 
 }
@@ -167,7 +176,7 @@ public class GitHubBuildStatusNotification {
     @Extension public static class PRJobScheduledListener extends QueueListener {
 
         /**
-         * Manages the Github Commit Pending Status.
+         * Manages the GitHub Commit Pending Status.
          */
         @Override public void onEnterWaiting(Queue.WaitingItem wi) {
             if (wi.task instanceof Job) {
@@ -191,8 +200,12 @@ public class GitHubBuildStatusNotification {
                             // In fact the submitter might push another commit before this build even starts.
                             createCommitStatus(repo, pr.getHead().getSha(), GHCommitState.PENDING, url, "This pull request is scheduled to be built");
                         }
+                    } catch (FileNotFoundException fnfe) {
+                        LOGGER.log(Level.WARNING, "Could not update commit status to PENDING. Valid scan credentials? Valid scopes?");
+                        LOGGER.log(Level.FINE, null, fnfe);
                     } catch (IOException ioe) {
-                        LOGGER.log(Level.WARNING, "Could not update commit status", ioe);
+                        LOGGER.log(Level.WARNING, "Could not update commit status to PENDING. Message: " + ioe.getMessage());
+                        LOGGER.log(Level.FINE, null, ioe);
                     }
                 }
             }
@@ -202,6 +215,7 @@ public class GitHubBuildStatusNotification {
 
     /**
      * With this listener one notifies to GitHub when the SCM checkout process has started.
+     * Possible option: GHCommitState.PENDING
      */
     @Extension public static class JobCheckOutListener extends SCMListener {
 
@@ -213,10 +227,10 @@ public class GitHubBuildStatusNotification {
 
     /**
      * With this listener one notifies to GitHub the build result.
+     * Possible options: GHCommitState.SUCCESS, GHCommitState.ERROR or GHCommitState.FAILURE
      */
     @Extension public static class JobCompletedListener extends RunListener<Run<?,?>> {
 
-        @SuppressWarnings("deprecation") // Run.getAbsoluteUrl appropriate here
         @Override public void onCompleted(Run<?, ?> build, TaskListener listener) {
             createBuildCommitStatus(build, listener);
         }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -275,46 +275,46 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         }
         listener.getLogger().format("%n  %d branches were processed%n", branches);
 
-            listener.getLogger().format("%n  Getting remote pull requests...%n");
-            int pullrequests = 0;
-            for (GHPullRequest ghPullRequest : repo.getPullRequests(GHIssueState.OPEN)) {
-                PullRequestSCMHead head = new PullRequestSCMHead(ghPullRequest);
-                final String branchName = head.getName();
-                listener.getLogger().format("%n    Checking pull request %s%n", HyperlinkNote.encodeTo(ghPullRequest.getHtmlUrl().toString(), "#" + branchName));
-                // FYI https://developer.github.com/v3/pulls/#response-1
-                Boolean mergeable = ghPullRequest.getMergeable();
-                if (!Boolean.TRUE.equals(mergeable)) {
-                    listener.getLogger().format("    Not mergeable, skipping%n%n");
-                    continue;
-                }
-                if (repo.getOwner().equals(ghPullRequest.getHead().getUser())) {
-                    listener.getLogger().format("    Submitted from origin repository, skipping%n%n");
-                    continue;
-                }
-                if (criteria != null) {
-                    SCMSourceCriteria.Probe probe = getProbe(branchName, "pull request", "refs/pull/" + head.getNumber() + "/head", repo, listener);
-                    if (criteria.isHead(probe, listener)) {
-                        listener.getLogger().format("    Met criteria%n");
-                    } else {
-                        listener.getLogger().format("    Does not meet criteria%n");
-                        continue;
-                    }
-                }
-                String trustedBase = trustedReplacement(repo, ghPullRequest);
-                SCMRevision hash;
-                if (trustedBase == null) {
-                    hash = new SCMRevisionImpl(head, ghPullRequest.getHead().getSha());
-                } else {
-                    listener.getLogger().format("    (not from a trusted source)%n");
-                    hash = new UntrustedPullRequestSCMRevision(head, ghPullRequest.getHead().getSha(), trustedBase);
-                }
-                observer.observe(head, hash);
-                if (!observer.isObserving()) {
-                    return;
-                }
-                pullrequests++;
+        listener.getLogger().format("%n  Getting remote pull requests...%n");
+        int pullrequests = 0;
+        for (GHPullRequest ghPullRequest : repo.getPullRequests(GHIssueState.OPEN)) {
+            PullRequestSCMHead head = new PullRequestSCMHead(ghPullRequest);
+            final String branchName = head.getName();
+            listener.getLogger().format("%n    Checking pull request %s%n", HyperlinkNote.encodeTo(ghPullRequest.getHtmlUrl().toString(), "#" + branchName));
+            // FYI https://developer.github.com/v3/pulls/#response-1
+            Boolean mergeable = ghPullRequest.getMergeable();
+            if (!Boolean.TRUE.equals(mergeable)) {
+                listener.getLogger().format("    Not mergeable, skipping%n%n");
+                continue;
             }
-            listener.getLogger().format("%n  %d pull requests were processed%n", pullrequests);
+            if (repo.getOwner().equals(ghPullRequest.getHead().getUser())) {
+                listener.getLogger().format("    Submitted from origin repository, skipping%n%n");
+                continue;
+            }
+            if (criteria != null) {
+                SCMSourceCriteria.Probe probe = getProbe(branchName, "pull request", "refs/pull/" + head.getNumber() + "/head", repo, listener);
+                if (criteria.isHead(probe, listener)) {
+                    listener.getLogger().format("    Met criteria%n");
+                } else {
+                    listener.getLogger().format("    Does not meet criteria%n");
+                    continue;
+                }
+            }
+            String trustedBase = trustedReplacement(repo, ghPullRequest);
+            SCMRevision hash;
+            if (trustedBase == null) {
+                hash = new SCMRevisionImpl(head, ghPullRequest.getHead().getSha());
+            } else {
+                listener.getLogger().format("    (not from a trusted source)%n");
+                hash = new UntrustedPullRequestSCMRevision(head, ghPullRequest.getHead().getSha(), trustedBase);
+            }
+            observer.observe(head, hash);
+            if (!observer.isObserving()) {
+                return;
+            }
+            pullrequests++;
+        }
+        listener.getLogger().format("%n  %d pull requests were processed%n", pullrequests);
 
     }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -275,46 +275,46 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         }
         listener.getLogger().format("%n  %d branches were processed%n", branches);
 
-        listener.getLogger().format("%n  Getting remote pull requests...%n");
-        int pullrequests = 0;
-        for (GHPullRequest ghPullRequest : repo.getPullRequests(GHIssueState.OPEN)) {
-            PullRequestSCMHead head = new PullRequestSCMHead(ghPullRequest);
-            final String branchName = head.getName();
-            listener.getLogger().format("%n    Checking pull request %s%n", HyperlinkNote.encodeTo(ghPullRequest.getHtmlUrl().toString(), "#" + branchName));
-            // FYI https://developer.github.com/v3/pulls/#response-1
-            Boolean mergeable = ghPullRequest.getMergeable();
-            if (!Boolean.TRUE.equals(mergeable)) {
-                listener.getLogger().format("    Not mergeable, skipping%n%n");
-                continue;
-            }
-            if (repo.getOwner().equals(ghPullRequest.getHead().getUser())) {
-                listener.getLogger().format("    Submitted from origin repository, skipping%n%n");
-                continue;
-            }
-            if (criteria != null) {
-                SCMSourceCriteria.Probe probe = getProbe(branchName, "pull request", "refs/pull/" + head.getNumber() + "/head", repo, listener);
-                if (criteria.isHead(probe, listener)) {
-                    listener.getLogger().format("    Met criteria%n");
-                } else {
-                    listener.getLogger().format("    Does not meet criteria%n");
+            listener.getLogger().format("%n  Getting remote pull requests...%n");
+            int pullrequests = 0;
+            for (GHPullRequest ghPullRequest : repo.getPullRequests(GHIssueState.OPEN)) {
+                PullRequestSCMHead head = new PullRequestSCMHead(ghPullRequest);
+                final String branchName = head.getName();
+                listener.getLogger().format("%n    Checking pull request %s%n", HyperlinkNote.encodeTo(ghPullRequest.getHtmlUrl().toString(), "#" + branchName));
+                // FYI https://developer.github.com/v3/pulls/#response-1
+                Boolean mergeable = ghPullRequest.getMergeable();
+                if (!Boolean.TRUE.equals(mergeable)) {
+                    listener.getLogger().format("    Not mergeable, skipping%n%n");
                     continue;
                 }
+                if (repo.getOwner().equals(ghPullRequest.getHead().getUser())) {
+                    listener.getLogger().format("    Submitted from origin repository, skipping%n%n");
+                    continue;
+                }
+                if (criteria != null) {
+                    SCMSourceCriteria.Probe probe = getProbe(branchName, "pull request", "refs/pull/" + head.getNumber() + "/head", repo, listener);
+                    if (criteria.isHead(probe, listener)) {
+                        listener.getLogger().format("    Met criteria%n");
+                    } else {
+                        listener.getLogger().format("    Does not meet criteria%n");
+                        continue;
+                    }
+                }
+                String trustedBase = trustedReplacement(repo, ghPullRequest);
+                SCMRevision hash;
+                if (trustedBase == null) {
+                    hash = new SCMRevisionImpl(head, ghPullRequest.getHead().getSha());
+                } else {
+                    listener.getLogger().format("    (not from a trusted source)%n");
+                    hash = new UntrustedPullRequestSCMRevision(head, ghPullRequest.getHead().getSha(), trustedBase);
+                }
+                observer.observe(head, hash);
+                if (!observer.isObserving()) {
+                    return;
+                }
+                pullrequests++;
             }
-            String trustedBase = trustedReplacement(repo, ghPullRequest);
-            SCMRevision hash;
-            if (trustedBase == null) {
-                hash = new SCMRevisionImpl(head, ghPullRequest.getHead().getSha());
-            } else {
-                listener.getLogger().format("    (not from a trusted source)%n");
-                hash = new UntrustedPullRequestSCMRevision(head, ghPullRequest.getHead().getSha(), trustedBase);
-            }
-            observer.observe(head, hash);
-            if (!observer.isObserving()) {
-                return;
-            }
-            pullrequests++;
-        }
-        listener.getLogger().format("%n  %d pull requests were processed%n", pullrequests);
+            listener.getLogger().format("%n  %d pull requests were processed%n", pullrequests);
 
     }
 


### PR DESCRIPTION
[JENKINS-33306](https://issues.jenkins-ci.org/browse/JENKINS-33306)

### Example

```
Started by user anonymous
Connecting to GitHub using recena/****** (MyPAT)
 > git rev-parse --is-inside-work-tree # timeout=10
Fetching changes from 2 remote Git repositories
 > git config remote.origin.url https://github.com/seville-jam/workflow-helloworld.git # timeout=10
Fetching upstream changes from https://github.com/seville-jam/workflow-helloworld.git
 > git --version # timeout=10
using .gitcredentials to set credentials
 > git config --local credential.helper store --file=/var/folders/y_/9z0ktk9d2lxcs18kw7l10h9w0000gn/T/git4664648971215722216.credentials # timeout=10
 > git fetch --tags --progress https://github.com/seville-jam/workflow-helloworld.git +refs/heads/*:refs/remotes/origin/*
 > git config --local --remove-section credential # timeout=10
 > git config remote.origin1.url https://github.com/seville-jam/workflow-helloworld.git # timeout=10
Fetching upstream changes from https://github.com/seville-jam/workflow-helloworld.git
using .gitcredentials to set credentials
 > git config --local credential.helper store --file=/var/folders/y_/9z0ktk9d2lxcs18kw7l10h9w0000gn/T/git7045466587526744178.credentials # timeout=10
 > git fetch --tags --progress https://github.com/seville-jam/workflow-helloworld.git +refs/pull/*/merge:refs/remotes/origin/pr/*
 > git config --local --remove-section credential # timeout=10
Checking out Revision a8e55ab71a968d6dcf945172f0e3a5c64190cdb5 (PR-4)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f a8e55ab71a968d6dcf945172f0e3a5c64190cdb5
 > git rev-list a8e55ab71a968d6dcf945172f0e3a5c64190cdb5 # timeout=10
[Pipeline] Allocate node : Start
Running on master in /Users/recena/Development/projects/github-branch-source-plugin/work/jobs/JENKINS-33306-1/jobs/workflow-helloworld/branches/PR-4/workspace
[Pipeline] node {
[Pipeline] echo
Hello World
[Pipeline] } //node
[Pipeline] Allocate node : End
[Pipeline] End of Pipeline

Could not update commit status, please check if your scan credentials belong to a member of the organization or a collaborator of the repository and repo:status scope is selected

Finished: SUCCESS
```

@reviewbybees 