### PR TITLE
[JENKINS-47171] `github.getRepository` expects 'org/repo' format

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1964,7 +1964,8 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                         (Item) getOwner(), apiUri, credentialsId
                 );
                 github = Connector.connect(apiUri, credentials);
-                repo = github.getRepository(repository);
+                String fullName = repoOwner + "/" + repository;
+                repo = github.getRepository(fullName);
             }
             return repo.getPermission(username);
         }


### PR DESCRIPTION
`github.getRepository` accepts github paths in `organization/repository` format.

See https://github.com/kohsuke/github-api/blob/master/src/main/java/org/kohsuke/github/GitHub.java#L425-L428
