### PR TITLE
Fix identity comparison for GitHubSCMSource

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFileSystem.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFileSystem.java
@@ -88,11 +88,8 @@ public class GitHubSCMFileSystem extends SCMFileSystem implements GitHubClosable
                 PullRequestSCMRevision prRev = (PullRequestSCMRevision) rev;
                 PullRequestSCMHead pr = (PullRequestSCMHead) prRev.getHead();
                 if (pr.isMerge()) {
+                    prRev.validateMergeHash(repo);
                     this.ref = prRev.getMergeHash();
-                    List<String> parents = repo.getCommit(this.ref).getParentSHA1s();
-                    if (parents.size() != 2 || !parents.contains(prRev.getBaseHash()) || !parents.contains(prRev.getPullHash())) {
-                        throw new AbortException("Merge commit does not match base and head commits for pull request " + pr.getNumber() + ".");
-                    }
                 } else {
                     this.ref = prRev.getPullHash();
                 }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -222,7 +222,9 @@ public class GitHubSCMSourceTest {
         assertThat(byName.get("PR-2"), instanceOf(PullRequestSCMHead.class));
         assertThat(revByName.get("PR-2"), is((SCMRevision) new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-2")),
                 "8f1314fc3c8284d8c6d5886d473db98f2126071c",
-                "c0e024f89969b976da165eecaa71e09dc60c3da1"
+                "c0e024f89969b976da165eecaa71e09dc60c3da1",
+                "38814ca33833ff5583624c29f305be9133f27a40"
+
         )));
 
         assertThat(byName.get("master"), instanceOf(BranchSCMHead.class));


### PR DESCRIPTION

When scanning for new runs, PullRequestSCMRevision instances are compared.  While technically one combination of
base and pull commit produce the same merge, if we detect a new merge commit we should still treat that as a new revision.

For example:
Before this change, if a user closes a PR (unmerged) and then reopenes it, a repository scan would not treat the PR as changed.

After this change, a closing, reopening, and then scan will result in change being detected with a message like this (reformatted for clarity):

```
Changes detected: PR-3-merge (
58caa961c3fc5d68268e0d860670041b97cc86b0+edb61773c0185852a5d5c7afc17a924fee730363 (7c907cc0d0eaf15f2b84d030e23f5fd96e1b59d4) ->
58caa961c3fc5d68268e0d860670041b97cc86b0+edb61773c0185852a5d5c7afc17a924fee730363 (e0dd5f238a71951e6a48dc01443fb624a44ff278))
```
