### PR TITLE
[JENKINS-33305] Branch name filters at organization folder level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ target
 work
 /github-branch-source.iml
 /.idea
+.classpath
+.project
+.settings
+bin

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -63,8 +63,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
     private final String apiUri;
     private String pattern = ".*";
 
-    private @CheckForNull String includes;
-    private @CheckForNull String excludes;
+    @CheckForNull private String includes;
+    @CheckForNull private String excludes;
 
     @DataBoundConstructor public GitHubSCMNavigator(String apiUri, String repoOwner, String scanCredentialsId, String checkoutCredentialsId) {
         this.repoOwner = repoOwner;
@@ -73,7 +73,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
         this.apiUri = Util.fixEmpty(apiUri);
     }
 
-    public @Nonnull String getIncludes() {
+    @Nonnull public String getIncludes() {
         return includes != null ? includes : DescriptorImpl.defaultIncludes;
     }
 
@@ -81,7 +81,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
         this.includes = includes.equals(DescriptorImpl.defaultIncludes) ? null : includes;
     }
 
-    public @Nonnull String getExcludes() {
+    @Nonnull public String getExcludes() {
         return excludes != null ? excludes : DescriptorImpl.defaultExcludes;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -63,8 +63,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
     private final String apiUri;
     private String pattern = ".*";
 
-    private @Nonnull String includes = GitHubSCMSource.DescriptorImpl.defaultIncludes;
-    private @Nonnull String excludes = GitHubSCMSource.DescriptorImpl.defaultExcludes;
+    private @CheckForNull String includes;
+    private @CheckForNull String excludes;
 
     @DataBoundConstructor public GitHubSCMNavigator(String apiUri, String repoOwner, String scanCredentialsId, String checkoutCredentialsId) {
         this.repoOwner = repoOwner;
@@ -74,19 +74,19 @@ public class GitHubSCMNavigator extends SCMNavigator {
     }
 
     public @Nonnull String getIncludes() {
-        return includes;
+        return includes != null ? includes : DescriptorImpl.defaultIncludes;
     }
 
     @DataBoundSetter public void setIncludes(@Nonnull String includes) {
-        this.includes = includes;
+        this.includes = includes.equals(DescriptorImpl.defaultIncludes) ? null : includes;
     }
 
     public @Nonnull String getExcludes() {
-        return excludes;
+        return excludes != null ? excludes : DescriptorImpl.defaultExcludes;
     }
 
     @DataBoundSetter public void setExcludes(@Nonnull String excludes) {
-        this.excludes = excludes;
+        this.excludes = excludes.equals(DescriptorImpl.defaultExcludes) ? null : excludes;
     }
     
     public String getRepoOwner() {
@@ -203,8 +203,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
         SCMSourceObserver.ProjectObserver projectObserver = observer.observe(name);
         
         GitHubSCMSource ghSCMSource = new GitHubSCMSource(null, apiUri, checkoutCredentialsId, scanCredentialsId, repoOwner, name);
-        ghSCMSource.setExcludes(excludes);
-        ghSCMSource.setIncludes(includes);
+        ghSCMSource.setExcludes(getExcludes());
+        ghSCMSource.setIncludes(getIncludes());
         
         projectObserver.addSource(ghSCMSource);
         projectObserver.complete();
@@ -214,6 +214,10 @@ public class GitHubSCMNavigator extends SCMNavigator {
 
         private static final Logger LOGGER = Logger.getLogger(DescriptorImpl.class.getName());
 
+        public static final String defaultIncludes = GitHubSCMSource.DescriptorImpl.defaultIncludes;
+        public static final String defaultExcludes = GitHubSCMSource.DescriptorImpl.defaultExcludes;
+        public static final String SAME = GitHubSCMSource.DescriptorImpl.SAME;
+        
         @Override public String getDisplayName() {
             return Messages.GitHubSCMNavigator_DisplayName();
         }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -38,6 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMNavigatorDescriptor;
 import jenkins.scm.api.SCMSourceObserver;
@@ -62,6 +63,9 @@ public class GitHubSCMNavigator extends SCMNavigator {
     private final String apiUri;
     private String pattern = ".*";
 
+    private @Nonnull String includes = GitHubSCMSource.DescriptorImpl.defaultIncludes;
+    private @Nonnull String excludes = GitHubSCMSource.DescriptorImpl.defaultExcludes;
+
     @DataBoundConstructor public GitHubSCMNavigator(String apiUri, String repoOwner, String scanCredentialsId, String checkoutCredentialsId) {
         this.repoOwner = repoOwner;
         this.scanCredentialsId = Util.fixEmpty(scanCredentialsId);
@@ -69,6 +73,22 @@ public class GitHubSCMNavigator extends SCMNavigator {
         this.apiUri = Util.fixEmpty(apiUri);
     }
 
+    public @Nonnull String getIncludes() {
+        return includes;
+    }
+
+    @DataBoundSetter public void setIncludes(@Nonnull String includes) {
+        this.includes = includes;
+    }
+
+    public @Nonnull String getExcludes() {
+        return excludes;
+    }
+
+    @DataBoundSetter public void setExcludes(@Nonnull String excludes) {
+        this.excludes = excludes;
+    }
+    
     public String getRepoOwner() {
         return repoOwner;
     }
@@ -181,7 +201,12 @@ public class GitHubSCMNavigator extends SCMNavigator {
             throw new InterruptedException();
         }
         SCMSourceObserver.ProjectObserver projectObserver = observer.observe(name);
-        projectObserver.addSource(new GitHubSCMSource(null, apiUri, checkoutCredentialsId, scanCredentialsId, repoOwner, name));
+        
+        GitHubSCMSource ghSCMSource = new GitHubSCMSource(null, apiUri, checkoutCredentialsId, scanCredentialsId, repoOwner, name);
+        ghSCMSource.setExcludes(excludes);
+        ghSCMSource.setIncludes(includes);
+        
+        projectObserver.addSource(ghSCMSource);
         projectObserver.complete();
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/config.jelly
@@ -17,10 +17,10 @@
         <f:entry title="${%Checkout credentials}" field="checkoutCredentialsId">
             <c:select default="${descriptor.SAME}"/>
         </f:entry>
-            <f:entry title="${%Include branches}" field="includes">
-        <f:textbox default="${descriptor.defaultIncludes}"/>
+        <f:entry title="${%Include branches}" field="includes">
+            <f:textbox default="${descriptor.defaultIncludes}"/>
         </f:entry>
-            <f:entry title="${%Exclude branches}" field="excludes">
+        <f:entry title="${%Exclude branches}" field="excludes">
             <f:textbox default="${descriptor.defaultExcludes}"/>
         </f:entry>
     </f:advanced>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/config.jelly
@@ -17,5 +17,11 @@
         <f:entry title="${%Checkout credentials}" field="checkoutCredentialsId">
             <c:select default="${descriptor.SAME}"/>
         </f:entry>
+            <f:entry title="${%Include branches}" field="includes">
+        <f:textbox default="${descriptor.defaultIncludes}"/>
+        </f:entry>
+            <f:entry title="${%Exclude branches}" field="excludes">
+            <f:textbox default="${descriptor.defaultExcludes}"/>
+        </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/help-excludes.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/help-excludes.html
@@ -1,0 +1,4 @@
+<div>
+    Branch name patterns to ignore even if matched by the includes list.
+    For example: <code>release</code>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/help-includes.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/help-includes.html
@@ -1,0 +1,4 @@
+<div>
+    Space-separated list of branch name patterns to consider.
+    You may use <code>*</code> as a wildcard; for example: <code>master release*</code>
+</div>


### PR DESCRIPTION
[JENKINS-33305](https://issues.jenkins-ci.org/browse/JENKINS-33305)

- [x] Support for branch filtering at organization folder level.
- [x] Update `.gitignore`.

@reviewbybees esp. @jglick 