### PR TITLE
remove invisible entry from drop down list

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/config-detail.jelly
@@ -28,11 +28,6 @@
           <f:select/>
         </f:entry>
         </j:when>
-        <j:otherwise>
-          <f:invisibleEntry>
-            <f:select field="apiUri"/>
-          </f:invisibleEntry>
-        </j:otherwise>
       </j:choose>
       <f:entry title ="${%Owner}" field="repoOwner">
         <f:textbox/>


### PR DESCRIPTION
* JENKINS issue(s):
    * [NGPIPELINE-775](https://cloudbees.atlassian.net/browse/NGPIPELINE-775)
* Description:
    * When adding a github source, the `API endpoint` drop down list is partially visible when the `Repository Scan` radio button is selected.
<img width="942" alt="Screen Shot 2020-01-09 at 11 57 41 PM" src="https://user-images.githubusercontent.com/48068285/72137378-942aa380-333f-11ea-9693-6692e58c3508.png">

The problem appears  to be in the GithubSCMSource jelly (`config-detail.jelly`). If there are no API Endpoints, an `invisibleEntry` is added to the `radioBlock`. However, it looks like there is a bug that `invisibleEntries` are still partially visible in a `radioBlock`.
(Technically, the list of API Endpoints is never empty as it always has a "Github" title as the first entry. I confirmed that the bug was still present when the list was truly empty.)

Since there is no reason to store an empty list of API Endpoints in an invisible entry, I completely removed the logic and the issue went away.
<img width="954" alt="Screen Shot 2020-01-09 at 11 55 30 PM" src="https://user-images.githubusercontent.com/48068285/72137413-a3a9ec80-333f-11ea-8f73-66b1f2aaea1a.png">

* Documentation changes:
    * bugfix, no documentation changes
* Users/aliases to notify:
    * See reviewers list