### PR TITLE
Clarify api rate limit messaging

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
@@ -72,7 +72,7 @@ public enum ApiRateLimitChecker {
                         )));
                     }
                     listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(),
-                            "Jenkins is attempting to evenly distribute GitHub API requests. To configure a different rate limiting strategy, such as having Jenkins attempt to evenly distribute GitHub API requests, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings."));
+                            "Jenkins is attempting to evenly distribute GitHub API requests. To configure a different rate limiting strategy, such as having Jenkins restrict GitHub API requests only when near or above the GitHub rate limit, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings."));
                     waitUntilRateLimit(listener, github, rateLimit, expiration);
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
@@ -32,7 +32,7 @@ public enum ApiRateLimitChecker {
                 int ideal = (int) ((rateLimit.limit - buffer - burst) * resetProgress) + buffer;
                 if (rateLimit.remaining >= ideal && rateLimit.remaining < ideal + buffer) {
                     listener.getLogger().println(GitHubConsoleNote.create(start, String.format(
-                            "GitHub API Usage: Current quota has %d remaining (%d under budget). Next quota of %d in %s",
+                            "Jenkins-Imposed API Limiter: Current quota for Github API usage has %d remaining (%d under budget). Next quota of %d in %s",
                             rateLimit.remaining, rateLimit.remaining - ideal, rateLimit.limit,
                             Util.getTimeSpanString(rateLimitResetMillis)
                     )));
@@ -46,14 +46,14 @@ public enum ApiRateLimitChecker {
                         if (rateLimitResetMillis < 0) {
                             expiration = System.currentTimeMillis() + ENTROPY.nextInt(EXPIRATION_WAIT_MILLIS);
                             listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(), String.format(
-                                    "GitHub API Usage: Current quota has %d remaining (%d over budget). Next quota of %d due now. Sleeping for %s.",
+                                    "Jenkins-Imposed API Limiter: Current quota for Github API usage has %d remaining (%d over budget). Next quota of %d due now. Sleeping for %s.",
                                     rateLimit.remaining, ideal - rateLimit.remaining, rateLimit.limit,
                                     Util.getTimeSpanString(expiration - System.currentTimeMillis())
                             )));
                         } else {
                             expiration = rateLimit.getResetDate().getTime() + ENTROPY.nextInt(EXPIRATION_WAIT_MILLIS);
                             listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(), String.format(
-                                    "GitHub API Usage: Current quota has %d remaining (%d over budget). Next quota of %d in %s. Sleeping until reset.",
+                                    "Jenkins-Imposed API Limiter: Current quota for Github API usage has %d remaining (%d over budget). Next quota of %d in %s. Sleeping until reset.",
                                     rateLimit.remaining, ideal - rateLimit.remaining, rateLimit.limit,
                                     Util.getTimeSpanString(rateLimitResetMillis)
                             )));
@@ -65,12 +65,14 @@ public enum ApiRateLimitChecker {
                                 - Math.max(0, (long) (targetFraction * MILLIS_PER_HOUR))
                                 + ENTROPY.nextInt(1000);
                         listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(), String.format(
-                                "GitHub API Usage: Current quota has %d remaining (%d over budget). Next quota of %d in %s. Sleeping for %s.",
+                                "Jenkins-Imposed API Limiter: Current quota for Github API usage has %d remaining (%d over budget). Next quota of %d in %s. Sleeping for %s.",
                                 rateLimit.remaining, ideal - rateLimit.remaining, rateLimit.limit,
                                 Util.getTimeSpanString(rateLimitResetMillis),
                                 Util.getTimeSpanString(expiration - System.currentTimeMillis())
                         )));
                     }
+                    listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(),
+                            "Jenkins is using \"Throttle for Normalize\" to try and evenly distribute GitHub API requests. Use \"Throttle on Over\" to have Jenkins restrict GitHub API requests only when near or above the rate limit."));
                     waitUntilRateLimit(listener, github, rateLimit, expiration);
                 }
             }
@@ -94,12 +96,14 @@ public enum ApiRateLimitChecker {
                 }
                 final long expiration = rateLimit.getResetDate().getTime() + ENTROPY.nextInt(EXPIRATION_WAIT_MILLIS);
                 listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(), String.format(
-                        "GitHub API Usage: Current quota has %d remaining (%d over buffer). Next quota of %d due in %s. Sleeping for %s.",
+                        "Jenkins-Imposed API Limiter: Current quota for Github API usage has %d remaining (%d over buffer). Next quota of %d due in %s. Sleeping for %s.",
                         rateLimit.remaining, buffer - rateLimit.remaining, rateLimit.limit,
                         Util.getTimeSpanString(expiration - System.currentTimeMillis()),
                         Util.getTimeSpanString(NOTIFICATION_WAIT_MILLIS)
 
                 )));
+                listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(),
+                        "Jenkins is using \"Throttle on Over\" to restrict GitHub API requests only when near or above the rate limit. Use \"Throttle on Over\" to try and evenly distribute GitHub API requests."));
                 waitUntilRateLimit(listener, github, rateLimit, expiration);
             }
         }
@@ -165,12 +169,12 @@ public enum ApiRateLimitChecker {
                 if (current.remaining > rateLimit.remaining
                         || current.getResetDate().getTime() > rateLimit.getResetDate().getTime()) {
                     listener.getLogger().println(GitHubConsoleNote.create(now,
-                            "GitHub API Usage: The quota may have been refreshed earlier than expected, rechecking..."
+                            "Jenkins-Imposed API Limiter: The Github API usage quota may have been refreshed earlier than expected, rechecking..."
                     ));
                     break;
                 }
                 listener.getLogger().println(GitHubConsoleNote.create(now, String.format(
-                        "GitHub API Usage: Still sleeping, now only %s remaining.",
+                        "Jenkins-Imposed API Limiter: Still sleeping, now only %s remaining.",
                         Util.getTimeSpanString(expiration - now)
                 )));
             }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
@@ -103,7 +103,7 @@ public enum ApiRateLimitChecker {
 
                 )));
                 listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(),
-                        "Jenkins is restricting GitHub API requests only when near or above the rate limit. To configure a different rate limiting strategy, such as having Jenkins restrict GitHub API requests only when near or above the GitHub rate limit, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings."));
+                        "Jenkins is restricting GitHub API requests only when near or above the rate limit. To configure a different rate limiting strategy, such as having Jenkins attempt to evenly distribute GitHub API requests, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings."));
                 waitUntilRateLimit(listener, github, rateLimit, expiration);
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
@@ -72,7 +72,7 @@ public enum ApiRateLimitChecker {
                         )));
                     }
                     listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(),
-                            "Jenkins is using \"Throttle for Normalize\" to try and evenly distribute GitHub API requests. Use \"Throttle on Over\" to have Jenkins restrict GitHub API requests only when near or above the rate limit."));
+                            "Jenkins is attempting to evenly distribute GitHub API requests. To configure a different rate limiting strategy, such as having Jenkins attempt to evenly distribute GitHub API requests, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings."));
                     waitUntilRateLimit(listener, github, rateLimit, expiration);
                 }
             }
@@ -103,7 +103,7 @@ public enum ApiRateLimitChecker {
 
                 )));
                 listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(),
-                        "Jenkins is using \"Throttle on Over\" to restrict GitHub API requests only when near or above the rate limit. Use \"Throttle for Normalize\" to try and evenly distribute GitHub API requests."));
+                        "Jenkins is restricting GitHub API requests only when near or above the rate limit. To configure a different rate limiting strategy, such as having Jenkins restrict GitHub API requests only when near or above the GitHub rate limit, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings."));
                 waitUntilRateLimit(listener, github, rateLimit, expiration);
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
@@ -103,7 +103,7 @@ public enum ApiRateLimitChecker {
 
                 )));
                 listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(),
-                        "Jenkins is using \"Throttle on Over\" to restrict GitHub API requests only when near or above the rate limit. Use \"Throttle on Over\" to try and evenly distribute GitHub API requests."));
+                        "Jenkins is using \"Throttle on Over\" to restrict GitHub API requests only when near or above the rate limit. Use \"Throttle for Normalize\" to try and evenly distribute GitHub API requests."));
                 waitUntilRateLimit(listener, github, rateLimit, expiration);
             }
         }

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubConfiguration/help-apiRateLimitChecker.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubConfiguration/help-apiRateLimitChecker.html
@@ -1,0 +1,11 @@
+<div>
+    <p>
+        <b>Throttle For Normalize</b>: Attempt to evenly distribute GitHub API requests. This strategy can be helpful when there are numerous pipelines
+        that are managed by multiple users and/or there are many concurrent builds, making it difficult to know when a pipeline has been paused
+        due to exceeding the GitHub API usage limit.
+    </p>
+    <p>
+        <b>Throttle On Over</b>: Restrict GitHub API requests only when near or above rate limit. This strategy may be preferred over "Throttle for Normalize"
+        if there are relatively few/infrequent queries to the GitHub API.
+    </p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubConfiguration/help-apiRateLimitChecker.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubConfiguration/help-apiRateLimitChecker.html
@@ -1,11 +1,11 @@
 <div>
     <p>
-        <b>Throttle For Normalize</b>: Attempt to evenly distribute GitHub API requests. This strategy can be helpful when there are numerous pipelines
+        <b>Normalize API requests</b>: Attempt to evenly distribute GitHub API requests. This strategy can be helpful when there are numerous pipelines
         that are managed by multiple users and/or there are many concurrent builds, making it difficult to know when a pipeline has been paused
         due to exceeding the GitHub API usage limit.
     </p>
     <p>
-        <b>Throttle On Over</b>: Restrict GitHub API requests only when near or above rate limit. This strategy may be preferred over "Throttle for Normalize"
+        <b>Throttle at/near rate limit</b>: Restrict GitHub API requests only when near or above rate limit. This strategy may be preferred over "Throttle for Normalize"
         if there are relatively few/infrequent queries to the GitHub API.
     </p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -21,8 +21,8 @@ GitHubBuildStatusNotification.CommitStatus.Pending=This commit is being built
 GitHubBuildStatusNotification.CommitStatus.Queued=This commit is scheduled to be built
 GitHubBuildStatusNotification.CommitStatusSet=GitHub has been notified of this commit\u2019s build result
 
-ApiRateLimitChecker.ThrottleForNormalize=Attempt to evenly distribute GitHub API requests
-ApiRateLimitChecker.ThrottleOnOver=Restrict GitHub API requests only when near or above rate limit
+ApiRateLimitChecker.ThrottleForNormalize=Throttle For Normalize: Attempt to evenly distribute GitHub API requests
+ApiRateLimitChecker.ThrottleOnOver=Throttle On Over: Restrict GitHub API requests only when near or above rate limit
 
 GitHubLink.DisplayName=GitHub
 

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -21,8 +21,8 @@ GitHubBuildStatusNotification.CommitStatus.Pending=This commit is being built
 GitHubBuildStatusNotification.CommitStatus.Queued=This commit is scheduled to be built
 GitHubBuildStatusNotification.CommitStatusSet=GitHub has been notified of this commit\u2019s build result
 
-ApiRateLimitChecker.ThrottleForNormalize=Throttle For Normalize: Attempt to evenly distribute GitHub API requests
-ApiRateLimitChecker.ThrottleOnOver=Throttle On Over: Restrict GitHub API requests only when near or above rate limit
+ApiRateLimitChecker.ThrottleForNormalize=Normalize API requests
+ApiRateLimitChecker.ThrottleOnOver=Throttle at/near rate limit
 
 GitHubLink.DisplayName=GitHub
 

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
@@ -297,6 +297,8 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
             "Current quota for Github API usage has 0 remaining (250 over budget). Next quota of 5000 due now. Sleeping for 15 ms."));
         assertEquals(1, countOfOutputLinesContaining(
             "Current quota for Github API usage has 0 remaining (250 over budget). Next quota of 5000 due now. Sleeping for 16 ms."));
+        assertEquals(4, countOfOutputLinesContaining(
+            "Jenkins is using \"Throttle for Normalize\" to try and evenly distribute GitHub API requests. Use \"Throttle on Over\" to have Jenkins restrict GitHub API requests only when near or above the rate limit."));
         assertEquals(4, countOfOutputLinesContaining("Sleeping"));
         // Expect that we stopped waiting on a refresh
         assertEquals(1, countOfOutputLinesContaining("refreshed"));
@@ -495,6 +497,7 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
         assertEquals(1, countOfOutputLinesContaining("Current quota"));
         //Making sure the budget messages are correct
         assertEquals(1, countOfOutputLinesContaining("1 over buffer"));
+        assertEquals(1, countOfOutputLinesContaining("Jenkins is using \"Throttle on Over\" to restrict GitHub API requests only when near or above the rate limit. Use \"Throttle for Normalize\" to try and evenly distribute GitHub API requests."));
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
@@ -258,6 +258,7 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
         assertEquals(3, countOfOutputLinesContaining("Still sleeping"));
         assertEquals(2, countOfOutputLinesContaining("Sleeping for"));
         assertEquals(1, countOfOutputLinesContaining("under budget"));
+        assertEquals(2, countOfOutputLinesContaining("Jenkins is using \"Throttle for Normalize\""));
 
         // The last scenario will trigger back to under budget with a full limit but no new messages
         assertEquals(10, handler.getView().size());

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
@@ -260,7 +260,7 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
         assertEquals(1, countOfOutputLinesContaining("under budget"));
 
         // The last scenario will trigger back to under budget with a full limit but no new messages
-        assertEquals(8, handler.getView().size());
+        assertEquals(10, handler.getView().size());
     }
 
     /**
@@ -292,11 +292,11 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
 
         // Expect a triggered throttle for normalize
         assertEquals(1, countOfOutputLinesContaining(
-            "Current quota has 0 remaining (250 over budget). Next quota of 5000 due now. Sleeping for 7 ms."));
+            "Current quota for Github API usage has 0 remaining (250 over budget). Next quota of 5000 due now. Sleeping for 7 ms."));
         assertEquals(1, countOfOutputLinesContaining(
-            "Current quota has 0 remaining (250 over budget). Next quota of 5000 due now. Sleeping for 15 ms."));
+            "Current quota for Github API usage has 0 remaining (250 over budget). Next quota of 5000 due now. Sleeping for 15 ms."));
         assertEquals(1, countOfOutputLinesContaining(
-            "Current quota has 0 remaining (250 over budget). Next quota of 5000 due now. Sleeping for 16 ms."));
+            "Current quota for Github API usage has 0 remaining (250 over budget). Next quota of 5000 due now. Sleeping for 16 ms."));
         assertEquals(4, countOfOutputLinesContaining("Sleeping"));
         // Expect that we stopped waiting on a refresh
         assertEquals(1, countOfOutputLinesContaining("refreshed"));

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
@@ -258,7 +258,7 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
         assertEquals(3, countOfOutputLinesContaining("Still sleeping"));
         assertEquals(2, countOfOutputLinesContaining("Sleeping for"));
         assertEquals(1, countOfOutputLinesContaining("under budget"));
-        assertEquals(2, countOfOutputLinesContaining("Jenkins is using \"Throttle for Normalize\""));
+        assertEquals(2, countOfOutputLinesContaining("Jenkins is attempting to evenly distribute GitHub API requests"));
 
         // The last scenario will trigger back to under budget with a full limit but no new messages
         assertEquals(10, handler.getView().size());
@@ -299,7 +299,7 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
         assertEquals(1, countOfOutputLinesContaining(
             "Current quota for Github API usage has 0 remaining (250 over budget). Next quota of 5000 due now. Sleeping for 16 ms."));
         assertEquals(4, countOfOutputLinesContaining(
-            "Jenkins is using \"Throttle for Normalize\" to try and evenly distribute GitHub API requests. Use \"Throttle on Over\" to have Jenkins restrict GitHub API requests only when near or above the rate limit."));
+            "Jenkins is attempting to evenly distribute GitHub API requests. To configure a different rate limiting strategy, such as having Jenkins restrict GitHub API requests only when near or above the GitHub rate limit, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings."));
         assertEquals(4, countOfOutputLinesContaining("Sleeping"));
         // Expect that we stopped waiting on a refresh
         assertEquals(1, countOfOutputLinesContaining("refreshed"));
@@ -498,7 +498,7 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
         assertEquals(1, countOfOutputLinesContaining("Current quota"));
         //Making sure the budget messages are correct
         assertEquals(1, countOfOutputLinesContaining("1 over buffer"));
-        assertEquals(1, countOfOutputLinesContaining("Jenkins is using \"Throttle on Over\" to restrict GitHub API requests only when near or above the rate limit. Use \"Throttle for Normalize\" to try and evenly distribute GitHub API requests."));
+        assertEquals(1, countOfOutputLinesContaining("Jenkins is restricting GitHub API requests only when near or above the rate limit. To configure a different rate limiting strategy, such as having Jenkins restrict GitHub API requests only when near or above the GitHub rate limit, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings."));
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
@@ -498,7 +498,7 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
         assertEquals(1, countOfOutputLinesContaining("Current quota"));
         //Making sure the budget messages are correct
         assertEquals(1, countOfOutputLinesContaining("1 over buffer"));
-        assertEquals(1, countOfOutputLinesContaining("Jenkins is restricting GitHub API requests only when near or above the rate limit. To configure a different rate limiting strategy, such as having Jenkins restrict GitHub API requests only when near or above the GitHub rate limit, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings."));
+        assertEquals(1, countOfOutputLinesContaining("Jenkins is restricting GitHub API requests only when near or above the rate limit. To configure a different rate limiting strategy, such as having Jenkins attempt to evenly distribute GitHub API requests, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings."));
     }
 
     /**


### PR DESCRIPTION
# Description

The current messaging for the Github API Usage rate limiter can lead users to think that Github itself is doing the limiting instead of Jenkins. This PR attempts to make it clearer that Jenkins is the one that is doing the rate limiting.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

