### PR TITLE
Upgrade to github-api 1.105.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <changelist>-SNAPSHOT</changelist>
         <hpi.compatibleSinceVersion>2.2.0</hpi.compatibleSinceVersion>
         <java.level>8</java.level>
-        <jenkins.version>2.150.3</jenkins.version>
+        <jenkins.version>2.164.3</jenkins.version>
         <scm-api.version>2.6.3</scm-api.version>
         <hamcrest.version>2.2</hamcrest.version>
         <useBeta>true</useBeta>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.105</version>
+            <version>1.106</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.106</version>
+            <version>1.105.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.95</version>
+            <version>1.105</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
@@ -158,9 +158,14 @@ public class ApiRateLimitCheckerTest {
             String limit = Integer.toString(scenarioResponse.limit);
             String remaining = Integer.toString(scenarioResponse.remaining);
             String reset = Long.toString(scenarioResponse.reset.toInstant().getEpochSecond());
-            String body = "{ \"rate\": { \"limit\": " + limit + ", " +
-                    "\"remaining\": " + remaining + ", " +
-                    "\"reset\": " + reset + " } }";
+            String body = "{" +
+                String.format(" \"rate\": { \"limit\": %s, \"remaining\": %s, \"reset\": %s },", limit, remaining, reset) +
+                " \"resources\": {" +
+                String.format(" \"core\": { \"limit\": %s, \"remaining\": %s, \"reset\": %s },", limit, remaining, reset) +
+                String.format(" \"search\": { \"limit\": %s, \"remaining\": %s, \"reset\": %s },", limit, remaining, reset) +
+                String.format(" \"graphql\": { \"limit\": %s, \"remaining\": %s, \"reset\": %s },", limit, remaining, reset) +
+                String.format(" \"integration_manifest\": { \"limit\": %s, \"remaining\": %s, \"reset\": %s }", limit, remaining, reset) +
+                " } }";
             ScenarioMappingBuilder scenario = get(urlEqualTo("/rate_limit"))
                     .inScenario(scenarioName)
                     .whenScenarioStateIs(state)

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFileSystemTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFileSystemTest.java
@@ -225,16 +225,21 @@ public class GitHubSCMFileSystemTest {
                 is("c0e024f89969b976da165eecaa71e09dc60c3da1"));
         SCMFileSystem fs = SCMFileSystem.of(source, master, revision);
 
-        // On windows, if somebody has not configured Git correctly, the checkout may have "fixed" line endings
-        // So let's detect that and fix our expectations.
         String expected = "Some text\n";
-        try (InputStream is = getClass().getResourceAsStream("/raw/__files/body-fu-bar.txt-b4k4I.txt")) {
-            if (is != null) {
-                expected = IOUtils.toString(is, StandardCharsets.US_ASCII);
-            }
-        } catch (IOException e) {
-            // ignore
-        }
+        // In previous versions of github-api, GHContent.read() (called by contentAsString())
+        // would pull from the "raw" url of the GHContent instance.
+        // Thus on windows, if somebody did not configure Git correctly,
+        // the checkout may have "fixed" line endings that we needed to handle.
+        // The problem with the raw url data is that it can get out of sync when from the actual content.
+        // The GitHub API info stays sync'd and correct, so now GHContent.read() pulls from mime encoded data
+        // in the GHContent record itself. Keeping this for refence in case it changes again.
+//        try (InputStream inputStream = getClass().getResourceAsStream("/raw/__files/body-fu-bar.txt-b4k4I.txt")) {
+//            if (inputStream != null) {
+//                expected = IOUtils.toString(inputStream, StandardCharsets.US_ASCII);
+//            }
+//        } catch (IOException e) {
+//            // ignore
+//        }
         assertThat(fs.getRoot().child("fu/bar.txt").contentAsString(), is(expected));
     }
 


### PR DESCRIPTION
* JENKINS issue(s):
    * First part of fix to JENKINS-54126 and others.
* Description:
    * It has been far too long since we've updated. This isn't quite done, but this is the last set of changes.  When the github-api-plugin is published I'll update the version in this PR. 

@car-roll @kshultzCB @joseblas @dwnusbaum 