### PR TITLE
[JENKINS-46119] Add GitHubStatusContextProperty support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .project
 .settings
 bin
+/tags

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
             <version>2.1.2</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusContextBranchProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusContextBranchProperty.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Yo-An Lin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.github_branch_source;
+
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
+import jenkins.branch.BranchProperty;
+import jenkins.branch.BranchPropertyDescriptor;
+import jenkins.branch.JobDecorator;
+
+import hudson.model.Run;
+
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+public class GitHubBuildStatusContextBranchProperty extends BranchProperty {
+
+    private String context; 
+
+    @DataBoundConstructor
+    public GitHubBuildStatusContextBranchProperty(String context) {
+        this.context = context;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    @Override
+    public <P extends Job<P, B>, B extends Run<P, B>> JobDecorator<P, B> jobDecorator(Class<P> clazz) {
+        return null;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BranchPropertyDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "GitHub Build Status Context";
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusContextBranchProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusContextBranchProperty/config.jelly
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="GitHub Build Status Context" field="context">
+        <f:textbox />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusContextBranchProperty/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusContextBranchProperty/help.html
@@ -1,0 +1,5 @@
+<div>
+    This property will cause a job for a pull request (PR-*) to use a customized context rather than the 
+    default build status context string.
+</div>
+


### PR DESCRIPTION
Add GitHubStatusContextProperty to support github build status context customization

This is to let user customize the github build status context from their pipeline.

## Screenshots

<img width="878" alt="image" src="https://user-images.githubusercontent.com/50894/53474337-28857200-3ab0-11e9-90e2-bcdb9e7977c4.png">


<img width="779" alt="image" src="https://user-images.githubusercontent.com/50894/53474275-fc69f100-3aaf-11e9-8d08-6a139e7c560e.png">

## Issues

Related issue: JENKINS-36574, JENKINS-46119