### PR TITLE
Name sections consistently

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1409,7 +1409,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                     true, result);
             NamedArrayList.select(all, "Within repository", NamedArrayList.anyOf(NamedArrayList.withAnnotation(Discovery.class),NamedArrayList.withAnnotation(Selection.class)),
                     true, result);
-            NamedArrayList.select(all, "Additional", null, true, result);
+            NamedArrayList.select(all, "General", null, true, result);
             return result;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1989,7 +1989,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                             .anyOf(NamedArrayList.withAnnotation(Discovery.class),
                                     NamedArrayList.withAnnotation(Selection.class)),
                     true, result);
-            NamedArrayList.select(all, "Additional", null, true, result);
+            NamedArrayList.select(all, "General", null, true, result);
             return result;
         }
 


### PR DESCRIPTION
* the "cloudbees-bitbucket-branch-source" plugin also uses "General"
* both help files use "General"
  * .../GitHubSCMNavigator/help-traits.html
  * .../GitHubSCMSource/help-traits.html