### PR TITLE
Allow GitHub app to be installed in multiple orgs

### DIFF
--- a/docs/github-app.adoc
+++ b/docs/github-app.adoc
@@ -87,7 +87,8 @@ Fill out the form:
 - App ID: the github app ID, it can be found in the 'About' section of your GitHub app in the general tab.
 - API endpoint (optional, only required for GitHub enterprise this will only show up if a GitHub enterprise server is configured).
 - Key: click add, paste the contents of the converted private key
-- Passphrase: do not fill this field, it will be ignored
+- Advanced: (optional) If you've installed your same GitHub app on multiple organisations you need the next step
+  * Owner: the name of the organisation or user, i.e. jenkinsci for https://github.com/jenkinsci
 - Click OK
 
 === link:https://github.com/jenkinsci/configuration-as-code-plugin[Configuration as Code Plugin]

--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,33 @@
             <artifactId>github-api</artifactId>
             <version>1.106</version>
         </dependency>
+        <!-- TODO: after upgrading jenkins.version >= 2.171, migrate dependency -->
+        <dependency>
+            <groupId>io.jenkins.temp.jelly</groupId>
+            <artifactId>multiline-secrets-ui</artifactId>
+            <version>1.0</version>
+        </dependency>
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
             <version>1.29.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,23 +77,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-api</artifactId>
-            <version>${jjwt.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-impl</artifactId>
-            <version>${jjwt.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-jackson</artifactId>
-            <version>${jjwt.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
             <classifier>tests</classifier>

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -30,6 +30,9 @@ import static org.jenkinsci.plugins.github_branch_source.JwtHelper.createJWT;
 public class GitHubAppCredentials extends BaseStandardCredentials implements StandardUsernamePasswordCredentials {
 
     private static final String ERROR_AUTHENTICATING_GITHUB_APP = "Couldn't authenticate with GitHub app ID %s";
+    private static final String NOT_INSTALLED = ", has it been installed to your GitHub organisation / user?";
+
+    private static final String ERROR_NOT_INSTALLED = ERROR_AUTHENTICATING_GITHUB_APP + NOT_INSTALLED;
 
     @NonNull
     private final String appID;
@@ -38,6 +41,8 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
     private final Secret privateKey;
 
     private String apiUri;
+
+    private String owner;
 
     @DataBoundConstructor
     @SuppressWarnings("unused") // by stapler
@@ -72,8 +77,26 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
         return privateKey;
     }
 
+    /**
+     * Owner of this installation, i.e. a user or organisation,
+     * used to differeniate app installations when the app is installed to multiple organisations / users.
+     *
+     * If this is null then call listInstallations and if there's only one in the list then use that installation.
+     *
+     * @return the owner of the organisation or null.
+     */
+    @CheckForNull
+    public String getOwner() {
+        return owner;
+    }
+
+    @DataBoundSetter
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
     @SuppressWarnings("deprecation") // preview features are required for GitHub app integration, GitHub api adds deprecated to all preview methods
-    static String generateAppInstallationToken(String appId, String appPrivateKey, String apiUrl) {
+    static String generateAppInstallationToken(String appId, String appPrivateKey, String apiUrl, String owner) {
         try {
             String jwtToken = createJWT(appId, appPrivateKey);
             GitHub gitHubApp = new GitHubBuilder().withEndpoint(apiUrl).withJwtToken(jwtToken).build();
@@ -81,18 +104,28 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
             GHApp app = gitHubApp.getApp();
 
             List<GHAppInstallation> appInstallations = app.listInstallations().asList();
-            if (!appInstallations.isEmpty()) {
-                GHAppInstallation appInstallation = appInstallations.get(0);
-                GHAppInstallationToken appInstallationToken = appInstallation
-                        .createToken(appInstallation.getPermissions())
-                        .create();
-
-                return appInstallationToken.getToken();
+            if (appInstallations.isEmpty()) {
+                throw new IllegalArgumentException(String.format(ERROR_NOT_INSTALLED, appId));
             }
+            GHAppInstallation appInstallation;
+            if (appInstallations.size() == 1) {
+                appInstallation = appInstallations.get(0);
+            } else {
+                appInstallation = appInstallations.stream()
+                        .filter(installation -> installation.getAccount().getLogin().equals(owner))
+                        .findAny()
+                        .orElseThrow(() -> new IllegalArgumentException(String.format(ERROR_NOT_INSTALLED, appId)));
+            }
+
+            GHAppInstallationToken appInstallationToken = appInstallation
+                    .createToken(appInstallation.getPermissions())
+                    .create();
+
+            return appInstallationToken.getToken();
         } catch (IOException e) {
             throw new IllegalArgumentException(String.format(ERROR_AUTHENTICATING_GITHUB_APP, appId), e);
         }
-        throw new IllegalArgumentException(String.format(ERROR_AUTHENTICATING_GITHUB_APP, appId));
+
     }
 
     /**
@@ -105,7 +138,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
             apiUri = "https://api.github.com";
         }
 
-        String appInstallationToken = generateAppInstallationToken(appID, privateKey.getPlainText(), apiUri);
+        String appInstallationToken = generateAppInstallationToken(appID, privateKey.getPlainText(), apiUri, owner);
 
         return Secret.fromString(appInstallationToken);
     }
@@ -163,7 +196,8 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
         public FormValidation doTestConnection(
                 @QueryParameter("appID") final String appID,
                 @QueryParameter("privateKey") final String privateKey,
-                @QueryParameter("apiUri") final String apiUri
+                @QueryParameter("apiUri") final String apiUri,
+                @QueryParameter("owner") final String owner
 
         ) {
             GitHubAppCredentials gitHubAppCredential = new GitHubAppCredentials(
@@ -171,10 +205,10 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
                     appID, Secret.fromString(privateKey)
             );
             gitHubAppCredential.setApiUri(apiUri);
+            gitHubAppCredential.setOwner(owner);
 
             try {
                 GitHub connect = Connector.connect(apiUri, gitHubAppCredential);
-
                 return FormValidation.ok("Success, Remaining rate limit: " + connect.getRateLimit().getRemaining());
             } catch (Exception e) {
                 return FormValidation.error(e, String.format(ERROR_AUTHENTICATING_GITHUB_APP, appID));

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials/config.jelly
@@ -24,7 +24,13 @@
     <secretTextarea xmlns="/io/jenkins/temp/jelly"/>
   </f:entry>
 
+  <f:advanced>
+    <f:entry title="${%Owner}" field="owner">
+      <f:textbox/>
+    </f:entry>
+  </f:advanced>
+
   <f:validateButton
       title="${%Test Connection}" progress="${%Testing...}"
-      method="testConnection" with="appID,apiUri,privateKey" />
+      method="testConnection" with="appID,apiUri,privateKey,owner" />
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials/help-owner.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials/help-owner.html
@@ -1,0 +1,3 @@
+<p>
+    The organisation or user that this app is to be used for, only required if this app is installed to multiple organisations.
+</p>


### PR DESCRIPTION
# Description

See https://github.com/jenkinsci/github-branch-source-plugin/pull/269#discussion_r395887018

To test it you need multiple organisation, ideally with private repos on both as public repos can be read even if haven't granted access, install the app to both organisations and follow the steps in the documentation

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [-] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [-] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [x] Link to jenkins.io PR, or an explanation for why no doc changes are needed
doc is in the repo

# Users/aliases to notify
@jglick @bitwiseman @dwnusbaum 

