### PR TITLE
[JENKINS-54046] Set default cache size to 0 for Windows masters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -155,7 +155,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
      * How big (in megabytes) an on-disk cache to keep of GitHub API responses. Cache is per repo, per credentials.
      */
     private static /*mostly final*/ int cacheSize =
-            Math.min(1024, Math.max(0, Integer.getInteger(GitHubSCMSource.class.getName() + ".cacheSize", 20)));
+            Math.min(1024, Math.max(0, Integer.getInteger(GitHubSCMSource.class.getName() + ".cacheSize", 0)));
     /**
      * Lock to guard access to the {@link #pullRequestSourceMap} field and prevent concurrent GitHub queries during
      * a 1.x to 2.2.0+ upgrade.

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -133,6 +133,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
+import static hudson.Functions.isWindows;
 import static hudson.model.Items.XSTREAM2;
 import static org.jenkinsci.plugins.github_branch_source.Connector.isCredentialValid;
 
@@ -155,7 +156,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
      * How big (in megabytes) an on-disk cache to keep of GitHub API responses. Cache is per repo, per credentials.
      */
     private static /*mostly final*/ int cacheSize =
-            Math.min(1024, Math.max(0, Integer.getInteger(GitHubSCMSource.class.getName() + ".cacheSize", 0)));
+            Math.min(1024, Math.max(0, Integer.getInteger(GitHubSCMSource.class.getName() + ".cacheSize", isWindows() ? 0 : 20)));
     /**
      * Lock to guard access to the {@link #pullRequestSourceMap} field and prevent concurrent GitHub queries during
      * a 1.x to 2.2.0+ upgrade.


### PR DESCRIPTION
# Description

See [JENKINS-54030](https://issues.jenkins-ci.org/browse/JENKINS-54030) and [JENKINS-54046](https://issues.jenkins-ci.org/browse/JENKINS-54046). This PR is a workaround for Windows masters, on which there is a file renaming bug in the caching. 

I've tested this to verify the following behaviors:

**Windows masters**

- Caching is disabled by default
- Caching can be turned back on temporarily by running `org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.cacheSize=20` (or some other number) in the script console. This change does not remain in place across a Jenkins restart.
- Caching can be changed permanently, by adding a system property in `C:\Path-To-Jenkins-Install\jenkins.xml` , inside the `<arguments>` tag, like this, where I set it to 33, so it would be easy to see it in the UI. Everything else in this line was already there from a clean Windows install:

```
<arguments>-Dorg.jenkinsci.plugins.github_branch_source.GitHubSCMSource.cacheSize=33 -Xrs -Xmx256m -Dhudson.lifecycle=hudson.lifecycle.WindowsServiceLifecycle -jar "%BASE%\jenkins.war" --httpPort=8080 --webroot="%BASE%\war"</arguments>
```

**Linux masters**

- Previous behavior is unchanged - caching is enabled by default, and its size is is 20MB.
- Caching can be disabled, or changed, by way of running `org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.cacheSize=20` in the script console. This change does not remain in place across a Jenkins restart.
- Caching can be changed permanently, by editing `/etc/default/jenkins`, so that the `JAVA_ARGS` line includes `-Dorg.jenkinsci.plugins.github_branch_source.GitHubSCMSource.cacheSize=0` to disable, or by setting a different number to enable it at the specified size.