### PR TITLE
Fix build errors by updating minimum core version and parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.57</version>
+        <version>4.2</version>
         <relativePath />
     </parent>
     <artifactId>github-branch-source</artifactId>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.25.1</version>
+            <version>2.26.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Should fix enforcer errors seen in the CI builds when testing against 2.222.x.

2.176.x is the fourth-oldest LTS line at this point, so it seems like a conservative enough upgrade. The core BOM used by version 4.x of the parent POM also supports 2.164.3 if we want to be even more conservative.

