### PR TITLE
Handle change exeception tree for GHContent

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFile.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFile.java
@@ -111,7 +111,7 @@ class GitHubSCMFile extends SCMFile {
                             // Upcoming version of github-api hoists JsonMappingException up one level
                             // Support both the old and the new structure
                             if (e.getCause() instanceof JsonMappingException
-                                || e.getCause().getCause() instanceof JsonMappingException ) {
+                                || e.getCause() != null && e.getCause().getCause() instanceof JsonMappingException ) {
                                 metadata = repo.getDirectoryContent(getPath(),
                                         ref.indexOf('/') == -1 ? ref : Constants.R_REFS + ref);
                                 info = TypeInfo.DIRECTORY_CONFIRMED;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFile.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFile.java
@@ -108,8 +108,10 @@ class GitHubSCMFile extends SCMFile {
                             info = TypeInfo.NON_DIRECTORY_CONFIRMED;
                             resolved = true;
                         } catch (IOException e) {
-                            if (e.getCause() instanceof IOException
-                                    && e.getCause().getCause() instanceof JsonMappingException) {
+                            // Upcoming version of github-api hoists JsonMappingException up one level
+                            // Support both the old and the new structure
+                            if (e.getCause() instanceof JsonMappingException
+                                || e.getCause().getCause() instanceof JsonMappingException ) {
                                 metadata = repo.getDirectoryContent(getPath(),
                                         ref.indexOf('/') == -1 ? ref : Constants.R_REFS + ref);
                                 info = TypeInfo.DIRECTORY_CONFIRMED;


### PR DESCRIPTION
github-api v1.112 changes the structure of the exceptions thrown from GHContent.
This change handle both the new and the old structures.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

