### PR TITLE
Includes/excludes help

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -445,6 +445,14 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         }
 
         @Restricted(NoExternalUse.class)
+        public FormValidation doCheckIncludes(@QueryParameter String value) {
+            if (value.isEmpty()) {
+                return FormValidation.warning("Did you mean to use * to match all branches?");
+            }
+            return FormValidation.ok();
+        }
+
+        @Restricted(NoExternalUse.class)
         public FormValidation doCheckScanCredentialsId(@AncestorInPath SCMSourceOwner context,
                 @QueryParameter String scanCredentialsId, @QueryParameter String apiUri) {
             if (!scanCredentialsId.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -447,7 +447,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         @Restricted(NoExternalUse.class)
         public FormValidation doCheckIncludes(@QueryParameter String value) {
             if (value.isEmpty()) {
-                return FormValidation.warning("Did you mean to use * to match all branches?");
+                return FormValidation.warning(Messages.GitHubSCMSource_did_you_mean_to_use_to_match_all_branche());
             }
             return FormValidation.ok();
         }

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/help-excludes.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/help-excludes.html
@@ -1,0 +1,4 @@
+<div>
+    Branch name patterns to ignore even if matched by the includes list.
+    For example: <code>release</code>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/help-includes.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/help-includes.html
@@ -1,0 +1,4 @@
+<div>
+    Space-separated list of branch name patterns to consider.
+    You may use <code>*</code> as a wildcard; for example: <code>master release*</code>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -4,3 +4,4 @@ GitHubBuildStatusNotification.CommitStatus.Failure=This commit cannot be built
 GitHubBuildStatusNotification.CommitStatus.Other=Something is wrong with the build of this commit
 GitHubBuildStatusNotification.CommitStatus.Pending=This commit is being built
 GitHubBuildStatusNotification.CommitStatusSet=GitHub has been notified of this commit\u2019s build result
+GitHubSCMSource.did_you_mean_to_use_to_match_all_branche=Did you mean to use * to match all branches?


### PR DESCRIPTION
Not obvious that the default has to be `*`, not empty, for includes.

I also found a buglet fixed in https://github.com/jenkinsci/git-plugin/pull/391.

@reviewbybees esp. @abayer