### PR TITLE
Possible fix for [JENKINS-41246] Branch scanning fails when PR refer to a deleted fork

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -597,7 +597,8 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                 if (includes != null && !wantBranches && !wantPRNumbers.contains(number)) {
                     continue;
                 }
-                boolean fork = !repo.getOwner().equals(ghPullRequest.getHead().getUser());
+                GHUser headUser = ghPullRequest.getHead().getUser();
+                boolean fork = !repo.getOwner().equals(headUser);
                 if (wantPRs) {
                     listener.getLogger().format("%n    Checking pull request %s%n",
                             HyperlinkNote.encodeTo(ghPullRequest.getHtmlUrl().toString(), "#" + number));
@@ -619,8 +620,8 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                     }
                     continue;
                 }
-                boolean trusted = collaboratorNames != null
-                        && collaboratorNames.contains(ghPullRequest.getHead().getUser().getLogin());
+                boolean trusted = collaboratorNames != null && headUser != null
+                        && collaboratorNames.contains(headUser.getLogin());
                 if (!trusted) {
                     listener.getLogger().format("    (not from a trusted source)%n");
                 }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -620,7 +620,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                     continue;
                 }
                 boolean trusted = collaboratorNames != null
-                        && collaboratorNames.contains(ghPullRequest.getHead().getRepository().getOwnerName());
+                        && collaboratorNames.contains(ghPullRequest.getHead().getUser().getLogin());
                 if (!trusted) {
                     listener.getLogger().format("    (not from a trusted source)%n");
                 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-41246

If a PR is opened from a fork of the main repository and the fork is then deleted, the PR can stick around and the plugin will be unable to handle this PR. Specifically, the fork now has a null repository reference and the code attempts to grab the fork's owner to determine if the PR is from a trusted collaborator.

This manifests itself as an NPE like so:

```
ERROR: Failed to create or update a subproject Pydev
java.lang.NullPointerException
	at org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.doRetrieve(GitHubSCMSource.java:571)
	at org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.retrieve(GitHubSCMSource.java:451)
	at jenkins.scm.api.SCMSource._retrieve(SCMSource.java:300)
	at jenkins.scm.api.SCMSource.fetch(SCMSource.java:254)
	at jenkins.branch.MultiBranchProjectFactory$BySCMSourceCriteria.recognizes(MultiBranchProjectFactory.java:260)
	at jenkins.branch.OrganizationFolder$SCMSourceObserverImpl$1.recognizes(OrganizationFolder.java:1153)
	at jenkins.branch.OrganizationFolder$SCMSourceObserverImpl$1.complete(OrganizationFolder.java:1168)
	at org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator.add(GitHubSCMNavigator.java:459)
	at org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator.visitSources(GitHubSCMNavigator.java:319)
	at jenkins.branch.OrganizationFolder.computeChildren(OrganizationFolder.java:398)
	at com.cloudbees.hudson.plugins.folder.computed.ComputedFolder.updateChildren(ComputedFolder.java:219)
	at com.cloudbees.hudson.plugins.folder.computed.FolderComputation.run(FolderComputation.java:141)
	at jenkins.branch.OrganizationFolder$OrganizationScan.run(OrganizationFolder.java:849)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:404)
```

You can test this against a PR like https://api.github.com/repos/aptana/Pydev/pulls/56 where this was breaking scanning. 

Note that this PR is not tested by me, but I believe does address the issue. The only complication I can foresee is if a PR can stick around after a user deletes their account as well. In that case, we'll get another NPE likely.

⚠️  Note that this has another side effect, which I think is to correct grabbing the collaborator name. This will now use the name of the user who filed the PR as the collaborator to check - rather than the owner of the repo the changes come from. I don't think they'd often differ under normal workflows, but this has changed with this PR.