### PR TITLE
JENKINS-62655 Check running on master for proxy config

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -35,6 +35,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import jenkins.util.JenkinsJVM;
 import okhttp3.Cache;
 import okhttp3.OkHttpClient;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -513,13 +514,16 @@ public class Connector {
      */
     @Nonnull
     private static Proxy getProxy(@Nonnull String host) {
-        Jenkins jenkins = GitHubWebHook.getJenkinsInstance();
+        if (JenkinsJVM.isJenkinsJVM()) {
+            Jenkins jenkins = Jenkins.get();
 
-        if (jenkins.proxy == null) {
-            return Proxy.NO_PROXY;
-        } else {
-            return jenkins.proxy.createProxy(host);
+            if (jenkins.proxy == null) {
+                return Proxy.NO_PROXY;
+            } else {
+                return jenkins.proxy.createProxy(host);
+            }
         }
+        return Proxy.NO_PROXY;
     }
 
     /**


### PR DESCRIPTION
# Description

See 
[JENKINS-62655](https://issues.jenkins-ci.org/browse/JENKINS-62655) for further information. 

fixes:
```
java.lang.IllegalStateException: Jenkins has not been started, or was already shut down
12:03:53  	at org.apache.commons.lang3.Validate.validState(Validate.java:829)
12:03:53  	at com.cloudbees.jenkins.GitHubWebHook.getJenkinsInstance(GitHubWebHook.java:155)
```

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

@bitwiseman 