### PR TITLE
enable configurable notification context honoring JENKINS-36574

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Endpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Endpoint.java
@@ -50,11 +50,13 @@ import org.kohsuke.stapler.QueryParameter;
 public class Endpoint extends AbstractDescribableImpl<Endpoint> {
     private final String name;
     private final String apiUri;
+    private final String commitStatusContextIdentifier;
 
     @DataBoundConstructor
-    public Endpoint(String apiUri, String name) {
+    public Endpoint(String apiUri, String name, String commitStatusContextIdentifier) {
         this.apiUri = Util.fixEmptyAndTrim(apiUri);
         this.name = Util.fixEmptyAndTrim(name);
+        this.commitStatusContextIdentifier = commitStatusContextIdentifier;
     }
 
     public String getApiUri() {
@@ -64,6 +66,11 @@ public class Endpoint extends AbstractDescribableImpl<Endpoint> {
     public String getName() {
         return name;
     }
+
+    public String getCommitStatusContextIdentifier() {
+        return commitStatusContextIdentifier;
+    }
+
 
     @Override
     public String toString() {
@@ -101,6 +108,7 @@ public class Endpoint extends AbstractDescribableImpl<Endpoint> {
     public static class DesciptorImpl extends Descriptor<Endpoint> {
 
         private static final Logger LOGGER = Logger.getLogger(DesciptorImpl.class.getName());
+        public static final String defaultCommitStatusContextIdentifier = "continuous-integration/jenkins";
 
         @Override
         public String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Endpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Endpoint.java
@@ -105,9 +105,9 @@ public class Endpoint extends AbstractDescribableImpl<Endpoint> {
     }
 
     @Extension
-    public static class DesciptorImpl extends Descriptor<Endpoint> {
+    public static class DescriptorImpl extends Descriptor<Endpoint> {
 
-        private static final Logger LOGGER = Logger.getLogger(DesciptorImpl.class.getName());
+        private static final Logger LOGGER = Logger.getLogger(DescriptorImpl.class.getName());
         public static final String defaultCommitStatusContextIdentifier = "continuous-integration/jenkins";
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
@@ -77,7 +77,7 @@ public class GitHubBuildStatusNotification {
         LOGGER.log(Level.FINE, "{0}/commit/{1} {2} from {3}", new Object[] {repo.getHtmlUrl(), revision, state, url});
         String context;
         String commitstatuscontext = endpoint.getCommitStatusContextIdentifier();
-        
+
         if (head instanceof PullRequestSCMHead) {
             if (((PullRequestSCMHead) head).isMerge()) {
                 context = commitstatuscontext + "/pr-merge";
@@ -199,7 +199,7 @@ public class GitHubBuildStatusNotification {
      * Returns the Endpoint associated to a Job.
      *
      * @param job A {@link Job}
-     * @return An {@link Endpoint} or null, if an Enpoint was not defined.
+     * @return An {@link Endpoint} or null, if an Endpoint was not defined.
      * @throws IOException
      */
     @CheckForNull

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
@@ -77,12 +77,13 @@ public class GitHubBuildStatusNotification {
         String context;
         if (head instanceof PullRequestSCMHead) {
             if (((PullRequestSCMHead) head).isMerge()) {
-                context = "continuous-integration/jenkins/pr-merge";
+                context = commitstatuscontext + "/pr-merge";
+
             } else {
-                context = "continuous-integration/jenkins/pr-head";
+                context = commitstatuscontext + "/pr-head";
             }
         } else {
-            context = "continuous-integration/jenkins/branch";
+            context = commitstatuscontext + "/branch";
         }
         repo.createCommitStatus(revision, state, url, message, context);
     }

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Endpoint/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Endpoint/config.jelly
@@ -6,14 +6,11 @@
   <f:entry title="${%Name}" field="name">
     <f:textbox/>
   </f:entry>
-  <f:block>
-    <table>
-      <f:optionalBlock name="advanced options" title="advanced options">
-        <f:entry title="${%commit status context identifier}" field="commitStatusContextIdentifier">
-          <f:textbox default="${descriptor.defaultCommitStatusContextIdentifier}"/>
-        </f:entry>
-      </f:optionalBlock>
-    </table>
-  </f:block>
-
+  <f:section>
+    <f:advanced>
+      <f:entry title="${%commit status context identifier}" field="commitStatusContextIdentifier">
+        <f:textbox default="${descriptor.defaultCommitStatusContextIdentifier}"/>
+      </f:entry>
+    </f:advanced>
+  </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Endpoint/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Endpoint/config.jelly
@@ -6,9 +6,6 @@
   <f:entry title="${%Name}" field="name">
     <f:textbox/>
   </f:entry>
-  <f:entry title="${%commit status context identifier}" field="commitStatusContextIdentifier">
-    <f:textbox default="${descriptor.defaultCommitStatusContextIdentifier}"/>
-  </f:entry>
   <f:block>
     <table>
       <f:optionalBlock name="advanced options" title="advanced options">

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Endpoint/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Endpoint/config.jelly
@@ -6,4 +6,17 @@
   <f:entry title="${%Name}" field="name">
     <f:textbox/>
   </f:entry>
+  <f:entry title="${%commit status context identifier}" field="commitStatusContextIdentifier">
+    <f:textbox default="${descriptor.defaultCommitStatusContextIdentifier}"/>
+  </f:entry>
+  <f:block>
+    <table>
+      <f:optionalBlock name="advanced options" title="advanced options">
+        <f:entry title="${%commit status context identifier}" field="commitStatusContextIdentifier">
+          <f:textbox default="${descriptor.defaultCommitStatusContextIdentifier}"/>
+        </f:entry>
+      </f:optionalBlock>
+    </table>
+  </f:block>
+
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Endpoint/help-commitStatusContextIdentifier.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Endpoint/help-commitStatusContextIdentifier.html
@@ -1,0 +1,3 @@
+<p>
+    A custom status for git status API <code>https://developer.github.com/v3/repos/statuses/</code>.
+</p>


### PR DESCRIPTION
In JENKINS-36574 changes to the notification context were made.
The "notification context" is set to:
continuous-integration/jenkins/pr
continuous-integration/jenkins/branch
This change implements a configurable "continuous-integration/jenkins" part in the global config of the github server.
This makes it possible e.g. to run two different jenkins instances against a single github repo/Organisation. This would not be possible otherwise because they would have the same "notification context".

This contains the improvements mentioned in #88.