### PR TITLE
Need to loop twice

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbe.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbe.java
@@ -145,6 +145,8 @@ class GitHubSCMProbe extends SCMProbe implements GitHubClosable {
                         return SCMProbeStat.fromType(SCMFile.Type.OTHER);
                     }
                 }
+            }
+            for (GHContent content : directoryContent) {
                 if (content.getPath().equalsIgnoreCase(path)) {
                     return SCMProbeStat.fromAlternativePath(content.getPath());
                 }


### PR DESCRIPTION
In the event that a directory contains both `JENKINSFILE` and `Jenkinsfile`. If we are looking for `Jenkinsfile` then without looping twice we would see `JENKINSFILE` first (because alpha sort puts uppercase before lowercase) and return the alert of mismatch... what we want to do is exhaustively search for the correct name and only in the event of no exact match should we check for alternative case variants