### PR TITLE
[JENKINS-45504] Add missing @Symbol to OriginPullRequestDiscoveryTrait

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait.java
@@ -44,6 +44,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -127,6 +128,7 @@ public class OriginPullRequestDiscoveryTrait extends SCMSourceTrait {
         return category instanceof ChangeRequestSCMHeadCategory;
     }
 
+    @Symbol("gitHubPullRequestDiscovery")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
@@ -80,7 +80,7 @@ public class GitHubSCMSourceTraitsTest {
                         + "repository=repo,"
                         + "traits=["
                         + "@gitHubBranchDiscovery$org.jenkinsci.plugins.github_branch_source.BranchDiscoveryTrait(strategyId=1), "
-                        + "$OriginPullRequestDiscoveryTrait(strategyId=1), "
+                        + "@gitHubPullRequestDiscovery$OriginPullRequestDiscoveryTrait(strategyId=1), "
                         + "@gitHubForkDiscovery$ForkPullRequestDiscoveryTrait("
                         + "strategyId=2,"
                         + "trust=@gitHubTrustPermissions$TrustPermission()), "


### PR DESCRIPTION
Now all traits consistently have a `@Symbol` annotation.

This improves configuration with JobDSL. Otherwise there is a clash e.g. with the bitbucket-branch-source-plugin [here](https://github.com/jenkinsci/bitbucket-branch-source-plugin/blob/cloudbees-bitbucket-branch-source-2.6.0/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/OriginPullRequestDiscoveryTrait.java).

Also see https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/257.