### PR TITLE
Get updated pull request info when edited from Github [JENKINS-44715]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestGHEventSubscriber.java
@@ -132,7 +132,7 @@ public class PullRequestGHEventSubscriber extends GHEventsSubscriber {
                             changedRepository,
                             event.getOrigin()
                     ));
-                } else if ("reopened".equals(action) || "synchronize".equals(action)) {
+                } else if ("reopened".equals(action) || "synchronize".equals(action) || "edited".equals(action)) {
                     fireAfterDelay(new SCMHeadEventImpl(
                             SCMEvent.Type.UPDATED,
                             event.getTimestamp(),


### PR DESCRIPTION
Here's a use case scenario that this submission addresses:  

We have a `when` conditional to skip CI builds when there is "WIP" in the pull request title. Our builds are slow running (~2-3 hours), so the ability to skip is absolutely necessary.   
A developer edits the pull request title, removes "WIP" and reruns the pipeline. 
Without this change to the plugin, the pipeline will use the old title, and not see the updated title. The `when` conditional will falsely evaluate to true because it is not reading the latest title of the pull request.