### PR TITLE
AbstractGitHubNotificationStrategy is not an ExtensionPoint

### DIFF
--- a/docs/implementation.adoc
+++ b/docs/implementation.adoc
@@ -3,7 +3,7 @@
 == Extension Points
 
 === AbstractGitHubNotificationStrategy
-This extension points allows traits to modify the contents of a Github status notification for a build.
+This API allows traits to modify the contents of a GitHub status notification for a build.
 There are currently 3 points in a build lifecycle where notifications are sent:
 
 * On entering the queue

--- a/docs/implementation.adoc
+++ b/docs/implementation.adoc
@@ -1,8 +1,6 @@
 = Implementation Guide
 
-== Extension Points
-
-=== AbstractGitHubNotificationStrategy
+== AbstractGitHubNotificationStrategy
 This API allows traits to modify the contents of a GitHub status notification for a build.
 There are currently 3 points in a build lifecycle where notifications are sent:
 
@@ -44,7 +42,6 @@ explicitly apply a `DefaultGitHubNotificationStrategy` to the source context in 
 
 Duplicate (by equality) strategies are ignored when applied to the source context.
 
-==== Implementations:
+=== Implementations:
+
 https://github.com/jenkinsci/github-scm-trait-notification-context-plugin[github-scm-trait-notification-context]
-
-

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/AbstractGitHubNotificationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/AbstractGitHubNotificationStrategy.java
@@ -24,7 +24,6 @@
 
 package org.jenkinsci.plugins.github_branch_source;
 
-import hudson.ExtensionPoint;
 import hudson.model.TaskListener;
 
 import java.util.List;
@@ -33,7 +32,7 @@ import java.util.List;
  * Represents a strategy for constructing GitHub status notifications
  * @since 2.3.2
  */
-public abstract class AbstractGitHubNotificationStrategy implements ExtensionPoint {
+public abstract class AbstractGitHubNotificationStrategy {
 
     /**
      * Creates the list of {@link GitHubNotificationRequest} for the given context.


### PR DESCRIPTION
Amends #162. An `ExtensionPoint` is an interface you could implement as a singleton and apply an `@Extension` to. (Traditionally it is also used on `Describable`s, though technically the actual extension point is the corresponding `Descriptor`.) https://github.com/jenkinsci/github-scm-trait-notification-context-plugin/blob/f5cb5c1a32fc6da2775d6791285d5a5901dbee8a/src/main/java/org/jenkinsci/plugins/githubScmTraitNotificationContext/NotificationContextTrait.java#L51-L76 confirms that the actual extension point here remains the `SCMSourceTrait[Descriptor]`.