### PR TITLE
Add override to Github context

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubNotificationContext.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubNotificationContext.java
@@ -145,14 +145,15 @@ public final class GitHubNotificationContext {
      * @since TODO
      */
     public String getDefaultContext(TaskListener listener) {
+        String system = System.getProperty("OVERRIDE_GITHUB_CONTEXT", "jenkins");
         if (head instanceof PullRequestSCMHead) {
             if (((PullRequestSCMHead) head).isMerge()) {
-                return "continuous-integration/jenkins/pr-merge";
+                return "continuous-integration/" + system + "/pr-merge";
             } else {
-                return "continuous-integration/jenkins/pr-head";
+                return "continuous-integration/" + system + "/pr-head";
             }
         } else {
-            return "continuous-integration/jenkins/branch";
+            return "continuous-integration/" + system + "/branch";
         }
     }
 


### PR DESCRIPTION
For the blueocean plugins, we have both ci.jenkins and ci.blueocean building the plugins (and doing other work too).

Right now both servers are overriding the others status in PRs

I don't think this is a common occurence, so I thought a system property was a better option.

I figure this can be done with a plugin, but couldn't realy find an extension point