### PR TITLE
Not building origin merge when webhook is received.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestGHEventSubscriber.java
@@ -312,7 +312,7 @@ public class PullRequestGHEventSubscriber extends GHEventsSubscriber {
                             if (!src.getBuildOriginPRMerge()) {
                                 continue;
                             }
-                            if (src.getBuildForkPRHead()) {
+                            if (src.getBuildOriginPRHead()) {
                                 branchName += "-merge";
                             }
                         }


### PR DESCRIPTION
This looks like a simple typo, as its different (and the logic seems correct) here: https://github.com/jenkinsci/github-branch-source-plugin/blob/f4403aecf858d25e5356a8eac100edd76911378b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java#L642-L644
