### PR TITLE
[JENKINS-46967] Upgrading POM parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     </licenses>
 
     <properties>
-        <jenkins.version>1.625.3</jenkins.version>
+        <jenkins.version>1.642.3</jenkins.version>
         <workflow.version>1.14.2</workflow.version>
         <scm-api.version>2.2.0</scm-api.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.32</version>
+        <version>2.33</version>
         <relativePath />
     </parent>
     <artifactId>github-branch-source</artifactId>


### PR DESCRIPTION
[JENKINS-46967](https://issues.jenkins-ci.org/browse/JENKINS-46967)

- Upgrade to parent POM `2.33` to fix war-for-test issues.
- Current baseline for github-branch-source is `1.625.3` while baseline for branch-api `2.0.11` (dependency with scope test) is `1.642.3`.

@reviewbybees specially @stephenc 