### PR TITLE
Tune expiration - account for clock sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,33 @@
             <artifactId>github-api</artifactId>
             <version>1.106</version>
         </dependency>
+        <!-- TODO: after upgrading jenkins.version >= 2.171, migrate dependency -->
+        <dependency>
+            <groupId>io.jenkins.temp.jelly</groupId>
+            <artifactId>multiline-secrets-ui</artifactId>
+            <version>1.0</version>
+        </dependency>
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
             <version>1.29.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,23 +77,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-api</artifactId>
-            <version>${jjwt.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-impl</artifactId>
-            <version>${jjwt.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-jackson</artifactId>
-            <version>${jjwt.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
             <classifier>tests</classifier>

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/JwtHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/JwtHelper.java
@@ -42,7 +42,7 @@ class JwtHelper {
                 .setIssuer(githubAppId)
                 .signWith(signingKey, signatureAlgorithm);
 
-        int oneMinuteInMillis = 60 * 1000;
+        long oneMinuteInMillis = 60L * 1000L;
         long expMillis = nowMillis + (oneMinuteInMillis * 8);
         Date exp = new Date(expMillis);
         builder.setExpiration(exp);

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/JwtHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/JwtHelper.java
@@ -42,7 +42,8 @@ class JwtHelper {
                 .setIssuer(githubAppId)
                 .signWith(signingKey, signatureAlgorithm);
 
-        long expMillis = nowMillis + (60 * 1000 * 10);
+        int oneMinuteInMillis = 60 * 1000;
+        long expMillis = nowMillis + (oneMinuteInMillis * 8);
         Date exp = new Date(expMillis);
         builder.setExpiration(exp);
 


### PR DESCRIPTION
# Description

We've seen a few instances of the following log:

```
Caused: org.kohsuke.github.HttpException: Server returned HTTP response code: 401, message: 'Unauthorized' for URL: https://api.github.com/app/installations/111111/access_tokens
	at org.kohsuke.github.Requester._fetchOrRetry(Requester.java:537)
	at org.kohsuke.github.Requester._fetch(Requester.java:504)
Caused: org.kohsuke.github.HttpException: {"message":"'Expiration time' claim ('exp') is too far in the future","documentation_url":"https://developer.github.com/v3"}
	at org.kohsuke.github.Requester.handleApiError(Requester.java:1049)
	at org.kohsuke.github.Requester._fetch(Requester.java:506)
	at org.kohsuke.github.Requester._fetch(Requester.java:496)
	at org.kohsuke.github.Requester.fetch(Requester.java:412)
	at org.kohsuke.github.GHAppCreateTokenBuilder.create(GHAppCreateTokenBuilder.java:87)
	at org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.generateAppInstallationToken(GitHubAppCredentials.java:88)
Caused: java.lang.IllegalArgumentException: Couldn't authenticate with GitHub app ID 11111
```

This looks like clock sync issues on either our side or GitHub, it doesn't happen very often but this change should fix the issue

To test this just follow the regular testing instructions for a github app:
https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [-] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [-] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

@bitwiseman @dwnusbaum @ojacques 
