### PR TITLE
use http(s)/ssh URL by API's result rathar than fixed pattern.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -308,8 +308,9 @@ public class GitHubSCMNavigator extends SCMNavigator {
             throw new InterruptedException();
         }
         SCMSourceObserver.ProjectObserver projectObserver = observer.observe(name);
-        
-        GitHubSCMSource ghSCMSource = new GitHubSCMSource(null, apiUri, checkoutCredentialsId, scanCredentialsId, repoOwner, name);
+
+        GitHubSCMSource ghSCMSource = new GitHubSCMSource(null, apiUri, checkoutCredentialsId,
+                scanCredentialsId, repoOwner, name, repo.gitHttpTransportUrl(), repo.getSshUrl());
         ghSCMSource.setExcludes(getExcludes());
         ghSCMSource.setIncludes(getIncludes());
         ghSCMSource.setBuildOriginBranch(getBuildOriginBranch());

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -116,6 +116,10 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
 
     private final String repository;
 
+    private final String httpGitUrl;
+
+    private final String sshGitUrl;
+
     private @Nonnull String includes = DescriptorImpl.defaultIncludes;
 
     private @Nonnull String excludes = DescriptorImpl.defaultExcludes;
@@ -134,13 +138,15 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
     private @Nonnull Boolean buildForkPRHead = DescriptorImpl.defaultBuildForkPRHead;
 
     @DataBoundConstructor
-    public GitHubSCMSource(String id, String apiUri, String checkoutCredentialsId, String scanCredentialsId, String repoOwner, String repository) {
+    public GitHubSCMSource(String id, String apiUri, String checkoutCredentialsId, String scanCredentialsId, String repoOwner, String repository, String httpGitUrl, String sshGitUrl) {
         super(id);
         this.apiUri = Util.fixEmpty(apiUri);
         this.repoOwner = repoOwner;
         this.repository = repository;
         this.scanCredentialsId = Util.fixEmpty(scanCredentialsId);
         this.checkoutCredentialsId = checkoutCredentialsId;
+        this.httpGitUrl = Util.fixEmpty(httpGitUrl);
+        this.sshGitUrl = Util.fixEmpty(sshGitUrl);
     }
 
     /** Use defaults for old settings. */
@@ -327,7 +333,8 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
 
     @Override
     public String getRemote() {
-        return getUriResolver().getRepositoryUri(apiUri, repoOwner, repository);
+        String credentialsId = getCredentialsId();
+        return getUriResolver().getRepositoryUri(apiUri, repoOwner, repository, httpGitUrl, sshGitUrl);
     }
 
     @Override protected final void retrieve(SCMHeadObserver observer, final TaskListener listener) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/HttpsRepositoryUriResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/HttpsRepositoryUriResolver.java
@@ -30,8 +30,10 @@ package org.jenkinsci.plugins.github_branch_source;
 public class HttpsRepositoryUriResolver extends RepositoryUriResolver {
 
     @Override
-    public String getRepositoryUri(String apiUri, String owner, String repository) {
-        if (apiUri == null || apiUri.startsWith("https://")) {
+    public String getRepositoryUri(String apiUri, String owner, String repository, String httpUrl, String sshUrl) {
+        if (httpUrl != null) {
+            return httpUrl;
+        } else if (apiUri == null || apiUri.startsWith("https://")) {
             return "https://" + hostnameFromApiUri(apiUri) + "/" + owner + "/" + repository + ".git";
         } else {
             return "http://" + hostnameFromApiUri(apiUri) + "/" + owner + "/" + repository + ".git";

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/RepositoryUriResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/RepositoryUriResolver.java
@@ -32,7 +32,7 @@ import java.net.URL;
  */
 public abstract class RepositoryUriResolver {
 
-    public abstract String getRepositoryUri(String apiUri, String owner, String repository);
+    public abstract String getRepositoryUri(String apiUri, String owner, String repository, String httpUrl, String sshUrl);
 
     public static String hostnameFromApiUri(String apiUri) {
         if (apiUri != null) {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/SshRepositoryUriResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/SshRepositoryUriResolver.java
@@ -30,8 +30,12 @@ package org.jenkinsci.plugins.github_branch_source;
 public class SshRepositoryUriResolver extends RepositoryUriResolver {
 
     @Override
-    public String getRepositoryUri(String apiUri, String owner, String repository) {
-        return "git@" + hostnameFromApiUri(apiUri) + ":" + owner + "/" + repository + ".git";
+    public String getRepositoryUri(String apiUri, String owner, String repository, String httpUrl, String sshUrl) {
+        if (sshUrl != null) {
+            return sshUrl;
+        } else {
+            return "git@" + hostnameFromApiUri(apiUri) + ":" + owner + "/" + repository + ".git";
+        }
     }
 
 }


### PR DESCRIPTION
[GitBucket](https://github.com/gitbucket/gitbucket) is an opensource Git platform with high extensibility & github API compatibility.
It act as GitHub (Enterprise). But some differences are exists.

In GitBucket's side problems are fixed by my PR. gitbucket/gitbucket#1247, gitbucket/gitbucket#1248
But last one problem can't solve by GitBucket side.

**PROBLEM**
GitBucket provides git repository such as: http://server:port/git/user/repo.git 
GitHub Branch Source plugin use fixed pattern URL such as: http://server/user/repo.git 

**SOLUTION**
GitHub and GitBucket API returns http(s)/ssh git repository URL. Clients should use this URL rathar than fixed pattern URL.
