### PR TITLE
[JENKINS-59485] Trust level "Contributors" is ambiguous, should be called "Collaborators" instead

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-trust.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-trust.html
@@ -17,13 +17,13 @@
             trusted file (e.g. <code>Jenkinsfile</code>) the contents of that file will be retrieved from the
             target branch on the origin repository and not from the pull request branch on the fork repository.
         </dd>
-        <dt>Contributors</dt>
+        <dt>Collaborators</dt>
         <dd>
             Pull requests from <a href="https://developer.github.com/v3/repos/collaborators/" target="_blank">collaborators</a>
             to the origin repository will be treated as trusted, all other pull requests from fork repositories
             will be treated as untrusted.
             Note that if credentials used by Jenkins for scanning the repository does not have permission to
-            query the list of contributors to the origin repository then only the origin account will be treated
+            query the list of collaborators to the origin repository then only the origin account will be treated
             as trusted - i.e. this will fall back to <code>Nobody</code>.
             <strong>NOTE:</strong> all collaborators are trusted, even if they are only members of a team with read permission.
         </dd>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -1,7 +1,7 @@
 BranchSCMHead.Pronoun=Branch
 GitHubTagSCMHead.Pronoun=Tag
 
-ForkPullRequestDiscoveryTrait.contributorsDisplayName=Contributors
+ForkPullRequestDiscoveryTrait.contributorsDisplayName=Collaborators
 ForkPullRequestDiscoveryTrait.permissionsDisplayName=From users with Admin or Write permission
 ForkPullRequestDiscoveryTrait.displayName=Discover pull requests from forks
 ForkPullRequestDiscoveryTrait.everyoneDisplayName=Everyone


### PR DESCRIPTION
* JENKINS issue(s):
    * https://issues.jenkins-ci.org/browse/JENKINS-59485
* Description:
    * Change only display name in drop down and in help text. Method/class name changes would probably require migration code, which I can provide in a second pull request if necessary.
* Documentation changes:
    * No doc change, since trust level names are not mentioned in documentation
* Users/aliases to notify:
    * I guess @bitwiseman ?
