### PR TITLE
Github Pull request filtering

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceContext.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceContext.java
@@ -28,6 +28,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.TaskListener;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.regex.Pattern;
+
 import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
@@ -71,6 +73,11 @@ public class GitHubSCMSourceContext
      * {@code true} if notifications should be disabled in this context.
      */
     private boolean notificationsDisabled;
+
+    /**
+     * Label for pull request to build.
+     */
+    private Pattern pullRequestLabelRegexPattern;
 
     /**
      * Constructor.
@@ -155,6 +162,14 @@ public class GitHubSCMSourceContext
      */
     public final boolean notificationsDisabled() {
         return notificationsDisabled;
+    }
+
+
+    /**
+     * Returns pull request label if set
+     */
+    public final Pattern pullRequestLabelRegexPattern() {
+        return pullRequestLabelRegexPattern;
     }
 
     /**
@@ -242,6 +257,12 @@ public class GitHubSCMSourceContext
     @NonNull
     public final GitHubSCMSourceContext withNotificationsDisabled(boolean disabled) {
         this.notificationsDisabled = disabled;
+        return this;
+    }
+
+
+    public GitHubSCMSourceContext withPullRequestLabelRegexPattern(Pattern pullRequestLabelRegexPattern) {
+        this.pullRequestLabelRegexPattern = pullRequestLabelRegexPattern;
         return this;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRequest.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
+
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadOrigin;
 import jenkins.scm.api.SCMSource;
@@ -81,6 +83,10 @@ public class GitHubSCMSourceRequest extends SCMSourceRequest {
      */
     @NonNull
     private final Set<ChangeRequestCheckoutStrategy> forkPRStrategies;
+    /**
+     * The pull request label
+     */
+    private final Pattern pullRequestLabelRegexPattern;
     /**
      * The set of pull request numbers that the request is scoped to or {@code null} if the request is not limited.
      */
@@ -147,6 +153,7 @@ public class GitHubSCMSourceRequest extends SCMSourceRequest {
         fetchTags = context.wantTags();
         fetchOriginPRs = context.wantOriginPRs();
         fetchForkPRs = context.wantForkPRs();
+        pullRequestLabelRegexPattern = context.pullRequestLabelRegexPattern();
         originPRStrategies = fetchOriginPRs && !context.originPRStrategies().isEmpty()
                 ? Collections.unmodifiableSet(EnumSet.copyOf(context.originPRStrategies()))
                 : Collections.<ChangeRequestCheckoutStrategy>emptySet();
@@ -271,6 +278,15 @@ public class GitHubSCMSourceRequest extends SCMSourceRequest {
             result.put(fork, getPRStrategies(fork));
         }
         return result;
+    }
+
+    /**
+     * Returns the label of pull requests
+     *
+     * @return pull request label
+     */
+    public Pattern getPullRequestLabelRegexPattern() {
+        return pullRequestLabelRegexPattern;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestLabelFilterTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestLabelFilterTrait.java
@@ -1,0 +1,142 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.github_branch_source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.util.FormValidation;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
+import jenkins.scm.impl.trait.Discovery;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * A {@link Discovery} trait for GitHub that will only select pull requests that have specified label.
+ *
+ */
+public class PullRequestLabelFilterTrait extends SCMSourceTrait {
+    /**
+     * The strategy encoded as a bit-field.
+     */
+    private String pullRequestLabelRegex;
+
+    /**
+     * Constructor for stapler.
+     *
+     * @param pullRequestLabelRegex Label for selecting pull request
+     */
+    @DataBoundConstructor
+    public PullRequestLabelFilterTrait(String pullRequestLabelRegex) {
+        this.pullRequestLabelRegex = pullRequestLabelRegex;
+    }
+
+    /**
+     * Gets the pull request label
+     *
+     * @return the pull request label
+     */
+    public String getPullRequestLabelRegex() {
+        return pullRequestLabelRegex;
+    }
+
+    public Pattern getPullRequestLabelRegexPattern() {
+        Pattern pattern;
+        try {
+            pattern = Pattern.compile(getPullRequestLabelRegex());
+        } catch (PatternSyntaxException e) {
+            pattern = Pattern.compile(".*");
+        }
+        return pattern;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        GitHubSCMSourceContext ctx = (GitHubSCMSourceContext) context;
+        ctx.withPullRequestLabelRegexPattern(getPullRequestLabelRegexPattern());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean includeCategory(@NonNull SCMHeadCategory category) {
+        return category instanceof ChangeRequestSCMHeadCategory;
+    }
+
+    @Extension
+    @Discovery
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Filter pull requests by label";
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return GitHubSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return GitHubSCMSource.class;
+        }
+
+        @Restricted(NoExternalUse.class)
+        public FormValidation doCheckPullRequestLabelRegex(@QueryParameter String value) {
+            try {
+                if (value.trim().isEmpty()) {
+                    return FormValidation.error("Cannot have empty or blank regex.");
+                }
+                Pattern.compile(value);
+                return FormValidation.ok();
+            } catch (PatternSyntaxException e) {
+                return FormValidation.error(e.getMessage());
+            }
+        }
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/PullRequestLabelFilterTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/PullRequestLabelFilterTrait/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
+         xmlns:f="/lib/form" xmlns:f2="/org/jenkinsci/plugins/github_branch_source/form">
+  <f:entry title="Pull request label regex" field="pullRequestLabelRegex">
+    <f:textbox default=".*"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/PullRequestLabelFilterTrait/help-pullRequestLabelRegex.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/PullRequestLabelFilterTrait/help-pullRequestLabelRegex.html
@@ -1,0 +1,3 @@
+<div>
+    Regular expression to match labels with.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/PullRequestLabelFilterTrait/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/PullRequestLabelFilterTrait/help.html
@@ -1,0 +1,4 @@
+<div>
+    Filters github pull requests by label. Any github pull request that has a label matching with regular expression
+    will be built rest will be filtered out.
+</div>


### PR DESCRIPTION
This patch adds a Trait for filtering Github Pull Requests based on labels. User can optionally add a label regex in configuration and it only builds Pull Requests which have a matching label.