### PR TITLE
Make sure we pick up GithubLinkAnnotator fix for WorkflowRun

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
-            <version>1.14.0</version>
+            <version>1.14.1</version>
         </dependency>
         <!-- Currently just here for interactive testing via hpi:run: -->
         <dependency>


### PR DESCRIPTION
From https://github.com/jenkinsci/github-plugin/pull/84. Otherwise we get errors during `hpi:run` when browsing changelogs (cf. #70).

@reviewbybees