### PR TITLE
[JENKINS-61290] hard to see why a branch was not inspected - log them

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait.java
@@ -243,12 +243,9 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
                     if (headRepo != null // head repo can be null if the PR is from a repo that has been deleted
                             && p.getBase().getRepository().getFullName().equalsIgnoreCase(headRepo.getFullName())
                             && p.getHead().getRef().equals(head.getName())) {
-                        LOGGER.log(Level.WARNING, "Ignoring branch {0} of repository {1} because "
+                        LOGGER.log(Level.WARNING, "Ignoring {} because "
                                 + "current strategy excludes branches that ARE also filed as a pull request"
-                                , new Object[]{
-                                        head.getName(),
-                                        headRepo.getFullName()
-                                });
+                                , new Object[]{head.toString()});
                         return true;
                     }
                 }
@@ -276,12 +273,9 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
                         return false;
                     }
                 }
-                LOGGER.log(Level.WARNING, "Ignoring branch {0} of repository {1} because "
+                LOGGER.log(Level.WARNING, "Ignoring {} because "
                         + "current strategy excludes branches that ARE NOT also filed as a pull request"
-                        , new Object[]{
-                                head.getName(),
-                                headRepo.getFullName()
-                        });
+                        , new Object[]{head.toString()});
                 return true;
             }
             return false;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait.java
@@ -26,6 +26,8 @@ package org.jenkinsci.plugins.github_branch_source;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.util.ListBoxModel;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadCategory;
 import jenkins.scm.api.SCMHeadOrigin;
@@ -52,6 +54,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @since 2.2.0
  */
 public class BranchDiscoveryTrait extends SCMSourceTrait {
+    private static final Logger LOGGER = Logger.getLogger(Connector.class.getName());
+
     /**
      * The strategy encoded as a bit-field.
      */
@@ -239,6 +243,12 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
                     if (headRepo != null // head repo can be null if the PR is from a repo that has been deleted
                             && p.getBase().getRepository().getFullName().equalsIgnoreCase(headRepo.getFullName())
                             && p.getHead().getRef().equals(head.getName())) {
+                        LOGGER.log(Level.WARNING, "Ignoring branch {0} of repository {1} because "
+                                + "current strategy excludes branches that ARE also filed as a pull request"
+                                , new Object[]{
+                                        head.getName(),
+                                        headRepo.getFullName()
+                                });
                         return true;
                     }
                 }
@@ -262,9 +272,16 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
                     if (headRepo != null // head repo can be null if the PR is from a repo that has been deleted
                             && p.getBase().getRepository().getFullName().equalsIgnoreCase(headRepo.getFullName())
                             && p.getHead().getRef().equals(head.getName())) {
+
                         return false;
                     }
                 }
+                LOGGER.log(Level.WARNING, "Ignoring branch {0} of repository {1} because "
+                        + "current strategy excludes branches that ARE NOT also filed as a pull request"
+                        , new Object[]{
+                                head.getName(),
+                                headRepo.getFullName()
+                        });
                 return true;
             }
             return false;


### PR DESCRIPTION
* JENKINS issue(s):
    * https://issues.jenkins-ci.org/browse/JENKINS-61290
* Description:
    * When branch is not indexed/scanned because of policy setting, it is not easy to see why it was skipped. This PR adds logging of `isExcluded()` hits into global jenkins log. Alas, I did not find a way to log it into the indexing run's log itself where it would be more appropriate.
* Documentation changes:
    * No doc change proposed at this time, as this is a small change for trace-logging and no new/changed feature.
* Users/aliases to notify:
    * markewaite
