### PR TITLE
new trait to control github notifications

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceContext.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceContext.java
@@ -73,6 +73,11 @@ public class GitHubSCMSourceContext
     private boolean notificationsDisabled;
 
     /**
+     * {@code true} if Jenkins URL should be hidden in this context.
+     */
+    private boolean hideUrlInNotifications;
+
+    /**
      * Constructor.
      *
      * @param criteria (optional) criteria.
@@ -156,6 +161,16 @@ public class GitHubSCMSourceContext
     public final boolean notificationsDisabled() {
         return notificationsDisabled;
     }
+
+    /**
+     * Returns {@code true} if Jenkins url should be hidden in notifications
+     *
+     * @return {@code true} if Jenkins url should be hidden in notifications
+     */
+    public final boolean hideUrlInNotifications() {
+        return hideUrlInNotifications;
+    }
+
 
     /**
      * Adds a requirement for branch details to any {@link GitHubSCMSourceRequest} for this context.
@@ -244,6 +259,20 @@ public class GitHubSCMSourceContext
         this.notificationsDisabled = disabled;
         return this;
     }
+
+
+    /**
+     * Defines the notification mode to use in this context.
+     *
+     * @param hide {@code true} to hide our jenkins url in notifications
+     * @return {@code this} for method chaining.
+     */
+    @NonNull
+    public final GitHubSCMSourceContext withHideUrlInNotifications(boolean hide) {
+        this.hideUrlInNotifications = hide;
+        return this;
+    }
+
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTrait.java
@@ -1,0 +1,110 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.github_branch_source;
+
+import hudson.Extension;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Discovery;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * A {@link Discovery} trait for GitHub that will prevent notifications like status updates
+ *
+ * @since TODO
+ */
+public class PreventNotificationsTrait extends SCMSourceTrait {
+
+    private boolean preventNotifications;
+    private boolean hideUrl;
+
+    /**
+     * Constructor for stapler.
+     */
+    @DataBoundConstructor
+    public PreventNotificationsTrait(boolean preventNotifications, boolean hideUrl) {
+        this.preventNotifications = preventNotifications;
+        this.hideUrl = hideUrl;
+    }
+
+
+    public boolean isPreventNotifications() {
+        return preventNotifications;
+    }
+
+    public boolean isHideUrl() {
+        return hideUrl;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        GitHubSCMSourceContext ctx = (GitHubSCMSourceContext) context;
+        if (preventNotifications) {
+            ctx.withNotificationsDisabled(true);
+        }
+        if (hideUrl) {
+            ctx.withHideUrlInNotifications(true);
+        }
+
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Extension
+    @Discovery
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.PreventNotificationsTrait_displayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return GitHubSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return GitHubSCMSource.class;
+        }
+
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -20,6 +20,7 @@ GitHubBuildStatusNotification.CommitStatus.Other=Something is wrong with the bui
 GitHubBuildStatusNotification.CommitStatus.Pending=This commit is being built
 GitHubBuildStatusNotification.CommitStatus.Queued=This commit is scheduled to be built
 GitHubBuildStatusNotification.CommitStatusSet=GitHub has been notified of this commit\u2019s build result
+GitHubBuildStatusNotification.HiddenUrl=http://hidden
 
 GitHubLink.DisplayName=GitHub
 
@@ -55,3 +56,5 @@ SSHCheckoutTrait.missingCredentials=The currently configured credentials cannot 
 SSHCheckoutTrait.useAgentKey=- use build agent''s key -
 TagDiscoveryTrait.authorityDisplayName=Trust origin tags
 TagDiscoveryTrait.displayName=Discover tags
+
+PreventNotificationsTrait.displayName=Prevent Github Notifications

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTrait/config.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:f2="/org/jenkinsci/plugins/github_branch_source/form">
+
+  <f:entry title="Prevent Notifications" field="preventNotifications">
+    <f:checkbox/>
+  </f:entry>
+
+  <f:entry title="Hide Jenkins URL" field="hideUrl">
+    <f:checkbox/>
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTrait/help-hideUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTrait/help-hideUrl.html
@@ -1,0 +1,3 @@
+<div>
+    Hide Jenkins URL from the status notifications sent to GitHub
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTrait/help-preventNotifications.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTrait/help-preventNotifications.html
@@ -1,0 +1,3 @@
+<div>
+    Completely disables notifications so no build status updating will occur in GitHub
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTrait/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTrait/help.html
@@ -1,0 +1,3 @@
+<div>
+    Control API notifications sent to GitHub
+</div>

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTraitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/PreventNotificationsTraitTest.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+import jenkins.scm.api.SCMHeadObserver;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+public class PreventNotificationsTraitTest {
+
+    @Test
+    public void settings_initial() throws Exception {
+        GitHubSCMSourceContext ctx = new GitHubSCMSourceContext(null, SCMHeadObserver.none());
+        assumeThat(ctx.notificationsDisabled(), is(false));
+        assumeThat(ctx.hideUrlInNotifications(), is(false));
+    }
+
+    @Test
+    public void notification_disabled() throws Exception {
+        GitHubSCMSourceContext ctx = new GitHubSCMSourceContext(null, SCMHeadObserver.none());
+        PreventNotificationsTrait instance = new PreventNotificationsTrait(true, false);
+        instance.decorateContext(ctx);
+        assertThat(ctx.notificationsDisabled(), is(true));
+        assertThat(ctx.hideUrlInNotifications(), is(false));
+    }
+
+    @Test
+    public void hideUrl_enabled() throws Exception {
+        GitHubSCMSourceContext ctx = new GitHubSCMSourceContext(null, SCMHeadObserver.none());
+        PreventNotificationsTrait instance = new PreventNotificationsTrait(false, true);
+        instance.decorateContext(ctx);
+        assertThat(ctx.notificationsDisabled(), is(false));
+        assertThat(ctx.hideUrlInNotifications(), is(true));
+    }
+}


### PR DESCRIPTION
Adds two checkboxes in a new Trait:
- disable notifications altogether
- just hide the jenkins url in them.

https://issues.jenkins-ci.org/browse/JENKINS-48408