### PR TITLE
Add a layer of caching to API calls.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -35,6 +35,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.google.common.hash.Hashing;
+import com.squareup.okhttp.Cache;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.OkUrlFactory;
 import hudson.Util;
@@ -96,7 +97,10 @@ public class Connector {
         gb.withEndpoint(apiUrl);
         gb.withRateLimitHandler(CUSTOMIZED);
 
-        OkHttpClient client = new OkHttpClient().setProxy(getProxy(host));
+        Cache cache = new Cache(Jenkins.getInstance().root, 10 * 1024 * 1024);
+        OkHttpClient client = new OkHttpClient();
+        client.setProxy(getProxy(host));
+        client.setCache(cache);
 
         gb.withConnector(new OkHttpConnector(new OkUrlFactory(client)));
 


### PR DESCRIPTION
This change should help to fix JENKINS-37866

It will help to increase the amount of 304 responses which do not count against the rate limit