### PR TITLE
HOTFIX: add @Symbol annotation to all SCMSourceTrait implementations.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait.java
@@ -31,7 +31,6 @@ import jenkins.scm.api.SCMHeadCategory;
 import jenkins.scm.api.SCMHeadOrigin;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
-import jenkins.scm.api.trait.SCMBuilder;
 import jenkins.scm.api.trait.SCMHeadAuthority;
 import jenkins.scm.api.trait.SCMHeadAuthorityDescriptor;
 import jenkins.scm.api.trait.SCMHeadFilter;
@@ -40,6 +39,7 @@ import jenkins.scm.api.trait.SCMSourceRequest;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.github.GHPullRequest;
@@ -51,6 +51,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  *
  * @since 2.2.0
  */
+@Symbol("ghBranchDiscoveryTrait")
 public class BranchDiscoveryTrait extends SCMSourceTrait {
     /**
      * The strategy encoded as a bit-field.

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait.java
@@ -44,6 +44,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.github.GHPermissionType;
@@ -54,6 +55,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  *
  * @since 2.2.0
  */
+@Symbol("ghForkPullRequestDiscoveryTrait")
 public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
     /**
      * The strategy encoded as a bit-field.

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait.java
@@ -44,6 +44,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -54,6 +55,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  *
  * @since 2.2.0
  */
+@Symbol("ghOriginPullRequestDiscoveryTrait")
 public class OriginPullRequestDiscoveryTrait extends SCMSourceTrait {
     /**
      * The strategy encoded as a bit-field.

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/SSHCheckoutTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/SSHCheckoutTrait.java
@@ -50,6 +50,7 @@ import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -62,6 +63,7 @@ import org.kohsuke.stapler.QueryParameter;
  *
  * @since 2.2.0
  */
+@Symbol("ghSSHCheckoutTrait")
 public class SSHCheckoutTrait extends SCMSourceTrait {
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/TagDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/TagDiscoveryTrait.java
@@ -25,27 +25,19 @@ package org.jenkinsci.plugins.github_branch_source;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.util.ListBoxModel;
 import jenkins.plugins.git.GitTagSCMRevision;
-import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadCategory;
 import jenkins.scm.api.SCMHeadOrigin;
-import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMHeadAuthority;
 import jenkins.scm.api.trait.SCMHeadAuthorityDescriptor;
-import jenkins.scm.api.trait.SCMHeadFilter;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceRequest;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
-import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.TagSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.github.GHPullRequest;
-import org.kohsuke.github.GHRepository;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -53,6 +45,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  *
  * @since TODO
  */
+@Symbol("ghTagDiscoveryTrait")
 public class TagDiscoveryTrait extends SCMSourceTrait {
     /**
      * Constructor for stapler.


### PR DESCRIPTION
- Avoid collision with other plugins by prefixing gh to symbol name.
- Allows plugin to be configured through CasC plugin.