### PR TITLE
Remove redundant type info

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubConfiguration.java
@@ -63,7 +63,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
     @NonNull
     public synchronized List<Endpoint> getEndpoints() {
-        return endpoints == null ? Collections.<Endpoint>emptyList() : Collections.unmodifiableList(endpoints);
+        return endpoints == null ? Collections.emptyList() : Collections.unmodifiableList(endpoints);
     }
 
     @NonNull
@@ -122,7 +122,7 @@ import org.kohsuke.stapler.StaplerRequest;
     }
 
     public synchronized void setEndpoints(@CheckForNull List<Endpoint> endpoints) {
-        endpoints = new ArrayList<Endpoint>(endpoints == null ? Collections.<Endpoint>emptyList() : endpoints);
+        endpoints = new ArrayList<Endpoint>(endpoints == null ? Collections.emptyList() : endpoints);
         // remove duplicates and empty urls
         Set<String> apiUris = new HashSet<String>();
         for (Iterator<Endpoint> iterator = endpoints.iterator(); iterator.hasNext(); ) {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1352,7 +1352,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
         @Override
         public SCMNavigator newInstance(String name) {
             GitHubSCMNavigator navigator = new GitHubSCMNavigator(name);
-            navigator.setTraits((List) getTraitsDefaults());
+            navigator.setTraits(getTraitsDefaults());
             return navigator;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceContext.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceContext.java
@@ -165,7 +165,7 @@ public class GitHubSCMSourceContext
      */
     public final List<AbstractGitHubNotificationStrategy> notificationStrategies() {
         if (notificationStrategies.isEmpty()) {
-            return Collections.<AbstractGitHubNotificationStrategy>singletonList(new DefaultGitHubNotificationStrategy());
+            return Collections.singletonList(new DefaultGitHubNotificationStrategy());
         }
         return Collections.unmodifiableList(notificationStrategies);
     }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRequest.java
@@ -153,10 +153,10 @@ public class GitHubSCMSourceRequest extends SCMSourceRequest {
         fetchForkPRs = context.wantForkPRs();
         originPRStrategies = fetchOriginPRs && !context.originPRStrategies().isEmpty()
                 ? Collections.unmodifiableSet(EnumSet.copyOf(context.originPRStrategies()))
-                : Collections.<ChangeRequestCheckoutStrategy>emptySet();
+                : Collections.emptySet();
         forkPRStrategies = fetchForkPRs && !context.forkPRStrategies().isEmpty()
                 ? Collections.unmodifiableSet(EnumSet.copyOf(context.forkPRStrategies()))
-                : Collections.<ChangeRequestCheckoutStrategy>emptySet();
+                : Collections.emptySet();
         Set<SCMHead> includes = context.observer().getIncludes();
         if (includes != null) {
             Set<Integer> pullRequestNumbers = new HashSet<>(includes.size());
@@ -258,9 +258,9 @@ public class GitHubSCMSourceRequest extends SCMSourceRequest {
     @NonNull
     public final Set<ChangeRequestCheckoutStrategy> getPRStrategies(boolean fork) {
         if (fork) {
-            return fetchForkPRs ? getForkPRStrategies() : Collections.<ChangeRequestCheckoutStrategy>emptySet();
+            return fetchForkPRs ? getForkPRStrategies() : Collections.emptySet();
         }
-        return fetchOriginPRs ? getOriginPRStrategies() : Collections.<ChangeRequestCheckoutStrategy>emptySet();
+        return fetchOriginPRs ? getOriginPRStrategies() : Collections.emptySet();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PushGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PushGHEventSubscriber.java
@@ -319,8 +319,7 @@ public class PushGHEventSubscriber extends GHEventsSubscriber {
                     }
                 }
                 if (!excluded) {
-                    return Collections.<SCMHead, SCMRevision>singletonMap(head,
-                            new AbstractGitSCMSource.SCMRevisionImpl(head, push.getHead()));
+                    return Collections.singletonMap(head, new AbstractGitSCMSource.SCMRevisionImpl(head, push.getHead()));
                 }
             }
             if (context.wantTags() && ref.startsWith(R_TAGS)) {
@@ -352,8 +351,7 @@ public class PushGHEventSubscriber extends GHEventsSubscriber {
                     }
                 }
                 if (!excluded) {
-                    return Collections.<SCMHead, SCMRevision>singletonMap(head,
-                            new GitTagSCMRevision(head, push.getHead()));
+                    return Collections.singletonMap(head, new GitTagSCMRevision(head, push.getHead()));
                 }
             }
             return Collections.emptyMap();

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTraitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTraitTest.java
@@ -38,7 +38,7 @@ public class BranchDiscoveryTraitTest {
         assertThat(ctx.wantPRs(), is(false));
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
-        assertThat(ctx.authorities(), (Matcher) hasItem(
+        assertThat(ctx.authorities(), hasItem(
                 instanceOf(BranchDiscoveryTrait.BranchSCMHeadAuthority.class)
         ));
     }
@@ -60,7 +60,7 @@ public class BranchDiscoveryTraitTest {
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(),
                 contains(instanceOf(BranchDiscoveryTrait.ExcludeOriginPRBranchesSCMHeadFilter.class)));
-        assertThat(ctx.authorities(), (Matcher) hasItem(
+        assertThat(ctx.authorities(), hasItem(
                 instanceOf(BranchDiscoveryTrait.BranchSCMHeadAuthority.class)
         ));
     }
@@ -81,7 +81,7 @@ public class BranchDiscoveryTraitTest {
         assertThat(ctx.wantPRs(), is(true));
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), contains(instanceOf(BranchDiscoveryTrait.OnlyOriginPRBranchesSCMHeadFilter.class)));
-        assertThat(ctx.authorities(), (Matcher) hasItem(
+        assertThat(ctx.authorities(), hasItem(
                 instanceOf(BranchDiscoveryTrait.BranchSCMHeadAuthority.class)
         ));
     }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait2Test.java
@@ -74,7 +74,7 @@ public class ForkPullRequestDiscoveryTrait2Test {
             s = new GitHubSCMSource("nobody", "nowhere", null, false);
 
         p.setSourcesList(Collections.singletonList(new BranchSource(s)));
-        s.setTraits(Collections.<SCMSourceTrait>singletonList(new ForkPullRequestDiscoveryTrait(0, trust)));
+        s.setTraits(Collections.singletonList(new ForkPullRequestDiscoveryTrait(0, trust)));
         r.configRoundtrip(p);
         List<SCMSourceTrait> traits = ((GitHubSCMSource) p.getSourcesList().get(0).getSource()).getTraits();
         assertEquals(1, traits.size());

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTraitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTraitTest.java
@@ -44,8 +44,7 @@ public class ForkPullRequestDiscoveryTraitTest {
         assertThat(ctx.wantPRs(), is(true));
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
-        assertThat(ctx.forkPRStrategies(),
-                Matchers.<Set<ChangeRequestCheckoutStrategy>>is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
+        assertThat(ctx.forkPRStrategies(), Matchers.is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
         assertThat(ctx.authorities(), (Matcher) hasItem(
                 instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class)
         ));
@@ -70,8 +69,7 @@ public class ForkPullRequestDiscoveryTraitTest {
         assertThat(ctx.wantPRs(), is(true));
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
-        assertThat(ctx.forkPRStrategies(),
-                Matchers.<Set<ChangeRequestCheckoutStrategy>>is(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD)));
+        assertThat(ctx.forkPRStrategies(), Matchers.is(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD)));
         assertThat(ctx.authorities(), (Matcher) hasItem(
                 instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class)
         ));
@@ -96,8 +94,7 @@ public class ForkPullRequestDiscoveryTraitTest {
         assertThat(ctx.wantPRs(), is(true));
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
-        assertThat(ctx.forkPRStrategies(),
-                Matchers.<Set<ChangeRequestCheckoutStrategy>>is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)));
+        assertThat(ctx.forkPRStrategies(), Matchers.is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)));
         assertThat(ctx.authorities(), (Matcher) hasItem(
                 instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class)
         ));
@@ -122,8 +119,7 @@ public class ForkPullRequestDiscoveryTraitTest {
         assertThat(ctx.wantPRs(), is(true));
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
-        assertThat(ctx.forkPRStrategies(),
-                Matchers.<Set<ChangeRequestCheckoutStrategy>>is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
+        assertThat(ctx.forkPRStrategies(), Matchers.is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
         assertThat(ctx.authorities(), (Matcher) hasItem(
                 instanceOf(ForkPullRequestDiscoveryTrait.TrustEveryone.class)
         ));

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTraitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTraitTest.java
@@ -45,7 +45,7 @@ public class ForkPullRequestDiscoveryTraitTest {
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
         assertThat(ctx.forkPRStrategies(), Matchers.is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
-        assertThat(ctx.authorities(), (Matcher) hasItem(
+        assertThat(ctx.authorities(), hasItem(
                 instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class)
         ));
     }
@@ -70,7 +70,7 @@ public class ForkPullRequestDiscoveryTraitTest {
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
         assertThat(ctx.forkPRStrategies(), Matchers.is(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD)));
-        assertThat(ctx.authorities(), (Matcher) hasItem(
+        assertThat(ctx.authorities(), hasItem(
                 instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class)
         ));
     }
@@ -95,7 +95,7 @@ public class ForkPullRequestDiscoveryTraitTest {
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
         assertThat(ctx.forkPRStrategies(), Matchers.is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)));
-        assertThat(ctx.authorities(), (Matcher) hasItem(
+        assertThat(ctx.authorities(), hasItem(
                 instanceOf(ForkPullRequestDiscoveryTrait.TrustContributors.class)
         ));
     }
@@ -120,7 +120,7 @@ public class ForkPullRequestDiscoveryTraitTest {
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
         assertThat(ctx.forkPRStrategies(), Matchers.is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
-        assertThat(ctx.authorities(), (Matcher) hasItem(
+        assertThat(ctx.authorities(), hasItem(
                 instanceOf(ForkPullRequestDiscoveryTrait.TrustEveryone.class)
         ));
     }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubNotificationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubNotificationTest.java
@@ -59,7 +59,7 @@ public class GitHubNotificationTest {
     public void given__emptyStrategiesList__when__appliedToContext__then__defaultApplied() throws Exception {
         GitHubSCMSourceContext ctx = new GitHubSCMSourceContext(null, SCMHeadObserver.none());
         assumeThat(ctx.notificationStrategies().size(), is(1));
-        ctx.withNotificationStrategies(Collections.<AbstractGitHubNotificationStrategy>emptyList());
+        ctx.withNotificationStrategies(Collections.emptyList());
         assertThat(ctx.notificationStrategies().size(), is(1));
     }
 
@@ -67,7 +67,7 @@ public class GitHubNotificationTest {
     public void given__defaultStrategy__when__emptyStrategyList__then__strategyAdded() throws Exception {
         GitHubSCMSourceContext ctx = new GitHubSCMSourceContext(null, SCMHeadObserver.none());
         assumeThat(ctx.notificationStrategies().size(), is(1));
-        ctx.withNotificationStrategies(Collections.<AbstractGitHubNotificationStrategy>emptyList());
+        ctx.withNotificationStrategies(Collections.emptyList());
         assertThat(ctx.notificationStrategies().size(), is(1));
         ctx.withNotificationStrategy(new DefaultGitHubNotificationStrategy());
         assertThat(ctx.notificationStrategies().size(), is(1));
@@ -77,9 +77,9 @@ public class GitHubNotificationTest {
     public void given__defaultStrategyList__when__emptyStrategyList__then__strategyAdded() throws Exception {
         GitHubSCMSourceContext ctx = new GitHubSCMSourceContext(null, SCMHeadObserver.none());
         assumeThat(ctx.notificationStrategies().size(), is(1));
-        ctx.withNotificationStrategies(Collections.<AbstractGitHubNotificationStrategy>emptyList());
+        ctx.withNotificationStrategies(Collections.emptyList());
         assertThat(ctx.notificationStrategies().size(), is(1));
-        ctx.withNotificationStrategies(Collections.<AbstractGitHubNotificationStrategy>singletonList(new DefaultGitHubNotificationStrategy()));
+        ctx.withNotificationStrategies(Collections.singletonList(new DefaultGitHubNotificationStrategy()));
         assertThat(ctx.notificationStrategies().size(), is(1));
     }
 
@@ -90,7 +90,7 @@ public class GitHubNotificationTest {
         ctx.withNotificationStrategy(new TestNotificationStrategy());
         List<AbstractGitHubNotificationStrategy> strategies = ctx.notificationStrategies();
         assertThat(strategies.size(), is(1));
-        assertThat(strategies.get(0), Matchers.<AbstractGitHubNotificationStrategy>instanceOf(TestNotificationStrategy.class));
+        assertThat(strategies.get(0), Matchers.instanceOf(TestNotificationStrategy.class));
     }
 
     private final class TestNotificationStrategy extends AbstractGitHubNotificationStrategy {

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
@@ -108,8 +108,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -162,8 +162,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -216,8 +216,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -270,8 +270,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -331,8 +331,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -391,8 +391,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -451,8 +451,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -511,8 +511,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -571,8 +571,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -629,7 +629,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -669,7 +669,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -709,7 +709,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -751,8 +751,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.test/tester/test-repo.git"));
@@ -806,8 +806,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.test/tester/test-repo.git"));
@@ -860,8 +860,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.test/tester/test-repo.git"));
@@ -912,7 +912,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -952,7 +952,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -992,7 +992,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/heads/test-branch:refs/remotes/@{remote}/test-branch"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -1039,8 +1039,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -1098,8 +1098,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -1157,8 +1157,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -1211,7 +1211,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -1253,7 +1253,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -1295,7 +1295,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -1342,8 +1342,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.test/tester/test-repo.git"));
@@ -1402,8 +1402,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.test/tester/test-repo.git"));
@@ -1461,8 +1461,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.test/tester/test-repo.git"));
@@ -1515,7 +1515,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -1557,7 +1557,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -1599,7 +1599,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -1646,8 +1646,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -1716,8 +1716,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -1786,8 +1786,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.com/tester/test-repo.git"));
@@ -1851,7 +1851,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -1904,7 +1904,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -1957,7 +1957,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -2015,8 +2015,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.test/tester/test-repo.git"));
@@ -2086,8 +2086,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.test/tester/test-repo.git"));
@@ -2156,8 +2156,8 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
-        assertThat(instance.revision(), is((SCMRevision) revision));
+        assertThat(instance.head(), is(head));
+        assertThat(instance.revision(), is(revision));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
                 instance.remote(), is("https://github.test/tester/test-repo.git"));
@@ -2221,7 +2221,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId(null);
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is(nullValue()));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -2275,7 +2275,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-pass");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-pass"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",
@@ -2329,7 +2329,7 @@ public class GitHubSCMBuilderTest {
         source.setCredentialsId("user-key");
         GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, null);
         assertThat(instance.credentialsId(), is("user-key"));
-        assertThat(instance.head(), is((SCMHead) head));
+        assertThat(instance.head(), is(head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.refSpecs(), contains("+refs/pull/1/head:refs/remotes/@{remote}/PR-1"));
         assertThat("expecting guess value until withGitHubRemote called",

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
@@ -90,13 +90,12 @@ public class GitHubSCMBuilderTest {
         Credentials sshPrivateKeyCredential = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, "user-key", "git",
                 new BasicSSHUserPrivateKey.UsersPrivateKeySource(), null, null);
         SystemCredentialsProvider.getInstance().setDomainCredentialsMap(Collections.singletonMap(Domain.global(),
-                Arrays.<Credentials>asList(userPasswordCredential, sshPrivateKeyCredential)));
+                Arrays.asList(userPasswordCredential, sshPrivateKeyCredential)));
     }
 
     @After
     public void tearDown() throws IOException, InterruptedException {
-        SystemCredentialsProvider.getInstance()
-                .setDomainCredentialsMap(Collections.<Domain, List<Credentials>>emptyMap());
+        SystemCredentialsProvider.getInstance().setDomainCredentialsMap(Collections.emptyMap());
         owner.delete();
     }
 

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -347,12 +347,12 @@ public class GitHubSCMNavigatorTest {
 
     @Test
     public void fetchActions() throws Exception {
-        assertThat(navigator.fetchActions(Mockito.mock(SCMNavigatorOwner.class), null, null), Matchers.<Action>containsInAnyOrder(
-                Matchers.<Action>is(
+        assertThat(navigator.fetchActions(Mockito.mock(SCMNavigatorOwner.class), null, null), Matchers.containsInAnyOrder(
+                Matchers.is(
                         new ObjectMetadataAction("CloudBeers, Inc.", null, "https://github.com/cloudbeers")
                 ),
-                Matchers.<Action>is(new GitHubOrgMetadataAction("https://avatars.githubusercontent.com/u/4181899?v=3")),
-                Matchers.<Action>is(new GitHubLink("icon-github-logo", "https://github.com/cloudbeers"))));
+                Matchers.is(new GitHubOrgMetadataAction("https://avatars.githubusercontent.com/u/4181899?v=3")),
+                Matchers.is(new GitHubLink("icon-github-logo", "https://github.com/cloudbeers"))));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTraitsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTraitsTest.java
@@ -69,16 +69,16 @@ public class GitHubSCMNavigatorTraitsTest {
                 not(hasItem(Matchers.<SCMTrait<?>>instanceOf(RegexSCMSourceFilterTrait.class))));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
@@ -113,21 +113,21 @@ public class GitHubSCMNavigatorTraitsTest {
                 not(hasItem(Matchers.<SCMTrait<?>>instanceOf(RegexSCMSourceFilterTrait.class))));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
                                 hasProperty("credentialsId", is("8b2e4f77-39c5-41a9-b63b-8d367350bfdf"))
                         )
@@ -161,21 +161,21 @@ public class GitHubSCMNavigatorTraitsTest {
                 not(hasItem(Matchers.<SCMTrait<?>>instanceOf(RegexSCMSourceFilterTrait.class))));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
                                 hasProperty("credentialsId", is(nullValue()))
                         )
@@ -212,16 +212,16 @@ public class GitHubSCMNavigatorTraitsTest {
                 not(hasItem(Matchers.<SCMTrait<?>>instanceOf(RegexSCMSourceFilterTrait.class))));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
@@ -253,25 +253,25 @@ public class GitHubSCMNavigatorTraitsTest {
         );
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
                                 hasProperty("credentialsId", is("8b2e4f77-39c5-41a9-b63b-8d367350bfdf"))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(RegexSCMSourceFilterTrait.class),
                                 hasProperty("regex", is("limited.*"))
                         )
@@ -294,21 +294,21 @@ public class GitHubSCMNavigatorTraitsTest {
         assertThat(instance.getCredentialsId(), is("bcaef157-f105-407f-b150-df7722eab6c1"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(WildcardSCMHeadFilterTrait.class),
                                 hasProperty("includes", is("*")),
                                 hasProperty("excludes", is("master"))
@@ -331,21 +331,21 @@ public class GitHubSCMNavigatorTraitsTest {
         assertThat(instance.getCredentialsId(), is("bcaef157-f105-407f-b150-df7722eab6c1"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(WildcardSCMHeadFilterTrait.class),
                                 hasProperty("includes", is("feature/*")),
                                 hasProperty("excludes", is(""))
@@ -372,7 +372,7 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -385,7 +385,7 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -398,7 +398,7 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -411,7 +411,7 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -424,11 +424,11 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -441,11 +441,11 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -458,11 +458,11 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -475,7 +475,7 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -488,11 +488,11 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -505,11 +505,11 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -522,11 +522,11 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -539,7 +539,7 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -552,11 +552,11 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -569,11 +569,11 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -586,11 +586,11 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -603,7 +603,7 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
@@ -617,12 +617,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -635,12 +635,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -653,12 +653,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -671,12 +671,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -689,16 +689,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -711,16 +711,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -733,16 +733,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -755,12 +755,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -773,16 +773,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -795,16 +795,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -817,16 +817,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -839,12 +839,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -857,16 +857,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -879,16 +879,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -901,16 +901,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -923,7 +923,7 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
@@ -937,12 +937,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -955,12 +955,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -973,12 +973,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -991,12 +991,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1009,16 +1009,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1031,16 +1031,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1053,16 +1053,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1075,12 +1075,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1093,16 +1093,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1115,16 +1115,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1137,16 +1137,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1159,12 +1159,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1177,16 +1177,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1199,16 +1199,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1221,16 +1221,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1243,7 +1243,7 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
@@ -1257,12 +1257,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1275,12 +1275,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1293,12 +1293,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1311,12 +1311,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1329,16 +1329,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1351,16 +1351,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1373,16 +1373,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1395,12 +1395,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1413,16 +1413,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1435,16 +1435,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1457,16 +1457,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1479,12 +1479,12 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1497,16 +1497,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1519,16 +1519,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1541,16 +1541,16 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1572,12 +1572,12 @@ public class GitHubSCMNavigatorTraitsTest {
         assertThat(instance.getCredentialsId(), is("bcaef157-f105-407f-b150-df7722eab6c1"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategies", is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE))),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
@@ -1605,17 +1605,17 @@ public class GitHubSCMNavigatorTraitsTest {
         assertThat(instance.getCredentialsId(), is("bcaef157-f105-407f-b150-df7722eab6c1"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategies", is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE))),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
                                 hasProperty("credentialsId", is("8b2e4f77-39c5-41a9-b63b-8d367350bfdf"))
                         )
@@ -1638,16 +1638,16 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__instance__when__setTraits__then__traitsSet() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Arrays.<SCMTrait<?extends SCMTrait<?>>>asList(new BranchDiscoveryTrait(1),
+        instance.setTraits(Arrays.asList(new BranchDiscoveryTrait(1),
                 new SSHCheckoutTrait(null)));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMTrait<?>>allOf(
+                        Matchers.allOf(
                                 instanceOf(SSHCheckoutTrait.class),
                                 hasProperty("credentialsId", is(nullValue()))
                         )
@@ -1700,14 +1700,14 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__legacyCode__when__setPattern_default__then__patternSetAndTraitRemoved() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Arrays.<SCMTrait<?extends SCMTrait<?>>>asList(new BranchDiscoveryTrait(true, false), new RegexSCMSourceFilterTrait("job.*"),
+        instance.setTraits(Arrays.asList(new BranchDiscoveryTrait(true, false), new RegexSCMSourceFilterTrait("job.*"),
                 new SSHCheckoutTrait("dummy")));
         assertThat(instance.getPattern(), is("job.*"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(instanceOf(RegexSCMSourceFilterTrait.class)));
+        assertThat(instance.getTraits(), Matchers.hasItem(instanceOf(RegexSCMSourceFilterTrait.class)));
         instance.setPattern(".*");
         assertThat(instance.getPattern(), is(".*"));
         assertThat(instance.getTraits(),
-                not(Matchers.<SCMTrait<?>>hasItem(instanceOf(RegexSCMSourceFilterTrait.class))));
+                not(Matchers.hasItem(instanceOf(RegexSCMSourceFilterTrait.class))));
 
     }
 
@@ -1715,13 +1715,13 @@ public class GitHubSCMNavigatorTraitsTest {
     public void given__legacyCode__when__setPattern_custom__then__patternSetAndTraitAdded() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
         instance.setTraits(
-                Arrays.<SCMTrait<?extends SCMTrait<?>>>asList(new BranchDiscoveryTrait(true, false), new SSHCheckoutTrait("dummy")));
+                Arrays.asList(new BranchDiscoveryTrait(true, false), new SSHCheckoutTrait("dummy")));
         assertThat(instance.getPattern(), is(".*"));
         assertThat(instance.getTraits(),
-                not(Matchers.<SCMTrait<?>>hasItem(instanceOf(RegexSCMSourceFilterTrait.class))));
+                not(Matchers.hasItem(instanceOf(RegexSCMSourceFilterTrait.class))));
         instance.setPattern("job.*");
         assertThat(instance.getPattern(), is("job.*"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(
+        assertThat(instance.getTraits(), Matchers.hasItem(
                 allOf(instanceOf(RegexSCMSourceFilterTrait.class), hasProperty("regex", is("job.*")))));
 
     }
@@ -1732,12 +1732,12 @@ public class GitHubSCMNavigatorTraitsTest {
         instance.setTraits(new SCMTrait[]{new BranchDiscoveryTrait(true, false), new RegexSCMSourceFilterTrait("job.*"),
                 new SSHCheckoutTrait("dummy")});
         assertThat(instance.getPattern(), is("job.*"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(instanceOf(RegexSCMSourceFilterTrait.class)));
+        assertThat(instance.getTraits(), Matchers.hasItem(instanceOf(RegexSCMSourceFilterTrait.class)));
         instance.setPattern("project.*");
         assertThat(instance.getPattern(), is("project.*"));
-        assertThat(instance.getTraits(), not(Matchers.<SCMTrait<?>>hasItem(
+        assertThat(instance.getTraits(), not(Matchers.hasItem(
                 allOf(instanceOf(RegexSCMSourceFilterTrait.class), hasProperty("regex", is("job.*"))))));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(
+        assertThat(instance.getTraits(), Matchers.hasItem(
                 allOf(instanceOf(RegexSCMSourceFilterTrait.class), hasProperty("regex", is("project.*")))));
 
     }
@@ -1746,14 +1746,14 @@ public class GitHubSCMNavigatorTraitsTest {
     public void given__legacyCode__when__checkoutCredentials_SAME__then__noTraitAdded() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator(null, "test", "scan", GitHubSCMSource.DescriptorImpl.SAME);
         assertThat(instance.getCheckoutCredentialsId(), is(GitHubSCMNavigator.DescriptorImpl.SAME));
-        assertThat(instance.getTraits(), not(Matchers.<SCMTrait<?>>hasItem(instanceOf(SSHCheckoutTrait.class))));
+        assertThat(instance.getTraits(), not(Matchers.hasItem(instanceOf(SSHCheckoutTrait.class))));
     }
 
     @Test
     public void given__legacyCode__when__checkoutCredentials_null__then__traitAdded_ANONYMOUS() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator(null, "test", "scan", null);
         assertThat(instance.getCheckoutCredentialsId(), is(GitHubSCMSource.DescriptorImpl.ANONYMOUS));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(SSHCheckoutTrait.class),
                 hasProperty("credentialsId", is(nullValue()))
         )));
@@ -1763,7 +1763,7 @@ public class GitHubSCMNavigatorTraitsTest {
     public void given__legacyCode__when__checkoutCredentials_value__then__traitAdded() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator(null, "test", "scan", "value");
         assertThat(instance.getCheckoutCredentialsId(), is("value"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(SSHCheckoutTrait.class),
                 hasProperty("credentialsId", is("value"))
         )));
@@ -1774,7 +1774,7 @@ public class GitHubSCMNavigatorTraitsTest {
         GitHubSCMNavigator instance = new GitHubSCMNavigator(null, "test", "scan",
                 GitHubSCMSource.DescriptorImpl.ANONYMOUS);
         assertThat(instance.getCheckoutCredentialsId(), is(GitHubSCMSource.DescriptorImpl.ANONYMOUS));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(SSHCheckoutTrait.class),
                 hasProperty("credentialsId", is(nullValue()))
         )));
@@ -1783,14 +1783,14 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__legacyCode_withoutExcludes__when__setIncludes_default__then__traitRemoved() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Arrays.<SCMTrait<?extends SCMTrait<?>>>asList(
+        instance.setTraits(Arrays.asList(
                 new BranchDiscoveryTrait(true, false),
                 new RegexSCMSourceFilterTrait("job.*"),
                 new WildcardSCMHeadFilterTrait("feature/*", "")
         ));
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is(""))
@@ -1798,7 +1798,7 @@ public class GitHubSCMNavigatorTraitsTest {
         instance.setIncludes("*");
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), not(Matchers.<SCMTrait<?>>hasItem(
+        assertThat(instance.getTraits(), not(Matchers.hasItem(
                 instanceOf(WildcardSCMHeadFilterTrait.class)
         )));
     }
@@ -1813,7 +1813,7 @@ public class GitHubSCMNavigatorTraitsTest {
         });
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is(""))
@@ -1821,7 +1821,7 @@ public class GitHubSCMNavigatorTraitsTest {
         instance.setIncludes("bug/*");
         assertThat(instance.getIncludes(), is("bug/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("bug/*")),
                 hasProperty("excludes", is(""))
@@ -1831,19 +1831,19 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__legacyCode_withoutTrait__when__setIncludes_value__then__traitAdded() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Arrays.<SCMTrait<?extends SCMTrait<?>>>asList(
+        instance.setTraits(Arrays.asList(
                 new BranchDiscoveryTrait(true, false),
                 new RegexSCMSourceFilterTrait("job.*")
         ));
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), not(Matchers.<SCMTrait<?>>hasItem(
+        assertThat(instance.getTraits(), not(Matchers.hasItem(
                 instanceOf(WildcardSCMHeadFilterTrait.class)
         )));
         instance.setIncludes("feature/*");
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is(""))
@@ -1853,14 +1853,14 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__legacyCode_withExcludes__when__setIncludes_default__then__traitUpdated() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Arrays.<SCMTrait<?extends SCMTrait<?>>>asList(
+        instance.setTraits(Arrays.asList(
                 new BranchDiscoveryTrait(true, false),
                 new RegexSCMSourceFilterTrait("job.*"),
                 new WildcardSCMHeadFilterTrait("feature/*", "feature/ignore")
         ));
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -1868,7 +1868,7 @@ public class GitHubSCMNavigatorTraitsTest {
         instance.setIncludes("*");
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -1885,7 +1885,7 @@ public class GitHubSCMNavigatorTraitsTest {
         });
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -1893,7 +1893,7 @@ public class GitHubSCMNavigatorTraitsTest {
         instance.setIncludes("bug/*");
         assertThat(instance.getIncludes(), is("bug/*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("bug/*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -1903,14 +1903,14 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__legacyCode_withoutIncludes__when__setExcludes_default__then__traitRemoved() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Arrays.<SCMTrait<?extends SCMTrait<?>>>asList(
+        instance.setTraits(Arrays.asList(
                 new BranchDiscoveryTrait(true, false),
                 new RegexSCMSourceFilterTrait("job.*"),
                 new WildcardSCMHeadFilterTrait("*", "feature/ignore")
         ));
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -1918,7 +1918,7 @@ public class GitHubSCMNavigatorTraitsTest {
         instance.setExcludes("");
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), not(Matchers.<SCMTrait<?>>hasItem(
+        assertThat(instance.getTraits(), not(Matchers.hasItem(
                 instanceOf(WildcardSCMHeadFilterTrait.class)
         )));
     }
@@ -1926,14 +1926,14 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__legacyCode_withoutIncludes__when__setExcludes_value__then__traitUpdated() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Arrays.<SCMTrait<?extends SCMTrait<?>>>asList(
+        instance.setTraits(Arrays.asList(
                 new BranchDiscoveryTrait(true, false),
                 new RegexSCMSourceFilterTrait("job.*"),
                 new WildcardSCMHeadFilterTrait("*", "feature/ignore")
         ));
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -1941,7 +1941,7 @@ public class GitHubSCMNavigatorTraitsTest {
         instance.setExcludes("bug/ignore");
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is("bug/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("*")),
                 hasProperty("excludes", is("bug/ignore"))
@@ -1951,19 +1951,19 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__legacyCode_withoutTrait__when__setExcludes_value__then__traitAdded() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Arrays.<SCMTrait<?extends SCMTrait<?>>>asList(
+        instance.setTraits(Arrays.asList(
                 new BranchDiscoveryTrait(true, false),
                 new RegexSCMSourceFilterTrait("job.*")
         ));
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), not(Matchers.<SCMTrait<?>>hasItem(
+        assertThat(instance.getTraits(), not(Matchers.hasItem(
                 instanceOf(WildcardSCMHeadFilterTrait.class)
         )));
         instance.setExcludes("feature/ignore");
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -1973,14 +1973,14 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__legacyCode_withIncludes__when__setExcludes_default__then__traitUpdated() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Arrays.<SCMTrait<?extends SCMTrait<?>>>asList(
+        instance.setTraits(Arrays.asList(
                 new BranchDiscoveryTrait(true, false),
                 new RegexSCMSourceFilterTrait("job.*"),
                 new WildcardSCMHeadFilterTrait("feature/*", "feature/ignore")
         ));
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -1988,7 +1988,7 @@ public class GitHubSCMNavigatorTraitsTest {
         instance.setExcludes("");
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is(""))
@@ -1998,14 +1998,14 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__legacyCode_withIncludes__when__setExcludes_value__then__traitUpdated() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Arrays.<SCMTrait<?extends SCMTrait<?>>>asList(
+        instance.setTraits(Arrays.asList(
                 new BranchDiscoveryTrait(true, false),
                 new RegexSCMSourceFilterTrait("job.*"),
                 new WildcardSCMHeadFilterTrait("feature/*", "")
         ));
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is(""))
@@ -2013,7 +2013,7 @@ public class GitHubSCMNavigatorTraitsTest {
         instance.setExcludes("feature/ignore");
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMTrait<?>>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -2023,7 +2023,7 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__legacyCode__when__setBuildOriginBranch__then__traitsMaintained() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Collections.<SCMTrait<?extends SCMTrait<?>>>emptyList());
+        instance.setTraits(Collections.emptyList());
         assertThat(instance.getTraits(), is(Collections.<SCMTrait<?>>emptyList()));
         instance.setBuildOriginBranch(true);
         assertThat(instance.getTraits(), contains(instanceOf(BranchDiscoveryTrait.class)));

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -201,7 +201,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
 
         assertThat(byName.get("PR-2"), instanceOf(PullRequestSCMHead.class));
         assertThat(((PullRequestSCMHead)byName.get("PR-2")).isMerge(), is(true));
-        assertThat(revByName.get("PR-2"), is((SCMRevision) new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-2")),
+        assertThat(revByName.get("PR-2"), is(new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-2")),
                 "8f1314fc3c8284d8c6d5886d473db98f2126071c",
                 "c0e024f89969b976da165eecaa71e09dc60c3da1",
                 "38814ca33833ff5583624c29f305be9133f27a40"
@@ -211,7 +211,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
         assertThat(byName.get("PR-3"), instanceOf(PullRequestSCMHead.class));
         assertThat(((SCMHeadOrigin.Fork) byName.get("PR-3").getOrigin()).getName(), is("stephenc"));
         assertThat(((PullRequestSCMHead)byName.get("PR-3")).isMerge(), is(true));
-        assertThat(revByName.get("PR-3"), is((SCMRevision) new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
+        assertThat(revByName.get("PR-3"), is(new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
                 "8f1314fc3c8284d8c6d5886d473db98f2126071c",
                 "c0e024f89969b976da165eecaa71e09dc60c3da1",
                 PullRequestSCMRevision.NOT_MERGEABLE_HASH
@@ -274,7 +274,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
 
         assertThat(byName.get("PR-2"), instanceOf(PullRequestSCMHead.class));
         assertThat(((PullRequestSCMHead)byName.get("PR-2")).isMerge(), is(true));
-        assertThat(revByName.get("PR-2"), is((SCMRevision) new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-2")),
+        assertThat(revByName.get("PR-2"), is(new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-2")),
                 "8f1314fc3c8284d8c6d5886d473db98f2126071c",
                 "c0e024f89969b976da165eecaa71e09dc60c3da1",
                 null
@@ -284,7 +284,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
         assertThat(byName.get("PR-3"), instanceOf(PullRequestSCMHead.class));
         assertThat(((PullRequestSCMHead)byName.get("PR-3")).isMerge(), is(true));
         assertThat(((SCMHeadOrigin.Fork) byName.get("PR-3").getOrigin()).getName(), is("stephenc"));
-        assertThat(revByName.get("PR-3"), is((SCMRevision) new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
+        assertThat(revByName.get("PR-3"), is(new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
                 "8f1314fc3c8284d8c6d5886d473db98f2126071c",
                 "c0e024f89969b976da165eecaa71e09dc60c3da1",
                 PullRequestSCMRevision.NOT_MERGEABLE_HASH
@@ -354,7 +354,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
         assertThat(byName.get("PR-3"), instanceOf(PullRequestSCMHead.class));
         assertThat(((SCMHeadOrigin.Fork) byName.get("PR-3").getOrigin()).getName(), is("stephenc"));
         assertThat(((PullRequestSCMHead)byName.get("PR-3")).isMerge(), is(true));
-        assertThat(revByName.get("PR-3"), is((SCMRevision) new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
+        assertThat(revByName.get("PR-3"), is(new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
                 "8f1314fc3c8284d8c6d5886d473db98f2126071c",
                 "c0e024f89969b976da165eecaa71e09dc60c3da1",
                 PullRequestSCMRevision.NOT_MERGEABLE_HASH
@@ -444,7 +444,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
         assertThat(byName.get("PR-3"), instanceOf(PullRequestSCMHead.class));
         assertThat(((SCMHeadOrigin.Fork) byName.get("PR-3").getOrigin()).getName(), is("stephenc"));
         assertThat(((PullRequestSCMHead)byName.get("PR-3")).isMerge(), is(true));
-        assertThat(revByName.get("PR-3"), is((SCMRevision) new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
+        assertThat(revByName.get("PR-3"), is(new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
                 "8f1314fc3c8284d8c6d5886d473db98f2126071c",
                 "c0e024f89969b976da165eecaa71e09dc60c3da1",
                 PullRequestSCMRevision.NOT_MERGEABLE_HASH
@@ -503,7 +503,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
 
         assertThat(byName.get("PR-2"), instanceOf(PullRequestSCMHead.class));
         assertThat(((PullRequestSCMHead)byName.get("PR-2")).isMerge(), is(true));
-        assertThat(revByName.get("PR-2"), is((SCMRevision) new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-2")),
+        assertThat(revByName.get("PR-2"), is(new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-2")),
                 "8f1314fc3c8284d8c6d5886d473db98f2126071c",
                 "c0e024f89969b976da165eecaa71e09dc60c3da1",
                 null
@@ -513,7 +513,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
         assertThat(byName.get("PR-3"), instanceOf(PullRequestSCMHead.class));
         assertThat(((SCMHeadOrigin.Fork) byName.get("PR-3").getOrigin()).getName(), is("stephenc"));
         assertThat(((PullRequestSCMHead)byName.get("PR-3")).isMerge(), is(true));
-        assertThat(revByName.get("PR-3"), is((SCMRevision) new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
+        assertThat(revByName.get("PR-3"), is(new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
                 "8f1314fc3c8284d8c6d5886d473db98f2126071c",
                 "c0e024f89969b976da165eecaa71e09dc60c3da1",
                 PullRequestSCMRevision.NOT_MERGEABLE_HASH
@@ -605,7 +605,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
         assertThat(byName.keySet(), containsInAnyOrder("PR-2", "PR-3", "PR-4", "master", "stephenc-patch-1"));
         assertThat(byName.get("PR-2"), instanceOf(PullRequestSCMHead.class));
         assertThat(((PullRequestSCMHead)byName.get("PR-2")).isMerge(), is(false));
-        assertThat(revByName.get("PR-2"), is((SCMRevision) new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-2")),
+        assertThat(revByName.get("PR-2"), is(new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-2")),
                 "8f1314fc3c8284d8c6d5886d473db98f2126071c",
                 "c0e024f89969b976da165eecaa71e09dc60c3da1"
         )));
@@ -614,7 +614,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
         assertThat(byName.get("PR-3"), instanceOf(PullRequestSCMHead.class));
         assertThat(((SCMHeadOrigin.Fork) byName.get("PR-3").getOrigin()).getName(), is("stephenc"));
         assertThat(((PullRequestSCMHead)byName.get("PR-3")).isMerge(), is(false));
-        assertThat(revByName.get("PR-3"), is((SCMRevision) new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
+        assertThat(revByName.get("PR-3"), is(new PullRequestSCMRevision((PullRequestSCMHead)(byName.get("PR-3")),
                 "8f1314fc3c8284d8c6d5886d473db98f2126071c",
                 "c0e024f89969b976da165eecaa71e09dc60c3da1"
         )));
@@ -649,7 +649,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
     public void getTrustedRevisionReturnsRevisionIfRepoOwnerAndPullRequestBranchOwnerAreSameWithDifferentCase() throws Exception {
         source.setBuildOriginPRHead(true);
         PullRequestSCMRevision revision = createRevision("CloudBeers");
-        assertThat(source.getTrustedRevision(revision, new LogTaskListener(Logger.getAnonymousLogger(), Level.INFO)), sameInstance((SCMRevision) revision));
+        assertThat(source.getTrustedRevision(revision, new LogTaskListener(Logger.getAnonymousLogger(), Level.INFO)), sameInstance(revision));
     }
 
     private PullRequestSCMRevision createRevision(String sourceOwner) {

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -163,11 +163,11 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
         WorkflowMultiBranchProject job = r.createProject(WorkflowMultiBranchProject.class);
         job.setSourcesList(Arrays.asList(new BranchSource(new GitSCMSource("file://tmp/something"))));
         Collection<GitHubRepositoryName> names = GitHubRepositoryNameContributor.parseAssociatedNames(job);
-        assertThat(names, Matchers.<GitHubRepositoryName>empty());
+        assertThat(names, Matchers.empty());
         //And specifically...
         names = new ArrayList<>();
         ExtensionList.lookup(GitHubRepositoryNameContributor.class).get(GitHubSCMSourceRepositoryNameContributor.class).parseAssociatedNames(job, names);
-        assertThat(names, Matchers.<GitHubRepositoryName>empty());
+        assertThat(names, Matchers.empty());
     }
 
     @Test
@@ -175,11 +175,11 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
     public void testGitHubRepositoryNameContributor_When_not_MultiBranch() throws IOException {
         FreeStyleProject job = r.createProject(FreeStyleProject.class);
         Collection<GitHubRepositoryName> names = GitHubRepositoryNameContributor.parseAssociatedNames((Item) job);
-        assertThat(names, Matchers.<GitHubRepositoryName>empty());
+        assertThat(names, Matchers.empty());
         //And specifically...
         names = new ArrayList<>();
         ExtensionList.lookup(GitHubRepositoryNameContributor.class).get(GitHubSCMSourceRepositoryNameContributor.class).parseAssociatedNames((Item) job, names);
-        assertThat(names, Matchers.<GitHubRepositoryName>empty());
+        assertThat(names, Matchers.empty());
     }
 
     @Test
@@ -634,15 +634,15 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
 
     @Test
     public void fetchActions() throws Exception {
-        assertThat(source.fetchActions(null, null), Matchers.<Action>containsInAnyOrder(
-                Matchers.<Action>is(
+        assertThat(source.fetchActions(null, null), Matchers.containsInAnyOrder(
+                Matchers.is(
                         new ObjectMetadataAction(null, "You only live once", "http://yolo.example.com")
                 ),
-                Matchers.<Action>is(
+                Matchers.is(
                         new GitHubDefaultBranch("cloudbeers", "yolo", "master")
                 ),
                 instanceOf(GitHubRepoMetadataAction.class),
-                Matchers.<Action>is(new GitHubLink("icon-github-repo", "https://github.com/cloudbeers/yolo"))));
+                Matchers.is(new GitHubLink("icon-github-repo", "https://github.com/cloudbeers/yolo"))));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
@@ -146,12 +146,12 @@ public class GitHubSCMSourceTraitsTest {
         assertThat(instance.getCredentialsId(), is("e4d8c11a-0d24-472f-b86b-4b017c160e9a"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
@@ -183,16 +183,16 @@ public class GitHubSCMSourceTraitsTest {
         assertThat(instance.getCredentialsId(), is("e4d8c11a-0d24-472f-b86b-4b017c160e9a"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
@@ -224,21 +224,21 @@ public class GitHubSCMSourceTraitsTest {
         assertThat(instance.getCredentialsId(), is("e4d8c11a-0d24-472f-b86b-4b017c160e9a"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
                                 hasProperty("credentialsId", is("other-credentials"))
                         )
@@ -270,16 +270,16 @@ public class GitHubSCMSourceTraitsTest {
         assertThat(instance.getCredentialsId(), is("e4d8c11a-0d24-472f-b86b-4b017c160e9a"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
@@ -311,17 +311,17 @@ public class GitHubSCMSourceTraitsTest {
         assertThat(instance.getCredentialsId(), is("e4d8c11a-0d24-472f-b86b-4b017c160e9a"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(WildcardSCMHeadFilterTrait.class),
                                 hasProperty("includes", is("*")),
                                 hasProperty("excludes", is("master"))
@@ -353,17 +353,17 @@ public class GitHubSCMSourceTraitsTest {
         assertThat(instance.getCredentialsId(), is("e4d8c11a-0d24-472f-b86b-4b017c160e9a"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(WildcardSCMHeadFilterTrait.class),
                                 hasProperty("includes", is("feature/*")),
                                 hasProperty("excludes", is(""))
@@ -395,17 +395,17 @@ public class GitHubSCMSourceTraitsTest {
         assertThat(instance.getCredentialsId(), is("e4d8c11a-0d24-472f-b86b-4b017c160e9a"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1)),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
                                 hasProperty("credentialsId", is(nullValue()))
                         )
@@ -434,12 +434,12 @@ public class GitHubSCMSourceTraitsTest {
         assertThat(instance.getCredentialsId(), is("e4d8c11a-0d24-472f-b86b-4b017c160e9a"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategies", is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE))),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
@@ -470,17 +470,17 @@ public class GitHubSCMSourceTraitsTest {
         assertThat(instance.getCredentialsId(), is("e4d8c11a-0d24-472f-b86b-4b017c160e9a"));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategies", is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE))),
                                 hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustPermission.class))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 Matchers.instanceOf(SSHCheckoutTrait.class),
                                 hasProperty("credentialsId", is("8b2e4f77-39c5-41a9-b63b-8d367350bfdf"))
                         )
@@ -501,14 +501,14 @@ public class GitHubSCMSourceTraitsTest {
     @Test
     public void given__instance__when__setTraits_empty__then__traitsEmpty() {
         GitHubSCMSource instance = new GitHubSCMSource("testing", "test-repo");
-        instance.setTraits(Collections.<SCMSourceTrait>emptyList());
+        instance.setTraits(Collections.emptyList());
         assertThat(instance.getTraits(), is(Collections.<SCMSourceTrait>emptyList()));
     }
 
     @Test
     public void given__legacyCode__when__setBuildOriginBranch__then__traitsMaintained() {
         GitHubSCMSource instance = new GitHubSCMSource("testing", "test-repo");
-        instance.setTraits(Collections.<SCMSourceTrait>emptyList());
+        instance.setTraits(Collections.emptyList());
         assertThat(instance.getTraits(), is(Collections.<SCMSourceTrait>emptyList()));
         instance.setBuildOriginBranch(true);
         assertThat(instance.getTraits(), contains(instanceOf(BranchDiscoveryTrait.class)));
@@ -544,12 +544,12 @@ public class GitHubSCMSourceTraitsTest {
                 new SSHCheckoutTrait("value")));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(SSHCheckoutTrait.class),
                                 hasProperty("credentialsId", is("value"))
                         )
@@ -597,7 +597,7 @@ public class GitHubSCMSourceTraitsTest {
         ));
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is(""))
@@ -605,7 +605,7 @@ public class GitHubSCMSourceTraitsTest {
         instance.setIncludes("*");
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), not(Matchers.<SCMSourceTrait>hasItem(
+        assertThat(instance.getTraits(), not(Matchers.hasItem(
                 instanceOf(WildcardSCMHeadFilterTrait.class)
         )));
     }
@@ -619,7 +619,7 @@ public class GitHubSCMSourceTraitsTest {
         ));
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is(""))
@@ -627,7 +627,7 @@ public class GitHubSCMSourceTraitsTest {
         instance.setIncludes("bug/*");
         assertThat(instance.getIncludes(), is("bug/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("bug/*")),
                 hasProperty("excludes", is(""))
@@ -643,13 +643,13 @@ public class GitHubSCMSourceTraitsTest {
         ));
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), not(Matchers.<SCMSourceTrait>hasItem(
+        assertThat(instance.getTraits(), not(Matchers.hasItem(
                 instanceOf(WildcardSCMHeadFilterTrait.class)
         )));
         instance.setIncludes("feature/*");
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is(""))
@@ -666,7 +666,7 @@ public class GitHubSCMSourceTraitsTest {
         ));
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -674,7 +674,7 @@ public class GitHubSCMSourceTraitsTest {
         instance.setIncludes("*");
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -691,7 +691,7 @@ public class GitHubSCMSourceTraitsTest {
         ));
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -699,7 +699,7 @@ public class GitHubSCMSourceTraitsTest {
         instance.setIncludes("bug/*");
         assertThat(instance.getIncludes(), is("bug/*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("bug/*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -716,7 +716,7 @@ public class GitHubSCMSourceTraitsTest {
         ));
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -724,7 +724,7 @@ public class GitHubSCMSourceTraitsTest {
         instance.setExcludes("");
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), not(Matchers.<SCMSourceTrait>hasItem(
+        assertThat(instance.getTraits(), not(Matchers.hasItem(
                 instanceOf(WildcardSCMHeadFilterTrait.class)
         )));
     }
@@ -739,7 +739,7 @@ public class GitHubSCMSourceTraitsTest {
         ));
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -747,7 +747,7 @@ public class GitHubSCMSourceTraitsTest {
         instance.setExcludes("bug/ignore");
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is("bug/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("*")),
                 hasProperty("excludes", is("bug/ignore"))
@@ -763,13 +763,13 @@ public class GitHubSCMSourceTraitsTest {
         ));
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), not(Matchers.<SCMSourceTrait>hasItem(
+        assertThat(instance.getTraits(), not(Matchers.hasItem(
                 instanceOf(WildcardSCMHeadFilterTrait.class)
         )));
         instance.setExcludes("feature/ignore");
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -786,7 +786,7 @@ public class GitHubSCMSourceTraitsTest {
         ));
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -794,7 +794,7 @@ public class GitHubSCMSourceTraitsTest {
         instance.setExcludes("");
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is(""))
@@ -811,7 +811,7 @@ public class GitHubSCMSourceTraitsTest {
         ));
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is(""));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is(""))
@@ -819,7 +819,7 @@ public class GitHubSCMSourceTraitsTest {
         instance.setExcludes("feature/ignore");
         assertThat(instance.getIncludes(), is("feature/*"));
         assertThat(instance.getExcludes(), is("feature/ignore"));
-        assertThat(instance.getTraits(), Matchers.<SCMSourceTrait>hasItem(allOf(
+        assertThat(instance.getTraits(), Matchers.hasItem(allOf(
                 instanceOf(WildcardSCMHeadFilterTrait.class),
                 hasProperty("includes", is("feature/*")),
                 hasProperty("excludes", is("feature/ignore"))
@@ -839,7 +839,7 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -852,7 +852,7 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -865,7 +865,7 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -878,7 +878,7 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -891,11 +891,11 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -908,11 +908,11 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -925,11 +925,11 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -942,7 +942,7 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -955,11 +955,11 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -972,11 +972,11 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -989,11 +989,11 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1006,7 +1006,7 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1019,11 +1019,11 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1036,11 +1036,11 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1053,11 +1053,11 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1070,7 +1070,7 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
@@ -1084,12 +1084,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1102,12 +1102,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1120,12 +1120,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1138,12 +1138,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1156,16 +1156,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1178,16 +1178,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1200,16 +1200,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1222,12 +1222,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1240,16 +1240,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1262,16 +1262,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1284,16 +1284,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1306,12 +1306,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1324,16 +1324,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1346,16 +1346,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1368,16 +1368,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(false)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1390,7 +1390,7 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
@@ -1404,12 +1404,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1422,12 +1422,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1440,12 +1440,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1458,12 +1458,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1476,16 +1476,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1498,16 +1498,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1520,16 +1520,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1542,12 +1542,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1560,16 +1560,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1582,16 +1582,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1604,16 +1604,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1626,12 +1626,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1644,16 +1644,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1666,16 +1666,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1688,16 +1688,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(false))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1710,7 +1710,7 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 contains(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
@@ -1724,12 +1724,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1742,12 +1742,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1760,12 +1760,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1778,12 +1778,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1796,16 +1796,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1818,16 +1818,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1840,16 +1840,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1862,12 +1862,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1880,16 +1880,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1902,16 +1902,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -1924,16 +1924,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1946,12 +1946,12 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )
@@ -1964,16 +1964,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(2))
                         )
@@ -1986,16 +1986,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(1))
                         )
@@ -2008,16 +2008,16 @@ public class GitHubSCMSourceTraitsTest {
         GitHubSCMSource instance = load();
         assertThat(instance.getTraits(),
                 containsInAnyOrder(
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(BranchDiscoveryTrait.class),
                                 hasProperty("buildBranch", is(true)),
                                 hasProperty("buildBranchesWithPR", is(true))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(OriginPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         ),
-                        Matchers.<SCMSourceTrait>allOf(
+                        Matchers.allOf(
                                 instanceOf(ForkPullRequestDiscoveryTrait.class),
                                 hasProperty("strategyId", is(3))
                         )

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTraitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTraitTest.java
@@ -37,8 +37,7 @@ public class OriginPullRequestDiscoveryTraitTest {
         assertThat(ctx.wantPRs(), is(true));
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
-        assertThat(ctx.originPRStrategies(),
-                Matchers.<Set<ChangeRequestCheckoutStrategy>>is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
+        assertThat(ctx.originPRStrategies(), Matchers.is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
         assertThat(ctx.authorities(), (Matcher) hasItem(
                 instanceOf(OriginPullRequestDiscoveryTrait.OriginChangeRequestSCMHeadAuthority.class)
         ));
@@ -62,8 +61,7 @@ public class OriginPullRequestDiscoveryTraitTest {
         assertThat(ctx.wantPRs(), is(true));
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
-        assertThat(ctx.originPRStrategies(),
-                Matchers.<Set<ChangeRequestCheckoutStrategy>>is(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD)));
+        assertThat(ctx.originPRStrategies(), Matchers.is(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD)));
         assertThat(ctx.authorities(), (Matcher) hasItem(
                 instanceOf(OriginPullRequestDiscoveryTrait.OriginChangeRequestSCMHeadAuthority.class)
         ));
@@ -88,7 +86,7 @@ public class OriginPullRequestDiscoveryTraitTest {
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
         assertThat(ctx.originPRStrategies(),
-                Matchers.<Set<ChangeRequestCheckoutStrategy>>is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)));
+                Matchers.is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)));
         assertThat(ctx.authorities(), (Matcher) hasItem(
                 instanceOf(OriginPullRequestDiscoveryTrait.OriginChangeRequestSCMHeadAuthority.class)
         ));
@@ -112,7 +110,7 @@ public class OriginPullRequestDiscoveryTraitTest {
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
         assertThat(ctx.originPRStrategies(),
-                Matchers.<Set<ChangeRequestCheckoutStrategy>>is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
+                Matchers.is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
         assertThat(ctx.authorities(), (Matcher) hasItem(
                 instanceOf(OriginPullRequestDiscoveryTrait.OriginChangeRequestSCMHeadAuthority.class)
         ));

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTraitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTraitTest.java
@@ -38,7 +38,7 @@ public class OriginPullRequestDiscoveryTraitTest {
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
         assertThat(ctx.originPRStrategies(), Matchers.is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
-        assertThat(ctx.authorities(), (Matcher) hasItem(
+        assertThat(ctx.authorities(), hasItem(
                 instanceOf(OriginPullRequestDiscoveryTrait.OriginChangeRequestSCMHeadAuthority.class)
         ));
     }
@@ -62,7 +62,7 @@ public class OriginPullRequestDiscoveryTraitTest {
         assertThat(ctx.prefilters(), is(Collections.<SCMHeadPrefilter>emptyList()));
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
         assertThat(ctx.originPRStrategies(), Matchers.is(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD)));
-        assertThat(ctx.authorities(), (Matcher) hasItem(
+        assertThat(ctx.authorities(), hasItem(
                 instanceOf(OriginPullRequestDiscoveryTrait.OriginChangeRequestSCMHeadAuthority.class)
         ));
     }
@@ -87,7 +87,7 @@ public class OriginPullRequestDiscoveryTraitTest {
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
         assertThat(ctx.originPRStrategies(),
                 Matchers.is(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)));
-        assertThat(ctx.authorities(), (Matcher) hasItem(
+        assertThat(ctx.authorities(), hasItem(
                 instanceOf(OriginPullRequestDiscoveryTrait.OriginChangeRequestSCMHeadAuthority.class)
         ));
     }
@@ -111,7 +111,7 @@ public class OriginPullRequestDiscoveryTraitTest {
         assertThat(ctx.filters(), is(Collections.<SCMHeadFilter>emptyList()));
         assertThat(ctx.originPRStrategies(),
                 Matchers.is(EnumSet.allOf(ChangeRequestCheckoutStrategy.class)));
-        assertThat(ctx.authorities(), (Matcher) hasItem(
+        assertThat(ctx.authorities(), hasItem(
                 instanceOf(OriginPullRequestDiscoveryTrait.OriginChangeRequestSCMHeadAuthority.class)
         ));
     }


### PR DESCRIPTION
Removing this redundant type information cleans up code.
