### PR TITLE
[JENKINS-57371] - Enable graceful fallback for merge hash

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMRevision.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMRevision.java
@@ -106,27 +106,9 @@ public class PullRequestSCMRevision extends ChangeRequestSCMRevision<PullRequest
         return mergeHash;
     }
 
-    void validateMergeHash(@NonNull GHRepository repo) throws IOException {
-        if (!isMerge()) {
-            throw new AbortException("Invalid merge hash for pull request " + ((PullRequestSCMHead)this.getHead()).getNumber() + " : Not a merge head");
-        } else if (this.mergeHash == null) {
-            throw new AbortException("Invalid merge hash for pull request " + ((PullRequestSCMHead)this.getHead()).getNumber() + " : Unknown merge state " + this.toString());
-        } else if (this.mergeHash == NOT_MERGEABLE_HASH) {
-            throw new AbortException("Invalid merge hash for pull request " + ((PullRequestSCMHead)this.getHead()).getNumber() + " : Not mergeable " + this.toString());
-        } else {
-            GHCommit commit = null;
-            try {
-                commit = repo.getCommit(this.mergeHash);
-            } catch (FileNotFoundException e) {
-                throw new AbortException("Invalid merge hash for pull request " + ((PullRequestSCMHead)this.getHead()).getNumber() + " : commit not found (" + this.mergeHash + "). Close and reopen the PR to reset its merge hash.");
-            } catch (IOException e) {
-                throw new AbortException("Invalid merge hash for pull request " + ((PullRequestSCMHead)this.getHead()).getNumber() + " : " + e.toString());
-            }
-            assert(commit != null);
-            List<String> parents = commit.getParentSHA1s();
-            if (parents.size() != 2 || !parents.contains(this.getBaseHash()) || !parents.contains(this.getPullHash())) {
-                throw new AbortException("Invalid merge hash for pull request " + ((PullRequestSCMHead)this.getHead()).getNumber() + " : Head and base commits do match merge commit " + this.toString() );
-            }
+    void validateMergeHash() throws AbortException {
+        if (this.mergeHash == NOT_MERGEABLE_HASH) {
+            throw new AbortException("Pull request " + ((PullRequestSCMHead)this.getHead()).getNumber() + " : Not mergeable at " + this.toString());
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMRevisionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMRevisionTest.java
@@ -148,6 +148,12 @@ public class PullRequestSCMRevisionTest {
 
         assertThat(prRevision,
             not(is(new PullRequestSCMRevision(prMerge, "master-revision", "pr-branch-revision", null))));
+
+        try {
+            prRevision.validateMergeHash();
+        } catch (AbortException e) {
+            fail("Validation should succeed, but: " + e.getMessage());
+        }
     }
 
     @Test
@@ -167,17 +173,11 @@ public class PullRequestSCMRevisionTest {
         assertThat(prRevision,
             not(is(new PullRequestSCMRevision(prMerge, "master-revision", "pr-branch-revision", "pr-merge-revision"))));
 
-
-        // validation should fail for this PR.
-        Exception abort = null;
         try {
-            prRevision.validateMergeHash(repo);
-        } catch (Exception e) {
-            abort = e;
+            prRevision.validateMergeHash();
+        } catch (AbortException e) {
+            fail("Validation should succeed, but: " + e.getMessage());
         }
-        assertThat(abort, instanceOf(AbortException.class));
-        assertThat(abort.getMessage(), containsString("Not a merge head"));
-
     }
 
     @Test
@@ -197,15 +197,11 @@ public class PullRequestSCMRevisionTest {
         assertThat(prRevision,
             not(is(new PullRequestSCMRevision(prHead, "master-revision", "pr-branch-revision", null))));
 
-        // validation should fail for this PR.
-        Exception abort = null;
         try {
-            prRevision.validateMergeHash(repo);
-        } catch (Exception e) {
-            abort = e;
+            prRevision.validateMergeHash();
+        } catch (AbortException e) {
+            fail("Validation should succeed, but: " + e.getMessage());
         }
-        assertThat(abort, instanceOf(AbortException.class));
-        assertThat(abort.getMessage(), containsString("Unknown merge state"));
     }
 
     @Test
@@ -228,7 +224,7 @@ public class PullRequestSCMRevisionTest {
         // validation should fail for this PR.
         Exception abort = null;
         try {
-            prRevision.validateMergeHash(repo);
+            prRevision.validateMergeHash();
         } catch (Exception e) {
             abort = e;
         }
@@ -252,43 +248,11 @@ public class PullRequestSCMRevisionTest {
 
         assertThat(prRevision,
             not(is(new PullRequestSCMRevision(prHead, "master-revision", "pr-branch-revision", "pr-merge-revision"))));
-    }
 
-    @Test
-    public void createMergewithMergeRevision_validation_valid() throws Exception {
-        PullRequestSCMRevision prRevision = new PullRequestSCMRevision(
-            prMerge,
-            "8f1314fc3c8284d8c6d5886d473db98f2126071c",
-            "c0e024f89969b976da165eecaa71e09dc60c3da1",
-            "38814ca33833ff5583624c29f305be9133f27a40");
-
-        assertThat(prRevision.toString(), is("c0e024f89969b976da165eecaa71e09dc60c3da1+8f1314fc3c8284d8c6d5886d473db98f2126071c (38814ca33833ff5583624c29f305be9133f27a40)"));
         try {
-            prRevision.validateMergeHash(repo);
+            prRevision.validateMergeHash();
         } catch (AbortException e) {
             fail("Validation should succeed, but: " + e.getMessage());
         }
     }
-
-    @Test
-    public void createMergewithMergeRevision_validation_invalid() throws Exception {
-        PullRequestSCMRevision prRevision = new PullRequestSCMRevision(
-            prMerge,
-            "INVALIDc3c8284d8c6d5886d473db98f2126071c",
-            "c0e024f89969b976da165eecaa71e09dc60c3da1",
-            "38814ca33833ff5583624c29f305be9133f27a40");
-
-        assertThat(prRevision.toString(), is("c0e024f89969b976da165eecaa71e09dc60c3da1+INVALIDc3c8284d8c6d5886d473db98f2126071c (38814ca33833ff5583624c29f305be9133f27a40)"));
-
-        // validation should fail for this PR.
-        Exception abort = null;
-        try {
-            prRevision.validateMergeHash(repo);
-        } catch (Exception e) {
-            abort = e;
-        }
-        assertThat(abort, instanceOf(AbortException.class));
-        assertThat(abort.getMessage(), containsString("Head and base commits do match merge commit"));
-    }
-
 }


### PR DESCRIPTION
We tried using strict merge commit handling to prevent cloning on master.
This resulted in some edge cases for some users where PRs would simply not build
and there was not viable workaround.

Change:
* Merge hash has been changed to best effort.  If it is missing or inconsistent,
Jenkins will gracefully revert to cloning on master.
* Most validity checking for merge hash has been moved to create time.
* Plugin tries harder than before to create a valid merge hash revision.

https://issues.jenkins-ci.org/browse/JENKINS-57371