### PR TITLE
[JENKINS-58862] MBPs configured via single URL always reference github.com

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -407,12 +407,12 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
      */
     @DataBoundSetter
     public void setApiUri(@CheckForNull String apiUri) {
-        apiUri = GitHubConfiguration.normalizeApiUri(Util.fixEmptyAndTrim(apiUri));
         // JENKINS-58862
         // If repositoryUrl is set, we don't want to set it again.
         if (this.repositoryUrl != null) {
             return;
         }
+        apiUri = GitHubConfiguration.normalizeApiUri(Util.fixEmptyAndTrim(apiUri));
         if (apiUri == null) {
             apiUri = GITHUB_URL;
         }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -407,8 +407,12 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
      */
     @DataBoundSetter
     public void setApiUri(@CheckForNull String apiUri) {
-        // TODO: What should happen when this is called and this instance is configured by URL? Nothing?
         apiUri = GitHubConfiguration.normalizeApiUri(Util.fixEmptyAndTrim(apiUri));
+        // JENKINS-58862
+        // If repositoryUrl is set, we don't want to set it again.
+        if (this.repositoryUrl != null) {
+            return;
+        }
         if (apiUri == null) {
             apiUri = GITHUB_URL;
         }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
@@ -72,7 +72,7 @@ public class GitHubSCMBuilderTest {
     }
 
     public void createGitHubSCMSourceForTest(boolean configuredByUrl, String repoUrlToConfigure) throws Exception {
-        owner = j.createProject(WorkflowMultiBranchProject.class);
+        // owner = j.createProject(WorkflowMultiBranchProject.class);
 
         GitHubSCMSource testSCMSource;
         if (configuredByUrl) {
@@ -84,15 +84,17 @@ public class GitHubSCMBuilderTest {
         } else {
             source = new GitHubSCMSource("tester", "test-repo");
         }
-        owner.setSourcesList(Collections.singletonList(new BranchSource(source)));
+        // owner.setSourcesList(Collections.singletonList(new BranchSource(source)));
         source.setOwner(owner);
 
         // return testSCMSource;
     }
 
+
+
     @Before
     public void setUp() throws IOException {
-//        owner = j.createProject(WorkflowMultiBranchProject.class);
+        owner = j.createProject(WorkflowMultiBranchProject.class);
 //        if (configuredByUrl) {
 //            source = new GitHubSCMSource("", "", "https://github.com/tester/test-repo", true);
 //        } else {
@@ -117,6 +119,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_rev_anon__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         SCMRevisionImpl revision =
                 new SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");
@@ -170,6 +173,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_rev_userpass__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         SCMRevisionImpl revision =
                 new SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");
@@ -223,6 +227,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_rev_userkey__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         SCMRevisionImpl revision =
                 new SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");
@@ -276,6 +281,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_rev_anon_sshtrait_anon__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         SCMRevisionImpl revision =
                 new SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");
@@ -805,7 +811,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_rev_userpass__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         AbstractGitSCMSource.SCMRevisionImpl revision =
                 new AbstractGitSCMSource.SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");
@@ -859,7 +866,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_rev_userkey__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         AbstractGitSCMSource.SCMRevisionImpl revision =
                 new AbstractGitSCMSource.SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");
@@ -913,7 +921,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_norev_anon__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
@@ -953,7 +962,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_norev_userpass__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
@@ -993,7 +1003,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_norev_userkey__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
@@ -1157,6 +1168,7 @@ public class GitHubSCMBuilderTest {
                 "deadbeefcafebabedeadbeefcafebabedeadbeef",
                 "cafebabedeadbeefcafebabedeadbeefcafebabe"
         );
+        createGitHubSCMSourceForTest(false,null);
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-key"));
@@ -1330,7 +1342,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_rev_anon__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.HEAD);
@@ -1390,7 +1403,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_rev_userpass__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.HEAD);
@@ -1449,7 +1463,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_rev_userkey__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.HEAD);
@@ -1508,7 +1523,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_norev_anon__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.HEAD);
@@ -1550,7 +1566,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_norev_userpass__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.HEAD);
@@ -1592,7 +1609,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_norev_userkey__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.HEAD);
@@ -1997,7 +2015,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_rev_anon__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);
@@ -2068,7 +2087,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_rev_userpass__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);
@@ -2138,7 +2158,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_rev_userkey__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);
@@ -2208,7 +2229,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_norev_anon__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);
@@ -2262,7 +2284,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_norev_userpass__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);
@@ -2316,7 +2339,8 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_norev_userkey__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
@@ -72,9 +72,6 @@ public class GitHubSCMBuilderTest {
     }
 
     public void createGitHubSCMSourceForTest(boolean configuredByUrl, String repoUrlToConfigure) throws Exception {
-        // owner = j.createProject(WorkflowMultiBranchProject.class);
-
-        GitHubSCMSource testSCMSource;
         if (configuredByUrl) {
             // Throw an exception if we don't supply a URL
             if (repoUrlToConfigure.isEmpty()) {
@@ -84,25 +81,12 @@ public class GitHubSCMBuilderTest {
         } else {
             source = new GitHubSCMSource("tester", "test-repo");
         }
-        // owner.setSourcesList(Collections.singletonList(new BranchSource(source)));
         source.setOwner(owner);
-
-        // return testSCMSource;
     }
-
-
 
     @Before
     public void setUp() throws IOException {
         owner = j.createProject(WorkflowMultiBranchProject.class);
-//        if (configuredByUrl) {
-//            source = new GitHubSCMSource("", "", "https://github.com/tester/test-repo", true);
-//        } else {
-//            source = new GitHubSCMSource( "tester", "test-repo");
-//        }
-
-//        owner.setSourcesList(Collections.singletonList(new BranchSource(source)));
-//        source.setOwner(owner);
         Credentials userPasswordCredential = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "user-pass", null, "git-user", "git-secret");
         Credentials sshPrivateKeyCredential = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, "user-key", "git",
                 new BasicSSHUserPrivateKey.UsersPrivateKeySource(), null, null);
@@ -342,6 +326,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_rev_userpass_sshtrait_anon__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         SCMRevisionImpl revision =
                 new SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");
@@ -401,6 +386,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_rev_userkey_sshtrait_anon__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         SCMRevisionImpl revision =
                 new SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");
@@ -460,6 +446,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_rev_anon_sshtrait_userkey__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         SCMRevisionImpl revision =
                 new SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");
@@ -519,6 +506,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_rev_userpass_sshtrait_userkey__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         SCMRevisionImpl revision =
                 new SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");
@@ -578,6 +566,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_rev_userkey_sshtrait_userkey__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         SCMRevisionImpl revision =
                 new SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");
@@ -637,6 +626,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_norev_anon__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
@@ -676,6 +666,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_norev_userpass__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
@@ -715,6 +706,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_branch_norev_userkey__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         BranchSCMHead head = new BranchSCMHead("test-branch");
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
@@ -754,8 +746,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_rev_anon__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
-        // helper method
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         AbstractGitSCMSource.SCMRevisionImpl revision =
@@ -811,7 +801,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_rev_userpass__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         AbstractGitSCMSource.SCMRevisionImpl revision =
@@ -866,7 +855,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_rev_userkey__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         AbstractGitSCMSource.SCMRevisionImpl revision =
@@ -921,7 +909,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_norev_anon__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         source.setCredentialsId(null);
@@ -962,7 +949,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_norev_userpass__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         source.setCredentialsId("user-pass");
@@ -1003,7 +989,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_norev_userkey__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         source.setCredentialsId("user-key");
@@ -1044,6 +1029,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_rev_anon__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.HEAD);
@@ -1102,6 +1088,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_rev_userpass__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.HEAD);
@@ -1219,6 +1206,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_norev_anon__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.HEAD);
@@ -1260,6 +1248,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_norev_userpass__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.HEAD);
@@ -1301,6 +1290,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_norev_userkey__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.HEAD);
@@ -1342,7 +1332,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_rev_anon__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
@@ -1403,7 +1392,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_rev_userpass__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
@@ -1463,7 +1451,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_rev_userkey__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
@@ -1523,7 +1510,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_norev_anon__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
@@ -1566,7 +1552,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_norev_userpass__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
@@ -1609,7 +1594,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullHead_norev_userkey__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
@@ -1652,6 +1636,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_rev_anon__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);
@@ -1721,6 +1706,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_rev_userpass__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);
@@ -1790,6 +1776,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_rev_userkey__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);
@@ -1859,6 +1846,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_norev_anon__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);
@@ -1911,6 +1899,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_norev_userpass__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);
@@ -1963,6 +1952,7 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_norev_userkey__when__build__then__scmBuilt() throws Exception {
+        createGitHubSCMSourceForTest(false, null);
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
                 ChangeRequestCheckoutStrategy.MERGE);
@@ -2015,7 +2005,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_rev_anon__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
@@ -2087,7 +2076,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_rev_userpass__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
@@ -2158,7 +2146,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_rev_userkey__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
@@ -2229,7 +2216,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_norev_anon__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
@@ -2284,7 +2270,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_norev_userpass__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
@@ -2339,7 +2324,6 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_pullMerge_norev_userkey__when__build__then__scmBuilt() throws Exception {
-        // source.setApiUri("https://github.test/api/v3");
         createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", 1,
                 new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
@@ -71,17 +71,36 @@ public class GitHubSCMBuilderTest {
         this.configuredByUrl = configuredByUrl;
     }
 
-    @Before
-    public void setUp() throws IOException {
+    public void createGitHubSCMSourceForTest(boolean configuredByUrl, String repoUrlToConfigure) throws Exception {
         owner = j.createProject(WorkflowMultiBranchProject.class);
-        if (configuredByUrl) {
-            source = new GitHubSCMSource("", "", "https://github.com/tester/test-repo", true);
-        } else {
-            source = new GitHubSCMSource( "tester", "test-repo");
-        }
 
+        GitHubSCMSource testSCMSource;
+        if (configuredByUrl) {
+            // Throw an exception if we don't supply a URL
+            if (repoUrlToConfigure.isEmpty()) {
+                throw new Exception("Must supply a URL when testing single-URL configured jobs");
+            }
+            source = new GitHubSCMSource("", "", repoUrlToConfigure, true);
+        } else {
+            source = new GitHubSCMSource("tester", "test-repo");
+        }
         owner.setSourcesList(Collections.singletonList(new BranchSource(source)));
         source.setOwner(owner);
+
+        // return testSCMSource;
+    }
+
+    @Before
+    public void setUp() throws IOException {
+//        owner = j.createProject(WorkflowMultiBranchProject.class);
+//        if (configuredByUrl) {
+//            source = new GitHubSCMSource("", "", "https://github.com/tester/test-repo", true);
+//        } else {
+//            source = new GitHubSCMSource( "tester", "test-repo");
+//        }
+
+//        owner.setSourcesList(Collections.singletonList(new BranchSource(source)));
+//        source.setOwner(owner);
         Credentials userPasswordCredential = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "user-pass", null, "git-user", "git-secret");
         Credentials sshPrivateKeyCredential = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, "user-key", "git",
                 new BasicSSHUserPrivateKey.UsersPrivateKeySource(), null, null);
@@ -729,7 +748,9 @@ public class GitHubSCMBuilderTest {
 
     @Test
     public void given__server_branch_rev_anon__when__build__then__scmBuilt() throws Exception {
-        source.setApiUri("https://github.test/api/v3");
+        // source.setApiUri("https://github.test/api/v3");
+        // helper method
+        createGitHubSCMSourceForTest(true, "https://github.test/tester/test-repo.git");
         BranchSCMHead head = new BranchSCMHead("test-branch");
         AbstractGitSCMSource.SCMRevisionImpl revision =
                 new AbstractGitSCMSource.SCMRevisionImpl(head, "cafebabedeadbeefcafebabedeadbeefcafebabe");

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -27,7 +27,6 @@ package org.jenkinsci.plugins.github_branch_source;
 
 import com.cloudbees.jenkins.GitHubRepositoryName;
 import com.cloudbees.jenkins.GitHubRepositoryNameContributor;
-import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -211,11 +210,8 @@ public class GitHubSCMSourceTest {
 
         githubApi.stubFor(
                 get(urlMatching(".*")).atPriority(10).willReturn(aResponse().proxiedFrom("https://api.github.com/")));
-                // get(urlMatching(".*")).atPriority(10).willReturn(aResponse().proxiedFrom("https://github.test/api/v3")));
         githubRaw.stubFor(get(urlMatching(".*")).atPriority(10)
                 .willReturn(aResponse().proxiedFrom("https://raw.githubusercontent.com/")));
-        // source.setApiUri("http://localhost:" + githubApi.port());
-        // source = new GitHubSCMSource("", "", "http://localhost:" + githubApi.port() + "/owner/repo", true);
         if (source.isConfiguredByUrl()) {
             source = new GitHubSCMSource("cloudbeers", "yolo", "http://localhost:" + githubApi.port() + "/cloudbeers/yolo", true);
         } else {

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -72,12 +72,10 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSourceCriteria;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
-import org.apache.commons.lang.StringUtils;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -165,8 +163,8 @@ public class GitHubSCMSourceTest {
     @Parameterized.Parameters(name = "{index}: revision={0}")
     public static GitHubSCMSource[] revisions() {
         return new GitHubSCMSource[]{
-                new GitHubSCMSource("cloudbeers", "yolo", null, false)
-                // new GitHubSCMSource("", "", "https://github.com/cloudbeers/yolo", true)
+                new GitHubSCMSource("cloudbeers", "yolo", null, false),
+                new GitHubSCMSource("", "", "https://github.com/cloudbeers/yolo", true)
             };
     }
 
@@ -220,7 +218,7 @@ public class GitHubSCMSourceTest {
         // source.setApiUri("http://localhost:" + githubApi.port());
         // source = new GitHubSCMSource("", "", "http://localhost:" + githubApi.port() + "/owner/repo", true);
         if (source.isConfiguredByUrl()) {
-            source = new GitHubSCMSource("cloudbeers", "yolo", "http://127.0.0.1:" + githubApi.port() + "/cloudbeers/yolo", true);
+            source = new GitHubSCMSource("cloudbeers", "yolo", "http://localhost:" + githubApi.port() + "/cloudbeers/yolo", true);
         } else {
             source.setApiUri("http://localhost:" + githubApi.port());
         }
@@ -400,7 +398,7 @@ public class GitHubSCMSourceTest {
     public void fetchSmokes_badUser() throws Exception {
         // make it so PR-2 returns a file not found for user
         githubApi.stubFor(
-            get(urlEqualTo("/repos/cloudbeers/yolo/pulls/2"))
+            get(urlMatching("(/api/v3)?/repos/cloudbeers/yolo/pulls/2"))
             .inScenario("Pull Request Merge Hash")
             .whenScenarioStateIs(Scenario.STARTED)
             .willReturn(
@@ -408,14 +406,13 @@ public class GitHubSCMSourceTest {
                 .withHeader("Content-Type", "application/json; charset=utf-8")
                 .withBodyFile("body-yolo-pulls-2-bad-user.json")));
         githubApi.stubFor(
-            get(urlEqualTo("/repos/cloudbeers/yolo/pulls?state=open"))
+            get(urlMatching("(/api/v3)?/repos/cloudbeers/yolo/pulls\\?state=open"))
             .inScenario("Pull Request Merge Hash")
             .whenScenarioStateIs(Scenario.STARTED)
             .willReturn(
                 aResponse()
                 .withHeader("Content-Type", "application/json; charset=utf-8")
                 .withBodyFile("body-yolo-pulls-bad-user.json")));
-
 
         SCMHeadObserver.Collector collector = SCMHeadObserver.collect();
         source.fetch(new SCMSourceCriteria() {
@@ -470,7 +467,7 @@ public class GitHubSCMSourceTest {
         // Then make it so refs/heads/master returns 404 for first call
         // Causes PR 2 to fail because it cannot determine base commit.
         githubApi.stubFor(
-            get(urlEqualTo("/repos/cloudbeers/yolo/commits/38814ca33833ff5583624c29f305be9133f27a40"))
+            get(urlMatching("(/api/v3)?/repos/cloudbeers/yolo/commits/38814ca33833ff5583624c29f305be9133f27a40"))
             .inScenario("PR 2 Merge 404")
             .whenScenarioStateIs(Scenario.STARTED)
             .willReturn(
@@ -481,7 +478,7 @@ public class GitHubSCMSourceTest {
             .willSetStateTo(Scenario.STARTED));
 
         githubApi.stubFor(
-            get(urlEqualTo("/repos/cloudbeers/yolo/git/refs/heads/master"))
+            get(urlMatching("(/api/v3)?/repos/cloudbeers/yolo/git/refs/heads/master"))
             .inScenario("PR 2 Master 404")
             .whenScenarioStateIs(Scenario.STARTED)
             .willReturn(
@@ -492,7 +489,7 @@ public class GitHubSCMSourceTest {
             .willSetStateTo("Master 200"));
 
         githubApi.stubFor(
-            get(urlEqualTo("/repos/cloudbeers/yolo/git/refs/heads/master"))
+            get(urlMatching("(/api/v3)?/repos/cloudbeers/yolo/git/refs/heads/master"))
             .inScenario("PR 2 Master 404")
             .whenScenarioStateIs("Master 200")
             .willReturn(

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -122,7 +122,6 @@ public class GitHubSCMSourceTest {
     public WireMockRule githubApi = factory.getRule(WireMockConfiguration.options()
             .dynamicPort()
             .usingFilesUnderClasspath("api")
-            .notifier(new ConsoleNotifier(true))
             .extensions(
                     new ResponseTransformer() {
                         @Override

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -133,8 +133,6 @@ public class GitHubSCMSourceTest {
                                         .body(response.getBodyAsString()
                                                 .replace("https://api.github.com/",
                                                         "http://localhost:" + githubApi.port() + "/")
-                                                .replace("http://github.test/api/v3",
-                                                        "http://localhost:" + githubApi.port())
                                                 .replace("https://raw.githubusercontent.com/",
                                                         "http://localhost:" + githubRaw.port() + "/")
                                         )

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
@@ -93,7 +93,7 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
 
         assertThat(instance.getId(), is("e4d8c11a-0d24-472f-b86b-4b017c160e9a"));
-        assertThat(instance.getApiUri(), is(GitHubSCMSource.GITHUB_URL));
+        assertThat(instance.getApiUri(), is("https://api.github.com"));
         assertThat(instance.getRepoOwner(), is("joseblas"));
         assertThat(instance.getRepository(), is("jx"));
         assertThat(instance.getCredentialsId(), is("abcd"));

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
@@ -93,7 +93,7 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
 
         assertThat(instance.getId(), is("e4d8c11a-0d24-472f-b86b-4b017c160e9a"));
-        assertThat(instance.getApiUri(), is("https://api.github.com"));
+        assertThat(instance.getApiUri(), is(GitHubSCMSource.GITHUB_URL));
         assertThat(instance.getRepoOwner(), is("joseblas"));
         assertThat(instance.getRepository(), is("jx"));
         assertThat(instance.getCredentialsId(), is("abcd"));

--- a/src/test/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest/repositoryUrl.xml
+++ b/src/test/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest/repositoryUrl.xml
@@ -1,5 +1,6 @@
 <org.jenkinsci.plugins.github_branch_source.GitHubSCMSource>
   <id>e4d8c11a-0d24-472f-b86b-4b017c160e9a</id>
+  <apiUri>https://api.github.com</apiUri>
   <repoOwner>joseblas</repoOwner>
   <repository>jx</repository>
   <repositoryUrl>https://github.com/joseblas/jx</repositoryUrl>


### PR DESCRIPTION
# Description

See [JENKINS-58862](https://issues.jenkins-ci.org/browse/JENKINS-58862). New Multibranch projects configured to use repositories on GitHub Enterprise servers were always setting `apiUri` to point to `https://api.github.com`. These changes stop that from happening.

Also included are test changes so that the tests work correctly without directly calling `setApiUri()`.

CC @dwnusbaum , as I cannot directly request reviewers when opening PRs to this repo.