### PR TITLE
[JENKINS-61924] Upgrade to github-api-plugin v1.112

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.111.4</version>
+            <version>1.112.0</version>
         </dependency>
         <!-- TODO: after upgrading jenkins.version >= 2.171, migrate dependency -->
         <dependency>

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -400,7 +400,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
             .willSetStateTo(Scenario.STARTED));
 
         githubApi.stubFor(
-            get(urlMatching("(/api/v3)?/repos/cloudbeers/yolo/git/refs/heads/master"))
+            get(urlMatching("(/api/v3)?/repos/cloudbeers/yolo/git/ref/heads/master"))
             .inScenario("PR 2 Master 404")
             .whenScenarioStateIs(Scenario.STARTED)
             .willReturn(
@@ -411,7 +411,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase{
             .willSetStateTo("Master 200"));
 
         githubApi.stubFor(
-            get(urlMatching("(/api/v3)?/repos/cloudbeers/yolo/git/refs/heads/master"))
+            get(urlMatching("(/api/v3)?/repos/cloudbeers/yolo/git/ref/heads/master"))
             .inScenario("PR 2 Master 404")
             .whenScenarioStateIs("Master 200")
             .willReturn(

--- a/src/test/resources/api/mappings/mapping-heads-master-raw.json
+++ b/src/test/resources/api/mappings/mapping-heads-master-raw.json
@@ -1,6 +1,6 @@
 {
   "request": {
-    "url": "/api/v3/repos/cloudbeers/yolo/git/refs/heads/master",
+    "url": "/api/v3/repos/cloudbeers/yolo/git/ref/heads/master",
     "method": "GET"
   },
   "response": {

--- a/src/test/resources/api/mappings/mapping-heads-master.json
+++ b/src/test/resources/api/mappings/mapping-heads-master.json
@@ -1,6 +1,6 @@
 {
   "request": {
-    "url": "/repos/cloudbeers/yolo/git/refs/heads/master",
+    "url": "/repos/cloudbeers/yolo/git/ref/heads/master",
     "method": "GET"
   },
   "response": {

--- a/src/test/resources/api/mappings/mapping-yolo-tags-existent-tag.json
+++ b/src/test/resources/api/mappings/mapping-yolo-tags-existent-tag.json
@@ -1,6 +1,6 @@
 {
   "request": {
-    "url": "/repos/cloudbeers/yolo/git/refs/tags/existent-tag",
+    "url": "/repos/cloudbeers/yolo/git/ref/tags/existent-tag",
     "method": "GET"
   },
   "response": {

--- a/src/test/resources/api/mappings/mapping-yolo-tags-non-existent-tag.json
+++ b/src/test/resources/api/mappings/mapping-yolo-tags-non-existent-tag.json
@@ -1,6 +1,6 @@
 {
   "request": {
-    "url": "/repos/cloudbeers/yolo/git/refs/tags/non-existent-tag",
+    "url": "/repos/cloudbeers/yolo/git/ref/tags/non-existent-tag",
     "method": "GET"
   },
   "response": {


### PR DESCRIPTION
# Description
v 1.112 of github-api fixes JENKINS-61924.

Product change: 
Look for shallower JsonMappingException in file metadata

Test change: 
Use `git/ref` endpoint where appropriate instead of `git/refs`

See 
[JENKINS-61924](https://issues.jenkins-ci.org/browse/JENKINS-61924) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

