### PR TITLE
[JENKINS-57557] Add test for JCasC compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <jenkins.version>2.138.4</jenkins.version>
         <scm-api.version>2.6.3</scm-api.version>
         <useBeta>true</useBeta>
+        <jcasc.version>1.30</jcasc.version>
     </properties>
 
     <scm>
@@ -172,6 +173,33 @@
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
                     <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- JCasC compatibility -->
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>${jcasc.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>${jcasc.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps-global-lib</artifactId>
+            <version>2.12</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubBranchSourcesJCasCCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubBranchSourcesJCasCCompatibilityTest.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
+import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
+import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class GitHubBranchSourcesJCasCCompatibilityTest extends RoundTripAbstractTest {
+
+    @Issue("JENKINS-57557")
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        assertEquals(1, GlobalLibraries.get().getLibraries().size());
+        final LibraryConfiguration library = GlobalLibraries.get().getLibraries().get(0);
+        assertEquals("jenkins-pipeline-lib", library.getName());
+        final SCMSourceRetriever retriever = (SCMSourceRetriever) library.getRetriever();
+        final GitHubSCMSource scm = (GitHubSCMSource) retriever.getScm();
+        assertEquals("e43d6600-ba0e-46c5-8eae-3989bf654055", scm.getId());
+        assertEquals("jenkins-infra", scm.getRepoOwner());
+        assertEquals("pipeline-library", scm.getRepository());
+        assertEquals(3, scm.getTraits().size());
+        final BranchDiscoveryTrait branchDiscovery = (BranchDiscoveryTrait) scm.getTraits().get(0);
+        assertEquals(1, branchDiscovery.getStrategyId());
+        final OriginPullRequestDiscoveryTrait prDiscovery = (OriginPullRequestDiscoveryTrait) scm.getTraits().get(1);
+        assertEquals(2, prDiscovery.getStrategyId());
+        final ForkPullRequestDiscoveryTrait forkDiscovery = (ForkPullRequestDiscoveryTrait) scm.getTraits().get(2);
+        assertEquals(3, forkDiscovery.getStrategyId());
+        assertThat(forkDiscovery.getTrust(), instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class));
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "Setting class org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.repoOwner = jenkins-infra";
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/github_branch_source/configuration-as-code.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/github_branch_source/configuration-as-code.yaml
@@ -1,0 +1,20 @@
+unclassified:
+  globalLibraries:
+    libraries:
+      - defaultVersion: "master"
+        name: "jenkins-pipeline-lib"
+        retriever:
+          modernSCM:
+            scm:
+              github:
+                id: "e43d6600-ba0e-46c5-8eae-3989bf654055"
+                repoOwner: "jenkins-infra"
+                repository: "pipeline-library"
+                traits:
+                  - gitHubBranchDiscovery:
+                      strategyId: 1
+                  - originPullRequestDiscoveryTrait:
+                      strategyId: 2
+                  - gitHubForkDiscovery:
+                      strategyId: 3
+                      trust: "trustPermission"


### PR DESCRIPTION
See [JENKINS-57557](https://issues.jenkins-ci.org/browse/JENKINS-57557). _github-branch-sources_ is compatible with the last version of _configuration-as-code_. This PR adds an integration test to check possible future issues.

@varyvol @MRamonLeon @alecharp @rsandell 
@abayer @dwnusbaum @car-roll @bitwiseman as maintainers of the plugin