### PR TITLE
[JENKINS-41522] Add better trust checking by allowing non-forked code to be trusted

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
@@ -43,6 +43,7 @@ public final class PullRequestSCMHead extends SCMHead implements ChangeRequestSC
     private final String sourceOwner;
     private final String sourceRepo;
     private final String sourceBranch;
+    private final String targetOwner;
 
     PullRequestSCMHead(GHPullRequest pr, String name, boolean merge) {
         super(name);
@@ -50,6 +51,7 @@ public final class PullRequestSCMHead extends SCMHead implements ChangeRequestSC
         this.merge = merge;
         this.number = pr.getNumber();
         this.target = new BranchSCMHead(pr.getBase().getRef());
+        this.targetOwner = pr.getBase().getRepository().getOwnerName();
         // the source stuff is immutable for a pull request on github, so safe to store here
         this.sourceOwner = pr.getHead().getRepository().getOwnerName();
         this.sourceRepo = pr.getHead().getRepository().getName();
@@ -101,6 +103,10 @@ public final class PullRequestSCMHead extends SCMHead implements ChangeRequestSC
     @Override
     public SCMHead getTarget() {
         return target;
+    }
+
+    public String getTargetOwner() {
+        return targetOwner;
     }
 
     public String getSourceOwner() {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
@@ -69,12 +69,13 @@ public final class PullRequestSCMHead extends SCMHead implements ChangeRequestSC
     }
 
     PullRequestSCMHead(@NonNull String name, boolean merge, int number,
-                       BranchSCMHead target, String sourceOwner, String sourceRepo, String sourceBranch) {
+                       BranchSCMHead target, String sourceOwner, String targetOwner, String sourceRepo, String sourceBranch) {
         super(name);
         this.merge = merge;
         this.number = number;
         this.target = target;
         this.sourceOwner = sourceOwner;
+        this.targetOwner = targetOwner;
         this.sourceRepo = sourceRepo;
         this.sourceBranch = sourceBranch;
     }
@@ -110,9 +111,11 @@ public final class PullRequestSCMHead extends SCMHead implements ChangeRequestSC
                     new BranchSCMHead(metadata.getBaseRef()),
                     metadata.getUserLogin(),
                     null,
+                    null,
                     null
             );
         }
+
         return this;
     }
 


### PR DESCRIPTION
This resolves:

1. https://issues.jenkins-ci.org/browse/JENKINS-40652
1. https://issues.jenkins-ci.org/browse/JENKINS-37931

* Better fork detection
* Allow PR's from non-fork code. Behave as before for forked code
* Allow trusted files inside PR's (Jenkinsfile) from non-fork pull-requests. Let Github handle permissions on pull-requests for code within the same origin.