### PR TITLE
Skip self user scan when using Github Apps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1132,9 +1132,6 @@ public class GitHubSCMNavigator extends SCMNavigator {
                         )));
                         return;
                     }
-                } else {
-                    listener.getLogger().format("Connecting to %s with no credentials, anonymous access%n",
-                            apiUri == null ? GitHubSCMSource.GITHUB_URL : apiUri);
                 }
 
                 GHOrganization org = getGhOrganization(github);

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1098,7 +1098,10 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 WitnessImpl witness = new WitnessImpl(listener);
 
                 boolean githubAppAuthentication = credentials instanceof GitHubAppCredentials;
-                if (!github.isAnonymous() && !githubAppAuthentication) {
+                if (github.isAnonymous()) {
+                    listener.getLogger().format("Connecting to %s with no credentials, anonymous access%n",
+                            apiUri == null ? GitHubSCMSource.GITHUB_URL : apiUri);                
+                } else if (!githubAppAuthentication) {
                     listener.getLogger()
                             .format("Connecting to %s using %s%n", apiUri == null ? GitHubSCMSource.GITHUB_URL : apiUri,
                                     CredentialsNameProvider.name(credentials));

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1097,7 +1097,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 SourceFactory sourceFactory = new SourceFactory(request);
                 WitnessImpl witness = new WitnessImpl(listener);
 
-                if (!github.isAnonymous()) {
+                boolean githubAppAuthentication = credentials instanceof GitHubAppCredentials;
+                if (!github.isAnonymous() && !githubAppAuthentication) {
                     listener.getLogger()
                             .format("Connecting to %s using %s%n", apiUri == null ? GitHubSCMSource.GITHUB_URL : apiUri,
                                     CredentialsNameProvider.name(credentials));

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -933,7 +933,10 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 WitnessImpl witness = new WitnessImpl(listener);
 
                 boolean githubAppAuthentication = credentials instanceof GitHubAppCredentials;
-                if (!github.isAnonymous() && !githubAppAuthentication) {
+                if (github.isAnonymous()) {
+                    listener.getLogger().format("Connecting to %s with no credentials, anonymous access%n",
+                            apiUri == null ? GitHubSCMSource.GITHUB_URL : apiUri);                
+                } else if (!githubAppAuthentication) {
                     GHMyself myself;
                     try {
                         // Requires an authenticated access


### PR DESCRIPTION
# Description

Repository discovery based on events is broken when using Github Apps.

```
Connecting to https://api.github.com using 61934/******
ERROR: https://api.github.com/user {"message":"Resource not accessible by integration","documentation_url":"https://developer.github.com/v3/users/#get-the-authenticated-user"}
java.io.FileNotFoundException: https://api.github.com/user
	at com.squareup.okhttp.internal.huc.HttpURLConnectionImpl.getInputStream(HttpURLConnectionImpl.java:243)
	at com.squareup.okhttp.internal.huc.DelegatingHttpsURLConnection.getInputStream(DelegatingHttpsURLConnection.java:210)
	at com.squareup.okhttp.internal.huc.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:25)
	at org.kohsuke.github.GitHubHttpUrlConnectionClient$HttpURLConnectionResponseInfo.bodyStream(GitHubHttpUrlConnectionClient.java:197)
	at org.kohsuke.github.GitHubResponse$ResponseInfo.getBodyAsString(GitHubResponse.java:313)
	at org.kohsuke.github.GitHubResponse.parseBody(GitHubResponse.java:80)
	at org.kohsuke.github.Requester.lambda$fetch$1(Requester.java:71)
	at org.kohsuke.github.GitHubClient.createResponse(GitHubClient.java:406)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:360)
Caused: org.kohsuke.github.GHFileNotFoundException: https://api.github.com/user {"message":"Resource not accessible by integration","documentation_url":"https://developer.github.com/v3/users/#get-the-authenticated-user"}
	at org.kohsuke.github.GitHubClient.interpretApiError(GitHubClient.java:437)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:368)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:312)
	at org.kohsuke.github.Requester.fetch(Requester.java:71)
	at org.kohsuke.github.GitHub.getMyself(GitHub.java:421)
	at org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator.visitSource(GitHubSCMNavigator.java:1107)
	at org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator.visitSources(GitHubSCMNavigator.java:902)
	at jenkins.scm.api.SCMNavigator.visitSources(SCMNavigator.java:221)
	at jenkins.branch.OrganizationFolder$SCMEventListenerImpl.onSCMHeadEvent(OrganizationFolder.java:1103)
	at jenkins.scm.api.SCMHeadEvent$DispatcherImpl.fire(SCMHeadEvent.java:246)
	at jenkins.scm.api.SCMHeadEvent$DispatcherImpl.fire(SCMHeadEvent.java:229)
	at jenkins.scm.api.SCMEvent$Dispatcher.run(SCMEvent.java:505)
	at jenkins.security.ImpersonatingScheduledExecutorService$1.run(ImpersonatingScheduledExecutorService.java:58)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

github.getMyself returns a 404 when using Github Apps.

This PR fixes the issue by skipping the self scan whenever getMyself returns a 404.

