### PR TITLE
UX: Document valid Scan Credentials

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/help-scanCredentialsId.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/help-scanCredentialsId.html
@@ -4,6 +4,11 @@
         <strong>check out</strong> sources and <strong>mark</strong> commit statuses.
     </p>
     <p>
+        Note that <strong>only "username with password"</strong> credentials are supported.
+        Existing credentials of other kinds will be filtered out. This is because jenkins
+        exercises GitHub API, and this last one does not support other ways of authentication.
+    </p>
+    <p>
         If none is given, only the public repositories will be scanned, and commit status
         will not be set on GitHub.
     </p>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/help-scanCredentialsId.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/help-scanCredentialsId.html
@@ -4,6 +4,11 @@
         <strong>check out</strong> sources and <strong>mark</strong> commit statuses.
     </p>
     <p>
+        Note that <strong>only "username with password"</strong> credentials are supported.
+        Existing credentials of other kinds will be filtered out. This is because jenkins
+        exercises GitHub API, and this last one does not support other ways of authentication.
+    </p>
+    <p>
         If none is given, only the public repositories will be scanned, and commit status
         will not be set on GitHub.
     </p>


### PR DESCRIPTION
The current UI hints about the need of creating "username with password" to access private repositories, but there is no explicit reference as to the fact that only these kind of credentials are supported (other credential kinds are silently filtered out).
At least https://issues.jenkins-ci.org/browse/JENKINS-38957 and https://issues.jenkins-ci.org/browse/JENKINS-34020 would have been prevented.