### PR TITLE
How can we make pull request jobs use our branch name instead of PR-XXX branches?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # GitHub Branch Source plugin for Jenkins
+ 


### PR DESCRIPTION
Hello, just writing here because I don't know where else to write.

Jenkins is making `PR-XXX` branches for my pull requests, and `env.BRANCH_NAME` shows this value when I echo it in Jenkinsfile. How can we make pull request builds use the original branch instead?