### PR TITLE
JENKINS-50323 Public constructors for PullRequestSCMHead and PullRequestSCMRevision

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
@@ -64,7 +64,7 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
      */
     private transient Metadata metadata;
 
-    PullRequestSCMHead(PullRequestSCMHead copy) {
+    public PullRequestSCMHead(PullRequestSCMHead copy) {
         super(copy.getName());
         this.merge = copy.merge;
         this.number = copy.number;
@@ -76,7 +76,7 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
         this.metadata = copy.metadata;
     }
 
-    PullRequestSCMHead(GHPullRequest pr, String name, boolean merge) {
+    public PullRequestSCMHead(GHPullRequest pr, String name, boolean merge) {
         super(name);
         // the merge flag is encoded into the name, so safe to store here
         this.merge = merge;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java
@@ -64,7 +64,7 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
      */
     private transient Metadata metadata;
 
-    public PullRequestSCMHead(PullRequestSCMHead copy) {
+    PullRequestSCMHead(PullRequestSCMHead copy) {
         super(copy.getName());
         this.merge = copy.merge;
         this.number = copy.number;
@@ -76,7 +76,7 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
         this.metadata = copy.metadata;
     }
 
-    public PullRequestSCMHead(GHPullRequest pr, String name, boolean merge) {
+    PullRequestSCMHead(GHPullRequest pr, String name, boolean merge) {
         super(name);
         // the merge flag is encoded into the name, so safe to store here
         this.merge = merge;
@@ -92,7 +92,7 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
                 : new SCMHeadOrigin.Fork(this.sourceOwner);
     }
 
-    PullRequestSCMHead(@NonNull String name, String sourceOwner, String sourceRepo, String sourceBranch, int number,
+    public PullRequestSCMHead(@NonNull String name, String sourceOwner, String sourceRepo, String sourceBranch, int number,
                        BranchSCMHead target, SCMHeadOrigin origin, ChangeRequestCheckoutStrategy strategy) {
         super(name);
         this.merge = ChangeRequestCheckoutStrategy.MERGE == strategy;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMRevision.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMRevision.java
@@ -41,7 +41,7 @@ public class PullRequestSCMRevision extends ChangeRequestSCMRevision<PullRequest
     private final @NonNull String baseHash;
     private final @NonNull String pullHash;
 
-    PullRequestSCMRevision(@NonNull PullRequestSCMHead head, @NonNull String baseHash, @NonNull String pullHash) {
+    public PullRequestSCMRevision(@NonNull PullRequestSCMHead head, @NonNull String baseHash, @NonNull String pullHash) {
         super(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(), baseHash));
         this.baseHash = baseHash;
         this.pullHash = pullHash;


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-50323

Make constructors public for extension plugins which work with the SCM Events API. This is possibly a naive suggestion, let me know if this is a bad idea and hopefully an alternative approach.