### PR TITLE
apiUrl api.github.com requires special case repository resolving

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/RepositoryUriResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/RepositoryUriResolver.java
@@ -38,7 +38,9 @@ public abstract class RepositoryUriResolver {
         if (apiUri != null) {
             try {
                 URL endpoint = new URL(apiUri);
-                return endpoint.getHost();
+                if (!java.util.Objects.equals(endpoint.getHost(),"api.github.com")) {
+                    return endpoint.getHost();
+                }
             } catch (MalformedURLException e) {
                 // ignore
             }


### PR DESCRIPTION
in our testing we found that when the apiUrl was "api.github.com", then we were seeing repository remotes of "https://api.github.com/.../..." and that was breaking things as you cannot clone from https://api.github.com.

the fix seems easy enough, just check if the apiUrl host is api.github.com and return github.com instead.

here is a test class that you can run on the mainline and the proposed fix to see the difference:

```
import org.jenkinsci.plugins.github_branch_source.*;

public class TestRemote {
    public static void main(String[] args) {
        System.out.println(new HttpsRepositoryUriResolver().getRepositoryUri("https://api.github.com","owner","repository"));
    }
}
```

the mainline code outputs:
`https://api.github.com/owner/repository.git`
the modified code outputs:
`https://github.com/owner/repository.git`
