### PR TITLE
[JENKINS-46364] Connector.lookupScanCredentials - pass apiUrl()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
@@ -197,7 +197,7 @@ public class GitHubBuildStatusNotification {
             }
             if (source.getScanCredentialsId() != null) {
                 return Connector.connect(source.getApiUri(), Connector.lookupScanCredentials
-                        (job, null, source.getScanCredentialsId()));
+                        (job, source.getApiUri(), source.getScanCredentialsId()));
             }
         }
         return null;


### PR DESCRIPTION
This should fix [JENKINS-46364](https://issues.jenkins-ci.org/browse/JENKINS-46364).

There appears to be an issue with the github-branch-source plugin where if you put a specification on a credential's domain, the credential will never be selected to authenticate when creating a GitHub Status. This appears to be because the apiUrl is not being passed when looking up the credential.

The project build log will display the following when this case occurs: `Could not update commit status. Message: {"message":"Must authenticate to access this API.","documentation_url":"https://developer.github.com/enterprise/2.9/v3"}`

I have tested it out for a hostname specification and was able to successfully have it fail before and succeed after the patch. I also reverted to 2.2.2 and the failure returned.