### PR TITLE
Cache app installation token

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -111,7 +111,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
 
         long now = System.currentTimeMillis();
         String appInstallationToken;
-        if (cachedToken != null && now - tokenCacheTime < JwtHelper.VALIDITY_MS - /* takes some time to send requests */ TimeUnit.SECONDS.toMillis(10)) {
+        if (cachedToken != null && now - tokenCacheTime < JwtHelper.VALIDITY_MS /* extra buffer */ / 2) {
             appInstallationToken = cachedToken;
         } else {
             appInstallationToken = generateAppInstallationToken(appID, privateKey.getPlainText(), apiUri);

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -5,6 +5,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
 import hudson.util.FormValidation;
@@ -28,6 +29,7 @@ import org.kohsuke.stapler.verb.POST;
 import static org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator.DescriptorImpl.getPossibleApiUriItems;
 import static org.jenkinsci.plugins.github_branch_source.JwtHelper.createJWT;
 
+@SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "XStream")
 public class GitHubAppCredentials extends BaseStandardCredentials implements StandardUsernamePasswordCredentials {
 
     private static final String ERROR_AUTHENTICATING_GITHUB_APP = "Couldn't authenticate with GitHub app ID %s";

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/JwtHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/JwtHelper.java
@@ -17,9 +17,9 @@ import java.util.concurrent.TimeUnit;
 class JwtHelper {
 
     /**
-     * @see <a href="https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">maximum JWT validity</a>
+     * Somewhat less than the <a href="https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">maximum JWT validity</a>.
      */
-    static final long VALIDITY_MS = TimeUnit.MINUTES.toMillis(10);
+    static final long VALIDITY_MS = TimeUnit.MINUTES.toMillis(8);
 
     /**
      * Create a JWT for authenticating to GitHub as an app installation

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/JwtHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/JwtHelper.java
@@ -10,11 +10,16 @@ import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 import java.util.Date;
-import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
+import java.util.concurrent.TimeUnit;
 
 class JwtHelper {
+
+    /**
+     * @see <a href="https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app">maximum JWT validity</a>
+     */
+    static final long VALIDITY_MS = TimeUnit.MINUTES.toMillis(10);
 
     /**
      * Create a JWT for authenticating to GitHub as an app installation
@@ -42,9 +47,7 @@ class JwtHelper {
                 .setIssuer(githubAppId)
                 .signWith(signingKey, signatureAlgorithm);
 
-        long oneMinuteInMillis = 60L * 1000L;
-        long expMillis = nowMillis + (oneMinuteInMillis * 8);
-        Date exp = new Date(expMillis);
+        Date exp = new Date(nowMillis + VALIDITY_MS);
         builder.setExpiration(exp);
 
         return builder.compact();


### PR DESCRIPTION
# Description

Amends #269 by caching the app installation token for almost the duration of its validity. Otherwise every time the token is requested, which would be for every API call to GitHub, Jenkins would by my count be making three additional HTTP requests: `/app`, `/app/installations`, and `/app/installations/:id/access_tokens`.

Tested directly via `jshell` (note that this requires https://github.com/jenkinsci/jenkins/pull/4603):

```java
var c = new org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials(com.cloudbees.plugins.credentials.CredentialsScope.GLOBAL, "test", null, "…",
    hudson.util.Secret.fromString(org.apache.commons.io.FileUtils.readFileToString(new java.io.File("/…-converted.pem"))))
var tok = c.getPassword().getPlainText()
new org.kohsuke.github.GitHubBuilder().withPassword(c.getUsername(), tok).build().getRateLimit().getRemaining()
```

I am not sure if there is a simple way to create a logger which records every GH API access.

Have been running some simple multibranch projects with this test and have not noticed any issues.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

