### PR TITLE
[JENKINS-42213] Changes in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,9 @@
     </licenses>
 
     <properties>
-        <jenkins.version>1.609.3</jenkins.version>
-        <workflow.version>1.14</workflow.version>
+        <jenkins.version>1.625.3</jenkins.version>
+        <java.level>7</java.level>
+        <workflow.version>1.14.2</workflow.version>
     </properties>
 
     <scm>
@@ -57,7 +58,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.6</version>
+            <version>2.1.8</version>
         </dependency>
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
@@ -70,6 +71,18 @@
             <version>0.1</version>
         </dependency>
         <!-- Currently just here for interactive testing via hpi:run: -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>script-security</artifactId>
+            <version>1.16</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-aggregator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
 
     <properties>
         <jenkins.version>1.625.3</jenkins.version>
-        <java.level>7</java.level>
         <workflow.version>1.14.2</workflow.version>
     </properties>
 


### PR DESCRIPTION
[JENKINS-42213](https://issues.jenkins-ci.org/browse/JENKINS-42213)

- Update baseline according to plugin dependencies.
- Check java.level is set to correct version.
- Bump and include plugins to fix PCT for 2.32.2

@reviewbybees @stephenc 