### PR TITLE
Upgrade to use jcasc test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.50</version>
+        <version>3.55</version>
         <relativePath />
     </parent>
     <artifactId>github-branch-source</artifactId>
@@ -27,9 +27,9 @@
         <java.level>8</java.level>
         <jenkins.version>2.150.3</jenkins.version>
         <scm-api.version>2.6.3</scm-api.version>
-        <hamcrest.version>2.1</hamcrest.version>
+        <hamcrest.version>2.2</hamcrest.version>
         <useBeta>true</useBeta>
-        <jcasc.version>1.30</jcasc.version>
+        <jcasc.version>1.35</jcasc.version>
     </properties>
 
     <scm>
@@ -43,6 +43,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
             <version>1.19</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+            <version>2.10.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -193,10 +198,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.jenkins</groupId>
-            <artifactId>configuration-as-code</artifactId>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
             <version>${jcasc.version}</version>
-            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a `tests` classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again,

Tracking:
https://github.com/jenkinsci/bom/pull/164

Note: We'll need a release for PCT please