### PR TITLE
[JENKINS-40652] origin pr builds not treated as trusted - fix for regression in org repos origin PRs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -619,8 +619,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                     }
                     continue;
                 }
-                boolean trusted = collaboratorNames != null
-                        && collaboratorNames.contains(ghPullRequest.getHead().getRepository().getOwnerName());
+                boolean trusted = isTrusted(ghPullRequest, collaboratorNames);
                 if (!trusted) {
                     listener.getLogger().format("    (not from a trusted source)%n");
                 }
@@ -805,6 +804,13 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             }
             listener.getLogger().format("%n  %d branches were processed%n", branches);
         }
+    }
+
+    private boolean isTrusted(GHPullRequest ghPullRequest, Collection<String> collaboratorNames) {
+        String prUserLogin = ghPullRequest.getUser().getLogin();
+        String prRepoOwner = ghPullRequest.getHead().getRepository().getOwnerName();
+        return collaboratorNames != null
+                && (collaboratorNames.contains(prRepoOwner) || collaboratorNames.contains(prUserLogin));
     }
 
     /**


### PR DESCRIPTION
[JENKINS-40652](https://issues.jenkins-ci.org/browse/JENKINS-40652) is still broken, steps to replicate:

- setup multibranch job on an org repo (owner 'myOrg') using valid scan credentials for myOrg
- create PR from origin 
- observe that PR is not trusted during the scan

Faulty line is [here](https://github.com/jenkinsci/github-branch-source-plugin/blob/9e780cb548ed3f3b428085bca36c2a0ca0d2f65a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java#L622). When scan credentials are valid collaboratorNames is set to actual collaborators and it does not contain 'myOrg'