### PR TITLE
[JENKINS-60353] Enable PR-204 workaround all the time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ target
 .classpath
 .project
 .settings
+.vscode
+.factorypath
 bin

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbe.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbe.java
@@ -53,7 +53,7 @@ import java.util.logging.Logger;
 class GitHubSCMProbe extends SCMProbe implements GitHubClosable {
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = Logger.getLogger(GitHubSCMProbe.class.getName());
-    static /*mostly final*/ boolean JENKINS_54126_WORKAROUND = Boolean.parseBoolean(System.getProperty(GitHubSCMProbe.class.getName() + ".JENKINS_54126_WORKAROUND", Boolean.FALSE.toString()));
+    static /*mostly final*/ boolean JENKINS_54126_WORKAROUND = Boolean.parseBoolean(System.getProperty(GitHubSCMProbe.class.getName() + ".JENKINS_54126_WORKAROUND", Boolean.TRUE.toString()));
     static /*mostly final*/ boolean STAT_RETHROW_API_FNF = Boolean.parseBoolean(System.getProperty(GitHubSCMProbe.class.getName() + ".STAT_RETHROW_API_FNF", Boolean.TRUE.toString()));
     private final SCMRevision revision;
     private final transient GitHub gitHub;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbe.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbe.java
@@ -175,7 +175,7 @@ class GitHubSCMProbe extends SCMProbe implements GitHubClosable {
                 // means that does not exist and this is handled below this try/catch block.
             }
             if (finicky && JENKINS_54126_WORKAROUND) {
-                LOG.log(Level.FINE, String.format("JENKINS-54126 Received finacky response from GitHub %s : %s", repo.getFullName(), ref), fnf);
+                LOG.log(Level.FINE, String.format("JENKINS-54126 Received finicky response from GitHub %s : %s", repo.getFullName(), ref), fnf);
                 final Optional<List<String>> status;
                 final Map<String, List<String>> responseHeaderFields = fnf.getResponseHeaderFields();
                 if (responseHeaderFields != null) {


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-60353](https://issues.jenkins-ci.org/browse/JENKINS-60353)
    * [JENKINS-54126](https://issues.jenkins-ci.org/browse/JENKINS-54126)
    * Possibly others.
* Description:
    * In short, this turns the workaround from [PR-204](https://github.com/jenkinsci/github-branch-source-plugin/pull/204) on all the time. 
    * There will be a very small uptick in the number of API requests used with this change in place - but only in the event of getting a `40*` response code back from GitHub
    * I don't expect this to solve all possible variants of the `Jenkinsfile not found` problem we've been battling for the last year and change. But some testing that @bitwiseman  and I worked on together, in the context of [JENKINS-60353](https://issues.jenkins-ci.org/browse/JENKINS-60353), shows that this does at least solve that particular case. The case can be seen in github-api-plugin PR-665, which provides a simple test to simulate the issue.
    * It is still possible to disable the workaround, by setting the system property `-Dorg.jenkinsci.plugins.github_branch_source.GitHubSCMProbe.JENKINS_54126_WORKAROUND=false`.
* Documentation changes:
    * Probably no documentation needed, although mentioning this in a release note might be useful.
* Testing performed:
    * Existing unit tests all pass
    * Manual verification that running without this change produces the bug described in [JENKINS-60353](https://issues.jenkins-ci.org/browse/JENKINS-60353), while running with this change in place fixes the problem
* Users/aliases to notify:
    * @rsandell , who originally committed the workaround we're now enabling by default
