### PR TITLE
Recommend TrustPermission over TrustContributors

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait.java
@@ -318,7 +318,7 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
     }
 
     /**
-     * An {@link SCMHeadAuthority} that trusts contributors to the repository.
+     * An {@link SCMHeadAuthority} that trusts those with write permission to the repository.
      */
     public static class TrustPermission
             extends SCMHeadAuthority<GitHubSCMSourceRequest, PullRequestSCMHead, PullRequestSCMRevision> {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait.java
@@ -222,7 +222,7 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
         @NonNull
         @SuppressWarnings("unused") // stapler
         public SCMHeadAuthority<?, ?, ?> getDefaultTrust() {
-            return new TrustContributors();
+            return new TrustPermission();
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -236,7 +236,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
         this.traits = new ArrayList<>();
         this.traits.add(new BranchDiscoveryTrait(true, true));
         this.traits.add(new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE),
-                new ForkPullRequestDiscoveryTrait.TrustContributors()));
+                new ForkPullRequestDiscoveryTrait.TrustPermission()));
         if (!GitHubSCMSource.DescriptorImpl.SAME.equals(checkoutCredentialsId)) {
             traits.add(new SSHCheckoutTrait(checkoutCredentialsId));
         }
@@ -360,7 +360,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 if (buildForkPRHead) {
                     s.add(ChangeRequestCheckoutStrategy.HEAD);
                 }
-                traits.add(new ForkPullRequestDiscoveryTrait(s, new ForkPullRequestDiscoveryTrait.TrustContributors()));
+                traits.add(new ForkPullRequestDiscoveryTrait(s, new ForkPullRequestDiscoveryTrait.TrustPermission()));
             }
             if (checkoutCredentialsId != null
                     && !DescriptorImpl.SAME.equals(checkoutCredentialsId)
@@ -739,7 +739,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
         }
         if (buildForkPRMerge) {
             traits.add(new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE),
-                    new ForkPullRequestDiscoveryTrait.TrustContributors()));
+                    new ForkPullRequestDiscoveryTrait.TrustPermission()));
         }
     }
 
@@ -790,7 +790,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
         }
         if (buildForkPRHead) {
             traits.add(new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD),
-                    new ForkPullRequestDiscoveryTrait.TrustContributors()));
+                    new ForkPullRequestDiscoveryTrait.TrustPermission()));
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -327,7 +327,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         // legacy constructor means legacy defaults
         this.traits = new ArrayList<>();
         this.traits.add(new BranchDiscoveryTrait(true, true));
-        this.traits.add(new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE), new ForkPullRequestDiscoveryTrait.TrustContributors()));
+        this.traits.add(new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE), new ForkPullRequestDiscoveryTrait.TrustPermission()));
         if (!DescriptorImpl.SAME.equals(checkoutCredentialsId)) {
             traits.add(new SSHCheckoutTrait(checkoutCredentialsId));
         }
@@ -457,7 +457,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                 if (buildForkPRHead) {
                     s.add(ChangeRequestCheckoutStrategy.HEAD);
                 }
-                traits.add(new ForkPullRequestDiscoveryTrait(s, new ForkPullRequestDiscoveryTrait.TrustContributors()));
+                traits.add(new ForkPullRequestDiscoveryTrait(s, new ForkPullRequestDiscoveryTrait.TrustPermission()));
             }
             if (!"*".equals(includes) || !"".equals(excludes)) {
                 traits.add(new WildcardSCMHeadFilterTrait(includes, excludes));
@@ -780,7 +780,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         }
         if (buildForkPRMerge) {
             traits.add(new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE),
-                    new ForkPullRequestDiscoveryTrait.TrustContributors()));
+                    new ForkPullRequestDiscoveryTrait.TrustPermission()));
         }
     }
 
@@ -819,7 +819,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         }
         if (buildForkPRHead) {
             traits.add(new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD),
-                    new ForkPullRequestDiscoveryTrait.TrustContributors()));
+                    new ForkPullRequestDiscoveryTrait.TrustPermission()));
         }
     }
 
@@ -1907,7 +1907,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             return Arrays.asList( // TODO finalize
                     new BranchDiscoveryTrait(true, false),
                     new OriginPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)),
-                    new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE), new ForkPullRequestDiscoveryTrait.TrustContributors())
+                    new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE), new ForkPullRequestDiscoveryTrait.TrustPermission())
             );
         }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/TagDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/TagDiscoveryTrait.java
@@ -114,7 +114,7 @@ public class TagDiscoveryTrait extends SCMSourceTrait {
     }
 
     /**
-     * Trusts branches from the origin repository.
+     * Trusts tags from the origin repository.
      */
     public static class TagSCMHeadAuthority extends SCMHeadAuthority<SCMSourceRequest, GitHubTagSCMHead, GitTagSCMRevision> {
         /**

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustContributors/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustContributors/config.jelly
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:description>${%blurb}</f:description>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustContributors/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustContributors/config.properties
@@ -1,0 +1,1 @@
+blurb=<div class="warning">This option may be insecure in some environments. See help button.</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustEveryone/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustEveryone/config.jelly
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:description>${%blurb}</f:description>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustEveryone/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustEveryone/config.properties
@@ -1,0 +1,1 @@
+blurb=<div class="warning">This option is generally insecure. See help button.</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustPermission/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustPermission/config.jelly
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:description>${%blurb}</f:description>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustPermission/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/TrustPermission/config.properties
@@ -1,0 +1,1 @@
+blurb=May not be supported on older versions of GitHub Enterprise. See help button.

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-trust.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-trust.html
@@ -19,7 +19,7 @@
         </dd>
         <dt>Contributors</dt>
         <dd>
-            Pull requests from <a href="https://developer.github.com/v3/repos/collaborators/">collaborators</a>
+            Pull requests from <a href="https://developer.github.com/v3/repos/collaborators/" target="_blank">collaborators</a>
             to the origin repository will be treated as trusted, all other pull requests from fork repositories
             will be treated as untrusted.
             Note that if credentials used by Jenkins for scanning the repository does not have permission to
@@ -38,7 +38,7 @@
             permissions on the origin repository.
             This is the recommended policy.
             Note that this strategy requires the
-            <a href="https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level">Review
+            <a href="https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level" target="_blank">Review
             a user's permission level</a> API, as a result on GitHub Enterprise Server versions before 2.12 this
             is the same as trusting <strong>Nobody</strong>.
         </dd>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-trust.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-trust.html
@@ -25,6 +25,7 @@
             Note that if credentials used by Jenkins for scanning the repository does not have permission to
             query the list of contributors to the origin repository then only the origin account will be treated
             as trusted - i.e. this will fall back to <code>Nobody</code>.
+            <strong>NOTE:</strong> all collaborators are trusted, even if they are only members of team with read permission.
         </dd>
         <dt>Everyone</dt>
         <dd>
@@ -35,6 +36,7 @@
         <dd>
             Pull requests forks will be treated as trusted if and only if the fork owner has either Admin or Write
             permissions on the origin repository.
+            This is the recommended policy.
             Note that this strategy requires the
             <a href="https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level">Review
             a user's permission level</a> API, as a result on GitHub Enterprise Server versions before 2.12 this

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-trust.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-trust.html
@@ -36,7 +36,7 @@
         <dd>
             Pull requests forks will be treated as trusted if and only if the fork owner has either Admin or Write
             permissions on the origin repository.
-            This is the recommended policy.
+            <strong>This is the recommended policy.</strong>
             Note that this strategy requires the
             <a href="https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level" target="_blank">Review
             a user's permission level</a> API, as a result on GitHub Enterprise Server versions before 2.12 this

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-trust.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-trust.html
@@ -25,7 +25,7 @@
             Note that if credentials used by Jenkins for scanning the repository does not have permission to
             query the list of contributors to the origin repository then only the origin account will be treated
             as trusted - i.e. this will fall back to <code>Nobody</code>.
-            <strong>NOTE:</strong> all collaborators are trusted, even if they are only members of team with read permission.
+            <strong>NOTE:</strong> all collaborators are trusted, even if they are only members of a team with read permission.
         </dd>
         <dt>Everyone</dt>
         <dd>

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait2Test.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.github_branch_source;
+
+import java.util.Collections;
+import java.util.List;
+import jenkins.branch.BranchSource;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
+import jenkins.scm.api.trait.SCMHeadAuthority;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.For;
+import org.jvnet.hudson.test.JenkinsRule;
+
+@For(ForkPullRequestDiscoveryTrait.class)
+public class ForkPullRequestDiscoveryTrait2Test {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void configRoundtrip() throws Exception {
+        WorkflowMultiBranchProject p = r.createProject(WorkflowMultiBranchProject.class);
+        assertRoundTrip(p, new ForkPullRequestDiscoveryTrait.TrustNobody());
+        assertRoundTrip(p, new ForkPullRequestDiscoveryTrait.TrustEveryone());
+        assertRoundTrip(p, new ForkPullRequestDiscoveryTrait.TrustContributors());
+        assertRoundTrip(p, new ForkPullRequestDiscoveryTrait.TrustPermission());
+    }
+    private void assertRoundTrip(WorkflowMultiBranchProject p, SCMHeadAuthority<? super GitHubSCMSourceRequest, ? extends ChangeRequestSCMHead2, ? extends SCMRevision> trust) throws Exception {
+        GitHubSCMSource s = new GitHubSCMSource("nobody", "nowhere");
+        p.setSourcesList(Collections.singletonList(new BranchSource(s)));
+        s.setTraits(Collections.<SCMSourceTrait>singletonList(new ForkPullRequestDiscoveryTrait(0, trust)));
+        r.configRoundtrip(p);
+        List<SCMSourceTrait> traits = ((GitHubSCMSource) p.getSourcesList().get(0).getSource()).getTraits();
+        assertEquals(1, traits.size());
+        assertEquals(trust.getClass(), ((ForkPullRequestDiscoveryTrait) traits.get(0)).getTrust().getClass());
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTraitsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTraitsTest.java
@@ -82,7 +82,7 @@ public class GitHubSCMNavigatorTraitsTest {
                         Matchers.<SCMTrait<?>>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         )
                 )
         );
@@ -126,7 +126,7 @@ public class GitHubSCMNavigatorTraitsTest {
                         Matchers.<SCMTrait<?>>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
                         Matchers.<SCMTrait<?>>allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
@@ -174,7 +174,7 @@ public class GitHubSCMNavigatorTraitsTest {
                         Matchers.<SCMTrait<?>>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
                         Matchers.<SCMTrait<?>>allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
@@ -225,7 +225,7 @@ public class GitHubSCMNavigatorTraitsTest {
                         Matchers.<SCMTrait<?>>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         )
                 )
         );
@@ -266,7 +266,7 @@ public class GitHubSCMNavigatorTraitsTest {
                         Matchers.<SCMTrait<?>>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
                         Matchers.<SCMTrait<?>>allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
@@ -307,7 +307,7 @@ public class GitHubSCMNavigatorTraitsTest {
                         Matchers.<SCMTrait<?>>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
                         Matchers.<SCMTrait<?>>allOf(
                                 instanceOf(WildcardSCMHeadFilterTrait.class),
@@ -344,7 +344,7 @@ public class GitHubSCMNavigatorTraitsTest {
                         Matchers.<SCMTrait<?>>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
                         Matchers.<SCMTrait<?>>allOf(
                                 instanceOf(WildcardSCMHeadFilterTrait.class),
@@ -1581,7 +1581,7 @@ public class GitHubSCMNavigatorTraitsTest {
                         Matchers.<SCMTrait<?>>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategies", is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE))),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         )
                 )
         );
@@ -1614,7 +1614,7 @@ public class GitHubSCMNavigatorTraitsTest {
                         Matchers.<SCMTrait<?>>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategies", is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE))),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
                         Matchers.<SCMTrait<?>>allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -56,7 +56,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import jenkins.branch.BranchSource;
-import jenkins.branch.MultiBranchProject;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMSource;
 import java.util.logging.Level;
@@ -67,7 +66,6 @@ import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMHeadOrigin;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSourceCriteria;
-import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import org.hamcrest.Matchers;
@@ -79,16 +77,15 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
-import org.jvnet.hudson.test.MockFolder;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import java.util.EnumSet;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -157,7 +154,9 @@ public class GitHubSCMSourceTest {
                 get(urlMatching(".*")).atPriority(10).willReturn(aResponse().proxiedFrom("https://api.github.com/")));
         githubRaw.stubFor(get(urlMatching(".*")).atPriority(10)
                 .willReturn(aResponse().proxiedFrom("https://raw.githubusercontent.com/")));
-        source = new GitHubSCMSource(null, "http://localhost:" + githubApi.port(), GitHubSCMSource.DescriptorImpl.SAME, null, "cloudbeers", "yolo");
+        source = new GitHubSCMSource("cloudbeers", "yolo");
+        source.setApiUri("http://localhost:" + githubApi.port());
+        source.setTraits(Arrays.asList(new BranchDiscoveryTrait(true, true), new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE), new ForkPullRequestDiscoveryTrait.TrustContributors())));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
@@ -78,7 +78,7 @@ public class GitHubSCMSourceTraitsTest {
                         + "$OriginPullRequestDiscoveryTrait(strategyId=1), "
                         + "$ForkPullRequestDiscoveryTrait("
                         + "strategyId=2,"
-                        + "trust=$TrustContributors()), "
+                        + "trust=$TrustPermission()), "
                         + "@headWildcardFilter$WildcardSCMHeadFilterTrait(excludes=production,includes=i*)])")
         );
     }
@@ -125,7 +125,7 @@ public class GitHubSCMSourceTraitsTest {
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         )
                 )
         );
@@ -166,7 +166,7 @@ public class GitHubSCMSourceTraitsTest {
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         )
                 )
         );
@@ -207,7 +207,7 @@ public class GitHubSCMSourceTraitsTest {
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
                         Matchers.<SCMSourceTrait>allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
@@ -253,7 +253,7 @@ public class GitHubSCMSourceTraitsTest {
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         )
                 )
         );
@@ -290,7 +290,7 @@ public class GitHubSCMSourceTraitsTest {
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(WildcardSCMHeadFilterTrait.class),
@@ -332,7 +332,7 @@ public class GitHubSCMSourceTraitsTest {
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(WildcardSCMHeadFilterTrait.class),
@@ -374,7 +374,7 @@ public class GitHubSCMSourceTraitsTest {
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1)),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
                         Matchers.<SCMSourceTrait>allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
@@ -413,7 +413,7 @@ public class GitHubSCMSourceTraitsTest {
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategies", is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE))),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         )
                 )
         );
@@ -449,7 +449,7 @@ public class GitHubSCMSourceTraitsTest {
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategies", is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE))),
-                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class))
+                                hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
                         Matchers.<SCMSourceTrait>allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),


### PR DESCRIPTION
A more secure default, with better documentation of the effects of other choices.

@reviewbybees