### PR TITLE
[JENKINS-54051] Fix error adding GitHub Enterprise Servers

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Endpoint/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Endpoint/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="${%API endpoint}" field="apiUri" checkMethod="post">
-    <f:textbox/>
+  <f:entry title="${%API endpoint}" field="apiUri">
+    <f:textbox checkMethod="post"/>
   </f:entry>
   <f:entry title="${%Name}" field="name">
     <f:textbox/>


### PR DESCRIPTION
See [JENKINS-54051](https://issues.jenkins-ci.org/browse/JENKINS-54051).

Moved location of checkMethod="post" from f:entry to f:textbox

- State before fix
![1_beforefix](https://user-images.githubusercontent.com/48068285/53975618-16ac5c00-40ba-11e9-8966-1dfc7a29f6c3.png)

- State after fix
![2_afterfix](https://user-images.githubusercontent.com/48068285/53975624-1a3fe300-40ba-11e9-8a5d-971c098c500b.png)

