### PR TITLE
fix(discover branches): keep "PR branches" option

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait/help-strategyId.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait/help-strategyId.html
@@ -3,8 +3,8 @@
     <dl>
         <dt>Exclude branches that are also filed as PRs</dt>
         <dd>
-            If you are discovering origin pull requests, you may not want to also build branches on which those
-            pull requests are based.
+            If you are discovering origin pull requests, you may not want to also build the source branches
+            for those pull requests.
         </dd>
         <dt>Only branches that are also filed as PRs</dt>
         <dd>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait/help-strategyId.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait/help-strategyId.html
@@ -3,13 +3,14 @@
     <dl>
         <dt>Exclude branches that are also filed as PRs</dt>
         <dd>
-            If you are discovering origin pull requests, it may not make sense to discover the same changes both as a
-            pull request and as a branch.
+            If you are discovering origin pull requests, you may not want to also build branches on which those
+            pull requests are based.
         </dd>
         <dt>Only branches that are also filed as PRs</dt>
         <dd>
-            Similar to discovering pull requests directly, but env.GIT_BRANCH is set to the branch name rather than PR-#,
-            and github pull-request checks are not updated.
+            Similar to discovering origin pull requests, but discovers the branch rather than the pull request. 
+            This means <code>env.GIT_BRANCH</code> will be set to the branch name rather than <code>PR-#</code>.
+            Also, status notifications for these builds will only be applied to the commit and not to the pull request.
         </dd>
         <dt>All branches</dt>
         <dd>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait/help-strategyId.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait/help-strategyId.html
@@ -8,8 +8,8 @@
         </dd>
         <dt>Only branches that are also filed as PRs</dt>
         <dd>
-            This option exists to preserve legacy behaviour when upgrading from older versions of the plugin.
-            NOTE: If you have an actual use case for this option please file a pull request against this text.
+            Similar to discovering pull requests directly, but env.GIT_BRANCH is set to the branch name rather than PR-#,
+            and github pull-request checks are not updated.
         </dd>
         <dt>All branches</dt>
         <dd>


### PR DESCRIPTION
This PR is in response to the branch-discovery help text:
"
Only branches that are also filed as PRs
This option exists to preserve legacy behaviour
when upgrading from older versions of the plugin.
NOTE: If you have an actual use case for this option
please file a pull request against this text.
"

We have a Jenkins pipeline that deploys dockers for
pull requests to a k8s cluster.  The Dockers are
built by a separate process, and tagged with the
branch name, so we want our k8s-deploy pipeline
to be fed the PR branch name in env.GIT_BRANCH,
so it can reference the appropriate docker.

Hope that makes sense.