### PR TITLE
[JENKINS-47366] Avoid reporting premature build status

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubNotificationContext.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubNotificationContext.java
@@ -213,7 +213,7 @@ public final class GitHubNotificationContext {
      * @since TODO
      */
     public GHCommitState getDefaultState(TaskListener listener) {
-        if (null != build) {
+        if (null != build && !build.isBuilding()) {
             Result result = build.getResult();
             if (Result.SUCCESS.equals(result)) {
                 return GHCommitState.SUCCESS;


### PR DESCRIPTION
[JENKINS-47366](https://issues.jenkins-ci.org/browse/JENKINS-47366)

If a build result is set in the middle of a build and a secondary checkout is made, the default strategy reports that intermediate build result instead of "pending".

getDefaultState is currently called onCheckout and onCompleted. This change means any call to getDefaultState will just report pending while the build is in _BUILDING_ state (it will be in _POST_PRODUCTION_ for the onCompleted call)
