### PR TITLE
[JENKINS-36574] Use the minimum number of status contexts necessary

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
@@ -70,9 +70,19 @@ public class GitHubBuildStatusNotification {
     
     private static final Logger LOGGER = Logger.getLogger(GitHubBuildStatusNotification.class.getName());
 
-    private static void createCommitStatus(@Nonnull GHRepository repo, @Nonnull String revision, @Nonnull GHCommitState state, @Nonnull String url, @Nonnull String message, @Nonnull Job<?,?> job) throws IOException {
+    private static void createCommitStatus(@Nonnull GHRepository repo, @Nonnull String revision, @Nonnull GHCommitState state, @Nonnull String url, @Nonnull String message, @Nonnull SCMHead head) throws IOException {
         LOGGER.log(Level.FINE, "{0}/commit/{1} {2} from {3}", new Object[] {repo.getHtmlUrl(), revision, state, url});
-        repo.createCommitStatus(revision, state, url, message, "Jenkins job " + job.getName());
+        String context;
+        if (head instanceof PullRequestSCMHead) {
+            if (((PullRequestSCMHead) head).isMerge()) {
+                context = "continuous-integration/jenkins/pr-merge";
+            } else {
+                context = "continuous-integration/jenkins/pr-head";
+            }
+        } else {
+            context = "continuous-integration/jenkins/branch";
+        }
+        repo.createCommitStatus(revision, state, url, message, context);
     }
 
     @SuppressWarnings("deprecation") // Run.getAbsoluteUrl appropriate here
@@ -93,18 +103,19 @@ public class GitHubBuildStatusNotification {
                     try {
                         Result result = build.getResult();
                         String revisionToNotify = resolveHeadCommit(repo, revision);
+                        SCMHead head = revision.getHead();
                         Job<?,?> job = build.getParent();
                         if (Result.SUCCESS.equals(result)) {
-                            createCommitStatus(repo, revisionToNotify, GHCommitState.SUCCESS, url, Messages.GitHubBuildStatusNotification_CommitStatus_Good(), job);
+                            createCommitStatus(repo, revisionToNotify, GHCommitState.SUCCESS, url, Messages.GitHubBuildStatusNotification_CommitStatus_Good(), head);
                         } else if (Result.UNSTABLE.equals(result)) {
-                            createCommitStatus(repo, revisionToNotify, GHCommitState.FAILURE, url, Messages.GitHubBuildStatusNotification_CommitStatus_Unstable(), job);
+                            createCommitStatus(repo, revisionToNotify, GHCommitState.FAILURE, url, Messages.GitHubBuildStatusNotification_CommitStatus_Unstable(), head);
                         } else if (Result.FAILURE.equals(result)) {
-                            createCommitStatus(repo, revisionToNotify, GHCommitState.FAILURE, url, Messages.GitHubBuildStatusNotification_CommitStatus_Failure(), job);
+                            createCommitStatus(repo, revisionToNotify, GHCommitState.FAILURE, url, Messages.GitHubBuildStatusNotification_CommitStatus_Failure(), head);
                         } else if (result != null) { // ABORTED etc.
-                            createCommitStatus(repo, revisionToNotify, GHCommitState.ERROR, url, Messages.GitHubBuildStatusNotification_CommitStatus_Other(), job);
+                            createCommitStatus(repo, revisionToNotify, GHCommitState.ERROR, url, Messages.GitHubBuildStatusNotification_CommitStatus_Other(), head);
                         } else {
                             ignoreError = true;
-                            createCommitStatus(repo, revisionToNotify, GHCommitState.PENDING, url, Messages.GitHubBuildStatusNotification_CommitStatus_Pending(), job);
+                            createCommitStatus(repo, revisionToNotify, GHCommitState.PENDING, url, Messages.GitHubBuildStatusNotification_CommitStatus_Pending(), head);
                         }
                         if (result != null) {
                             listener.getLogger().format("%n" + Messages.GitHubBuildStatusNotification_CommitStatusSet() + "%n%n");
@@ -196,7 +207,7 @@ public class GitHubBuildStatusNotification {
                             }
                             // Has not been built yet, so we can only guess that the current PR head is what will be built.
                             // In fact the submitter might push another commit before this build even starts.
-                            createCommitStatus(repo, pr.getHead().getSha(), GHCommitState.PENDING, url, "This pull request is scheduled to be built", job);
+                            createCommitStatus(repo, pr.getHead().getSha(), GHCommitState.PENDING, url, "This pull request is scheduled to be built", head);
                         }
                     } catch (FileNotFoundException fnfe) {
                         LOGGER.log(Level.WARNING, "Could not update commit status to PENDING. Valid scan credentials? Valid scopes?");

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
@@ -104,7 +104,6 @@ public class GitHubBuildStatusNotification {
                         Result result = build.getResult();
                         String revisionToNotify = resolveHeadCommit(repo, revision);
                         SCMHead head = revision.getHead();
-                        Job<?,?> job = build.getParent();
                         if (Result.SUCCESS.equals(result)) {
                             createCommitStatus(repo, revisionToNotify, GHCommitState.SUCCESS, url, Messages.GitHubBuildStatusNotification_CommitStatus_Good(), head);
                         } else if (Result.UNSTABLE.equals(result)) {


### PR DESCRIPTION
[JENKINS-36574](https://issues.jenkins-ci.org/browse/JENKINS-36574)

The idea is from #65. Tested successfully against https://github.com/cloudbeers/PR-demo/pulls when building all available options.

@reviewbybees