### PR TITLE
Invalid combination of Core and Pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <jenkins.version>1.609.3</jenkins.version>
-        <workflow.version>1.15</workflow.version>
+        <workflow.version>1.14</workflow.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Pipeline 1.15 [requires core 1.642.1](https://github.com/jenkinsci/pipeline-plugin/blob/workflow-1.15/pom.xml#L52), so only 1.14 can be set without bumping core here.

@reviewbybees