### PR TITLE
Chain the cause exception and log in case of failure

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1291,7 +1291,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             github.checkApiUrlValidity();
         } catch (HttpException e) {
             String message = String.format("It seems %s is unreachable", apiUri == null ? GITHUB_URL : apiUri);
-            throw new AbortException(message);
+            throw new IOException(message, e);
         }
     }
 


### PR DESCRIPTION
My org folder scanning is failing, and I don't know why.

```
ERROR: [Thu Sep 14 13:26:12 UTC 2017] Could not fetch sources from navigator org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator@416977f4
hudson.AbortException: It seems https://api.github.com is unreachable
	at org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.checkApiUrlValidity(GitHubSCMSource.java:1022)
	at org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.retrieve(GitHubSCMSource.java:825)
	at jenkins.scm.api.SCMSource._retrieve(SCMSource.java:355)
	at jenkins.scm.api.SCMSource.fetch(SCMSource.java:309)
	at jenkins.branch.MultiBranchProjectFactory$BySCMSourceCriteria.recognizes(MultiBranchProjectFactory.java:263)
	at jenkins.branch.OrganizationFolder$SCMSourceObserverImpl$1.recognizes(OrganizationFolder.java:1297)
	at jenkins.branch.OrganizationFolder$SCMSourceObserverImpl$1.complete(OrganizationFolder.java:1312)
	at jenkins.scm.api.trait.SCMNavigatorRequest.process(SCMNavigatorRequest.java:256)
	at jenkins.scm.api.trait.SCMNavigatorRequest.process(SCMNavigatorRequest.java:206)
	at org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator.visitSources(GitHubSCMNavigator.java:961)
	at jenkins.branch.OrganizationFolder.computeChildren(OrganizationFolder.java:412)
	at com.cloudbees.hudson.plugins.folder.computed.ComputedFolder.updateChildren(ComputedFolder.java:276)
	at com.cloudbees.hudson.plugins.folder.computed.FolderComputation.run(FolderComputation.java:165)
	at jenkins.branch.OrganizationFolder$OrganizationScan.run(OrganizationFolder.java:863)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:419)
[Thu Sep 14 13:26:12 UTC 2017] Finished organization scan. Scan took 48 sec
```

From https://twitter.com/githubstatus there doesn't seem to be an issue right now. So overall, having more data to diagnose such issue in the future would be definitely helpful.

@reviewbybees 