### PR TITLE
GitHubAppCredentials.writeReplace to avoid recalculating tokens

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -3,11 +3,13 @@ package org.jenkinsci.plugins.github_branch_source;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
+import hudson.remoting.Channel;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
@@ -164,6 +166,13 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
     public String getUsername() {
         return appID;
     }
+
+     private Object writeReplace() {
+        if (/* XStream */Channel.current() == null) {
+            return this;
+        }
+        return new UsernamePasswordCredentialsImpl(getScope(), getId(), getDescription(), getUsername(), getPassword().getPlainText());
+     }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Despite #291, using app authentication made checkouts on agents really slow. On a server I tested with using the `kubernetes` plugin, this reduces the time taken by `checkout scm` on a tiny github.com repo from 46s to 26s. Otherwise agent stack traces during checkout show lots of delays like

```
"pool-1-thread-11 for …
	at java.lang.Object.wait(Native Method)
	-  waiting on hudson.remoting.RemoteInvocationHandler$RPCRequest@7745dfbe
	at hudson.remoting.Request.call(Request.java:177)
	at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:288)
	at com.sun.proxy.$Proxy5.fetch3(Unknown Source)
	at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:211)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	-  locked hudson.remoting.RemoteClassLoader@26c7de78
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	at io.jsonwebtoken.lang.Classes.<clinit>(Classes.java:32)
	at io.jsonwebtoken.Jwts.builder(Jwts.java:115)
	at org.jenkinsci.plugins.github_branch_source.JwtHelper.createJWT(JwtHelper.java:45)
	at org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.generateAppInstallationToken(GitHubAppCredentials.java:106)
	at org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.getPassword(GitHubAppCredentials.java:151)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.createPasswordFile(CliGitAPIImpl.java:2122)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:1943)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.access$500(CliGitAPIImpl.java:80)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$1.execute(CliGitAPIImpl.java:563)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$2.execute(CliGitAPIImpl.java:787)
	at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$GitCommandMasterToSlaveCallable.call(RemoteGitImpl.java:161)
	at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$GitCommandMasterToSlaveCallable.call(RemoteGitImpl.java:154)
	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
	at …
"pool-1-thread-11 for …
	at java.lang.Object.wait(Native Method)
	-  waiting on hudson.remoting.RemoteInvocationHandler$RPCRequest@284ec61d
	at hudson.remoting.Request.call(Request.java:177)
	at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:288)
	at com.sun.proxy.$Proxy5.fetch3(Unknown Source)
	at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:211)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	-  locked hudson.remoting.RemoteClassLoader@6a818a9e
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	at com.fasterxml.jackson.databind.ser.BasicSerializerFactory.<clinit>(BasicSerializerFactory.java:80)
	at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:641)
	at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:540)
	at io.jsonwebtoken.io.JacksonSerializer.<clinit>(JacksonSerializer.java:12)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at io.jsonwebtoken.lang.Classes.newInstance(Classes.java:156)
	at io.jsonwebtoken.lang.Classes.newInstance(Classes.java:136)
	at io.jsonwebtoken.impl.io.RuntimeClasspathSerializerLocator.locate(RuntimeClasspathSerializerLocator.java:34)
	at io.jsonwebtoken.impl.io.RuntimeClasspathSerializerLocator.getInstance(RuntimeClasspathSerializerLocator.java:21)
	at io.jsonwebtoken.impl.io.RuntimeClasspathSerializerLocator.getInstance(RuntimeClasspathSerializerLocator.java:12)
	at io.jsonwebtoken.impl.DefaultJwtBuilder.compact(DefaultJwtBuilder.java:301)
	at org.jenkinsci.plugins.github_branch_source.JwtHelper.createJWT(JwtHelper.java:53)
	at org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.generateAppInstallationToken(GitHubAppCredentials.java:106)
	at org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.getPassword(GitHubAppCredentials.java:151)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.createPasswordFile(CliGitAPIImpl.java:2122)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:1943)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.access$500(CliGitAPIImpl.java:80)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$1.execute(CliGitAPIImpl.java:563)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$2.execute(CliGitAPIImpl.java:787)
	at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$GitCommandMasterToSlaveCallable.call(RemoteGitImpl.java:161)
	at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$GitCommandMasterToSlaveCallable.call(RemoteGitImpl.java:154)
	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
	at …
"pool-1-thread-11 for …
	at java.lang.Object.wait(Native Method)
	-  waiting on hudson.remoting.RemoteInvocationHandler$RPCRequest@169fca66
	at hudson.remoting.Request.call(Request.java:177)
	at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:288)
	at com.sun.proxy.$Proxy5.fetch3(Unknown Source)
	at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:211)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	-  locked hudson.remoting.RemoteClassLoader@6da2dee4
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	at org.bouncycastle.jcajce.provider.symmetric.util.ClassUtil.loadClass(Unknown Source)
	at org.bouncycastle.jce.provider.BouncyCastleProvider.loadAlgorithms(Unknown Source)
	at org.bouncycastle.jce.provider.BouncyCastleProvider.setup(Unknown Source)
	at org.bouncycastle.jce.provider.BouncyCastleProvider.access$000(Unknown Source)
	at org.bouncycastle.jce.provider.BouncyCastleProvider$1.run(Unknown Source)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.bouncycastle.jce.provider.BouncyCastleProvider.<init>(Unknown Source)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at io.jsonwebtoken.lang.Classes.newInstance(Classes.java:156)
	at io.jsonwebtoken.lang.RuntimeEnvironment.enableBouncyCastleIfPossible(RuntimeEnvironment.java:53)
	at io.jsonwebtoken.lang.RuntimeEnvironment.<clinit>(RuntimeEnvironment.java:62)
	at io.jsonwebtoken.impl.crypto.RsaProvider.<clinit>(RsaProvider.java:59)
	at io.jsonwebtoken.impl.crypto.DefaultSignerFactory.createSigner(DefaultSignerFactory.java:43)
	at io.jsonwebtoken.impl.crypto.DefaultJwtSigner.<init>(DefaultJwtSigner.java:51)
	at io.jsonwebtoken.impl.crypto.DefaultJwtSigner.<init>(DefaultJwtSigner.java:39)
	at io.jsonwebtoken.impl.DefaultJwtBuilder.createSigner(DefaultJwtBuilder.java:370)
	at io.jsonwebtoken.impl.DefaultJwtBuilder.compact(DefaultJwtBuilder.java:352)
	at org.jenkinsci.plugins.github_branch_source.JwtHelper.createJWT(JwtHelper.java:53)
	at org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.generateAppInstallationToken(GitHubAppCredentials.java:106)
	at org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.getPassword(GitHubAppCredentials.java:151)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.createPasswordFile(CliGitAPIImpl.java:2122)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:1943)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.access$500(CliGitAPIImpl.java:80)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$1.execute(CliGitAPIImpl.java:563)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$2.execute(CliGitAPIImpl.java:787)
	at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$GitCommandMasterToSlaveCallable.call(RemoteGitImpl.java:161)
	at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$GitCommandMasterToSlaveCallable.call(RemoteGitImpl.java:154)
	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
	at …
"pool-1-thread-11 for …
	at java.lang.Object.wait(Native Method)
	-  waiting on hudson.remoting.RemoteInvocationHandler$RPCRequest@4ae587eb
	at hudson.remoting.Request.call(Request.java:177)
	at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:288)
	at com.sun.proxy.$Proxy5.fetch3(Unknown Source)
	at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:211)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	-  locked hudson.remoting.RemoteClassLoader@45d5a06d
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	at java.lang.Class.getDeclaredMethods0(Native Method)
	at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
	at java.lang.Class.getDeclaredMethods(Class.java:1975)
	at com.fasterxml.jackson.databind.util.ClassUtil.getDeclaredMethods(ClassUtil.java:1120)
	at com.fasterxml.jackson.databind.util.ClassUtil.getClassMethods(ClassUtil.java:1143)
	at com.fasterxml.jackson.databind.introspect.AnnotatedMethodCollector._addMemberMethods(AnnotatedMethodCollector.java:110)
	at com.fasterxml.jackson.databind.introspect.AnnotatedMethodCollector.collect(AnnotatedMethodCollector.java:42)
	at com.fasterxml.jackson.databind.introspect.AnnotatedMethodCollector.collectMethods(AnnotatedMethodCollector.java:33)
	at com.fasterxml.jackson.databind.introspect.AnnotatedClass._methods(AnnotatedClass.java:365)
	at com.fasterxml.jackson.databind.introspect.AnnotatedClass.memberMethods(AnnotatedClass.java:305)
	at com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector._addMethods(POJOPropertiesCollector.java:525)
	at com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector.collectAll(POJOPropertiesCollector.java:309)
	at com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector.getPropertyMap(POJOPropertiesCollector.java:287)
	at com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector.getProperties(POJOPropertiesCollector.java:170)
	at com.fasterxml.jackson.databind.introspect.BasicBeanDescription._properties(BasicBeanDescription.java:164)
	at com.fasterxml.jackson.databind.introspect.BasicBeanDescription.findProperties(BasicBeanDescription.java:239)
	at com.fasterxml.jackson.databind.deser.BasicDeserializerFactory._findCreatorsFromProperties(BasicDeserializerFactory.java:292)
	at com.fasterxml.jackson.databind.deser.BasicDeserializerFactory._constructDefaultValueInstantiator(BasicDeserializerFactory.java:276)
	at com.fasterxml.jackson.databind.deser.BasicDeserializerFactory.findValueInstantiator(BasicDeserializerFactory.java:224)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.buildBeanDeserializer(BeanDeserializerFactory.java:220)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.createBeanDeserializer(BeanDeserializerFactory.java:143)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer2(DeserializerCache.java:414)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer(DeserializerCache.java:349)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCache2(DeserializerCache.java:264)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCacheValueDeserializer(DeserializerCache.java:244)
	-  locked java.util.HashMap@c84e754
	at com.fasterxml.jackson.databind.deser.DeserializerCache.findValueDeserializer(DeserializerCache.java:142)
	at com.fasterxml.jackson.databind.DeserializationContext.findContextualValueDeserializer(DeserializationContext.java:446)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.createContextual(CollectionDeserializer.java:183)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.createContextual(CollectionDeserializer.java:27)
	at com.fasterxml.jackson.databind.DeserializationContext.handlePrimaryContextualization(DeserializationContext.java:653)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.resolve(BeanDeserializerBase.java:484)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCache2(DeserializerCache.java:293)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCacheValueDeserializer(DeserializerCache.java:244)
	-  locked java.util.HashMap@c84e754
	at com.fasterxml.jackson.databind.deser.DeserializerCache.findValueDeserializer(DeserializerCache.java:142)
	at com.fasterxml.jackson.databind.DeserializationContext.findRootValueDeserializer(DeserializationContext.java:479)
	at com.fasterxml.jackson.databind.ObjectReader._prefetchRootDeserializer(ObjectReader.java:2094)
	at com.fasterxml.jackson.databind.ObjectReader.forType(ObjectReader.java:681)
	at com.fasterxml.jackson.databind.ObjectReader.forType(ObjectReader.java:701)
	at org.kohsuke.github.GitHubResponse.parseBody(GitHubResponse.java:85)
	at org.kohsuke.github.Requester.lambda$fetch$1(Requester.java:71)
	at org.kohsuke.github.Requester$$Lambda$33/440271353.apply(Unknown Source)
	at org.kohsuke.github.GitHubClient.createResponse(GitHubClient.java:406)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:360)
	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:312)
	at org.kohsuke.github.Requester.fetch(Requester.java:71)
	at org.kohsuke.github.GHAppCreateTokenBuilder.create(GHAppCreateTokenBuilder.java:87)
	at org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.generateAppInstallationToken(GitHubAppCredentials.java:127)
	at org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.getPassword(GitHubAppCredentials.java:151)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.createPasswordFile(CliGitAPIImpl.java:2122)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:1943)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.access$500(CliGitAPIImpl.java:80)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$1.execute(CliGitAPIImpl.java:563)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$2.execute(CliGitAPIImpl.java:787)
	at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$GitCommandMasterToSlaveCallable.call(RemoteGitImpl.java:161)
	at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$GitCommandMasterToSlaveCallable.call(RemoteGitImpl.java:154)
	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
	at …
```

because not only is the token generated on the master not being reused, the agent is loading a ton of additional classes.

Note that the poor design of `git-client-api` still results in plenty of overhead; you would expect the master to just issue some `/usr/bin/git` commands to the agent, but instead a lot of classes are transferred to the agent and computation done there. See JENKINS-30600.

Note that https://github.com/jenkinsci/credentials-plugin/blob/6f710a7e30156e94aff8a3c6c6799cef04ad35df/docs/implementation.adoc#additional-concerns suggests using `CredentialsSnapshotTaker`. After https://github.com/jenkinsci/ssh-credentials-plugin/commit/18b3121fa94a174064447d637dc11539e33b3a76 there seems to be no implementation in a widely used credentials type. I did not see any particular benefit to using this extension point since you need to implement your own `writeReplace` anyway—may as well inline the snapshotting (no reason for it to be extensible).