### PR TITLE
Making source owner compare case-insensitive for trusted revision

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1027,7 +1027,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             throws IOException, InterruptedException {
         if (revision instanceof PullRequestSCMRevision) {
             PullRequestSCMHead head = (PullRequestSCMHead) revision.getHead();
-            if (repoOwner.equals(head.getSourceOwner())) {
+            if (repoOwner.equalsIgnoreCase(head.getSourceOwner())) {
                 // origin PR
                 return revision;
             }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -40,7 +40,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
@@ -60,6 +59,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -206,6 +206,17 @@ public class GitHubSCMSourceTest {
                 ),
                 instanceOf(GitHubRepoMetadataAction.class),
                 Matchers.<Action>is(new GitHubLink("icon-github-repo", "https://github.com/cloudbeers/yolo"))));
+    }
+
+    @Test
+    public void getTrustedRevisionReturnsRevisionIfRepoOwnerAndPullRequestBranchOwnerAreSameWithDifferentCase() throws Exception {
+        PullRequestSCMRevision revision = createRevision("CloudBeers");
+        assertThat(source.getTrustedRevision(revision, null), sameInstance((SCMRevision) revision));
+    }
+
+    private PullRequestSCMRevision createRevision(String sourceOwner) {
+        PullRequestSCMHead head = new PullRequestSCMHead("", false, 0, null, sourceOwner, null, null);
+        return new PullRequestSCMRevision(head, null, null);
     }
 
 }


### PR DESCRIPTION
My team ran into this issue yesterday and spent a few hours trying to figure it out. We were seeing "Loading trusted files from base branch" messages for one of our organizations, and eventually traced it down to the organization being configured in one spot in Jenkins with a capital letter, versus all lower case elsewhere (including GitHub). Figured it was worth changing to prevent anyone else from getting similarly tripped up.