### PR TITLE
[JENKINS-58939] - Support filtering out pull requests by label

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/traits/PullRequestLabelFilterTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/traits/PullRequestLabelFilterTrait.java
@@ -1,0 +1,146 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.github_branch_source.traits;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMHeadFilter;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
+import jenkins.scm.impl.trait.Selection;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceContext;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceRequest;
+import org.jenkinsci.plugins.github_branch_source.PullRequestSCMHead;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+//TODO: add interface in SCM API?
+/**
+ * A {@code Filter} trait for GitHub that will filter out pull request matching the specified labels.
+ *
+ * @since TODO
+ */
+public class PullRequestLabelFilterTrait extends SCMSourceTrait {
+
+    /**
+     * Labels to be ignored.
+     */
+    Set<String> labelsToIgnore;
+
+    /**
+     * Constructor for stapler.
+     *
+     * @param labelsToIgnore Labels to ignore
+     */
+    @DataBoundConstructor
+    public PullRequestLabelFilterTrait(@NonNull Set<String> labelsToIgnore) {
+        this.labelsToIgnore = Collections.unmodifiableSet(labelsToIgnore);
+    }
+
+    @NonNull
+    public Set<String> getLabelsToIgnore() {
+        return labelsToIgnore;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        GitHubSCMSourceContext ctx = (GitHubSCMSourceContext) context;
+        ctx.wantForkPRs(true);
+        ctx.wantOriginPRs(true);
+        ctx.withFilter(new SCMHeadFilter() {
+            @Override
+            public boolean isExcluded(@NonNull SCMSourceRequest request, @NonNull SCMHead head) throws IOException, InterruptedException {
+                if (request instanceof GitHubSCMSourceRequest && head instanceof PullRequestSCMHead) {
+                    PullRequestSCMHead pr = (PullRequestSCMHead)head;
+                    Set<String> labels = pr.getLabels();
+                    for (String label : labelsToIgnore) {
+                        if(labels.contains(label)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+                return false;
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean includeCategory(@NonNull SCMHeadCategory category) {
+        return category instanceof ChangeRequestSCMHeadCategory;
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Symbol("gitHubFilterPRsByLabels")
+    @Extension
+    @Selection
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.PullRequestLabelFilterTrait_displayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return GitHubSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return GitHubSCMSource.class;
+        }
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/util/GitHubApiUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/util/GitHubApiUtils.java
@@ -1,0 +1,43 @@
+package org.jenkinsci.plugins.github_branch_source.util;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.github.GHLabel;
+import org.kohsuke.github.GHPullRequest;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Restricted(NoExternalUse.class)
+public class GitHubApiUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(GitHubApiUtils.class.getName());
+
+    private GitHubApiUtils() {}
+
+    public static Set<String> getLabels(@NonNull GHPullRequest pr) {
+        final Collection<GHLabel> labels;
+        try {
+            labels = pr.getLabels();
+        } catch (IOException ex) {
+            LOGGER.log(Level.WARNING, "Cannot retrieve labels from " + pr, ex);
+            return Collections.emptySet();
+        }
+
+        if (labels == null || labels.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        HashSet<String> res = new HashSet<>(labels.size());
+        for (GHLabel label : labels) {
+            res.add(label.getName());
+        }
+        return res;
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/traits/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/traits/Messages.properties
@@ -1,0 +1,1 @@
+PullRequestLabelFilterTrait.displayName=Filter pull requests by label

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/traits/PullRequestLabelFilterTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/traits/PullRequestLabelFilterTrait/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:f2="/org/jenkinsci/plugins/github_branch_source/form">
+  <f:entry title="${%Labels to ignore}" field="labelsToIgnore">
+    <f:textbox default="skip-ci"/>
+  </f:entry>
+</j:jelly>


### PR DESCRIPTION
Concept of a https://issues.jenkins-ci.org/browse/JENKINS-58939 fix for ci.jenkins.io. The fix should allow filtering pull request builds by label. It is not an ideal solution, because we would rather disable pull requests when a label is set. But it needs a deeper patch

Idea: We use a `stalled` or `skip-ci` label for pull requests in the core which we do not want to rebuild

@reviewbybees 