### PR TITLE
[JENKINS-48035] Add a GitHubRepositoryNameContributor that recognises…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
         <workflow.version>1.14.2</workflow.version>
-        <scm-api.version>2.2.0</scm-api.version>
+        <scm-api.version>2.2.3</scm-api.version>
     </properties>
 
     <scm>
@@ -68,6 +68,11 @@
             <artifactId>display-url-api</artifactId>
             <version>0.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+            <version>2.0.16</version>
+        </dependency>
         <!-- Currently just here for interactive testing via hpi:run: -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -86,12 +91,6 @@
             <artifactId>scm-api</artifactId>
             <version>${scm-api.version}</version>
             <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>branch-api</artifactId>
-            <version>2.0.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,11 +68,6 @@
             <artifactId>display-url-api</artifactId>
             <version>0.2</version>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>branch-api</artifactId>
-            <version>2.0.16</version>
-        </dependency>
         <!-- Currently just here for interactive testing via hpi:run: -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -91,6 +86,12 @@
             <artifactId>scm-api</artifactId>
             <version>${scm-api.version}</version>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+            <version>2.0.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRepositoryNameContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRepositoryNameContributor.java
@@ -4,7 +4,7 @@ import com.cloudbees.jenkins.GitHubRepositoryName;
 import com.cloudbees.jenkins.GitHubRepositoryNameContributor;
 import hudson.Extension;
 import hudson.model.Item;
-import jenkins.branch.MultiBranchProject;
+import jenkins.scm.api.SCMSourceOwner;
 
 import java.util.Collection;
 
@@ -13,8 +13,8 @@ public class GitHubSCMSourceRepositoryNameContributor extends GitHubRepositoryNa
 
     @Override
     public void parseAssociatedNames(Item item, Collection<GitHubRepositoryName> result) {
-        if (item instanceof MultiBranchProject) {
-            MultiBranchProject mp = (MultiBranchProject) item;
+        if (item instanceof SCMSourceOwner) {
+            SCMSourceOwner mp = (SCMSourceOwner) item;
             for (Object o : mp.getSCMSources()) {
                 if (o instanceof GitHubSCMSource) {
                     GitHubSCMSource gitHubSCMSource = (GitHubSCMSource) o;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRepositoryNameContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRepositoryNameContributor.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 package org.jenkinsci.plugins.github_branch_source;
 
 import com.cloudbees.jenkins.GitHubRepositoryName;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRepositoryNameContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRepositoryNameContributor.java
@@ -1,0 +1,30 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+import com.cloudbees.jenkins.GitHubRepositoryName;
+import com.cloudbees.jenkins.GitHubRepositoryNameContributor;
+import hudson.Extension;
+import hudson.model.Item;
+import jenkins.branch.MultiBranchProject;
+
+import java.util.Collection;
+
+@Extension
+public class GitHubSCMSourceRepositoryNameContributor extends GitHubRepositoryNameContributor {
+
+    @Override
+    public void parseAssociatedNames(Item item, Collection<GitHubRepositoryName> result) {
+        if (item instanceof MultiBranchProject) {
+            MultiBranchProject mp = (MultiBranchProject) item;
+            for (Object o : mp.getSCMSources()) {
+                if (o instanceof GitHubSCMSource) {
+                    GitHubSCMSource gitHubSCMSource = (GitHubSCMSource) o;
+                    result.add(new GitHubRepositoryName(
+                            RepositoryUriResolver.hostnameFromApiUri(gitHubSCMSource.getApiUri()),
+                            gitHubSCMSource.getRepoOwner(),
+                            gitHubSCMSource.getRepository()));
+
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRepositoryNameContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRepositoryNameContributor.java
@@ -32,6 +32,12 @@ import jenkins.scm.api.SCMSourceOwner;
 
 import java.util.Collection;
 
+/**
+ * Finds the repository name(s) associated with a {@link SCMSourceOwner}'s {@link GitHubSCMSource}s.
+ *
+ * @see GitHubRepositoryNameContributor#parseAssociatedNames(Item)
+ * @see org.jenkinsci.plugins.github.webhook.WebhookManager#registerFor(Item)
+ */
 @Extension
 public class GitHubSCMSourceRepositoryNameContributor extends GitHubRepositoryNameContributor {
 

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -38,6 +38,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
 import hudson.model.Action;
+import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.model.User;
@@ -176,6 +177,31 @@ public class GitHubSCMSourceTest {
                 hasProperty("userName", equalTo("cloudbeers")),
                 hasProperty("repositoryName", equalTo("yolo"))
         )));
+    }
+
+    @Test
+    @Issue("JENKINS-48035")
+    public void testGitHubRepositoryNameContributor_When_not_GitHub() throws IOException {
+        WorkflowMultiBranchProject job = r.createProject(WorkflowMultiBranchProject.class);
+        job.setSourcesList(Arrays.asList(new BranchSource(new GitSCMSource("file://tmp/something"))));
+        Collection<GitHubRepositoryName> names = GitHubRepositoryNameContributor.parseAssociatedNames(job);
+        assertThat(names, Matchers.<GitHubRepositoryName>empty());
+        //And specifically...
+        names = new ArrayList<>();
+        ExtensionList.lookup(GitHubRepositoryNameContributor.class).get(GitHubSCMSourceRepositoryNameContributor.class).parseAssociatedNames(job, names);
+        assertThat(names, Matchers.<GitHubRepositoryName>empty());
+    }
+
+    @Test
+    @Issue("JENKINS-48035")
+    public void testGitHubRepositoryNameContributor_When_not_MultiBranch() throws IOException {
+        FreeStyleProject job = r.createProject(FreeStyleProject.class);
+        Collection<GitHubRepositoryName> names = GitHubRepositoryNameContributor.parseAssociatedNames((Item) job);
+        assertThat(names, Matchers.<GitHubRepositoryName>empty());
+        //And specifically...
+        names = new ArrayList<>();
+        ExtensionList.lookup(GitHubRepositoryNameContributor.class).get(GitHubSCMSourceRepositoryNameContributor.class).parseAssociatedNames((Item) job, names);
+        assertThat(names, Matchers.<GitHubRepositoryName>empty());
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -25,6 +25,8 @@
 
 package org.jenkinsci.plugins.github_branch_source;
 
+import com.cloudbees.jenkins.GitHubRepositoryName;
+import com.cloudbees.jenkins.GitHubRepositoryNameContributor;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -34,6 +36,7 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
 import hudson.model.Action;
 import hudson.model.Item;
 import hudson.model.TaskListener;
@@ -45,8 +48,13 @@ import hudson.util.ListBoxModel;
 import hudson.util.LogTaskListener;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+
+import jenkins.branch.BranchSource;
 import jenkins.branch.MultiBranchProject;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMSource;
@@ -67,6 +75,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.MockFolder;
@@ -74,7 +83,11 @@ import org.jvnet.hudson.test.MockFolder;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -144,6 +157,25 @@ public class GitHubSCMSourceTest {
         githubRaw.stubFor(get(urlMatching(".*")).atPriority(10)
                 .willReturn(aResponse().proxiedFrom("https://raw.githubusercontent.com/")));
         source = new GitHubSCMSource(null, "http://localhost:" + githubApi.port(), GitHubSCMSource.DescriptorImpl.SAME, null, "cloudbeers", "yolo");
+    }
+
+    @Test
+    @Issue("JENKINS-48035")
+    public void testGitHubRepositoryNameContributor() throws IOException {
+        WorkflowMultiBranchProject job = r.createProject(WorkflowMultiBranchProject.class);
+        job.setSourcesList(Arrays.asList(new BranchSource(source)));
+        Collection<GitHubRepositoryName> names = GitHubRepositoryNameContributor.parseAssociatedNames(job);
+        assertThat(names, contains(allOf(
+                hasProperty("userName", equalTo("cloudbeers")),
+                hasProperty("repositoryName", equalTo("yolo"))
+        )));
+        //And specifically...
+        names = new ArrayList<>();
+        ExtensionList.lookup(GitHubRepositoryNameContributor.class).get(GitHubSCMSourceRepositoryNameContributor.class).parseAssociatedNames(job, names);
+        assertThat(names, contains(allOf(
+                hasProperty("userName", equalTo("cloudbeers")),
+                hasProperty("repositoryName", equalTo("yolo"))
+        )));
     }
 
     @Test


### PR DESCRIPTION
… multi branch

The existing name contributors could only find the repo name if a build
of a branch had been made and added git build data to the job.
Since branches are discovered and built after GitHubSCMSource.afterSaved is called
there was no repo names recognised to add webhooks to.

This only solves the case when a single multi branch project is created.
Because when an org folder creates the multi branch jobs it does not call
afterSaved on the children. So that needs to be fixed someplace else.

@reviewbybees 