### PR TITLE
[JENKINS-63078] Allow ignoring rate limits

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.github_branch_source;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
 import hudson.model.TaskListener;
+import org.jenkinsci.plugins.github.config.GitHubServerConfig;
 import org.kohsuke.github.GHRateLimit;
 import org.kohsuke.github.GitHub;
 
@@ -115,6 +116,13 @@ public enum ApiRateLimitChecker {
 
                 @Override
                 public void checkApiRateLimit(@NonNull TaskListener listener, GitHub github) throws IOException, InterruptedException {
+                    if (GitHubServerConfig.GITHUB_URL.equals(github.getApiUrl())) {
+
+                        // If the GitHub public API is being used, this will fallback to ThrottleOnOver
+                        listener.getLogger().println(GitHubConsoleNote.create(System.currentTimeMillis(),
+                                "GitHub throttling is disabled, which is not allowed for public GitHub usage, so ThrottleOnOver will be used instead. To configure a different rate limiting strategy, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings."));
+                        ThrottleOnOver.checkApiRateLimit(listener, github);
+                    }
                     // Nothing needed
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
@@ -111,7 +111,7 @@ public enum ApiRateLimitChecker {
     /**
      * Ignore GitHub API Rate limit. Useful for GitHub Enterprise instances that might not have a limit set up.
      */
-    ThrottleNone(Messages.ApiRateLimitChecker_ThrottleNone()) {
+    NoThrottle(Messages.ApiRateLimitChecker_NoThrottle()) {
 
                 @Override
                 public void checkApiRateLimit(@NonNull TaskListener listener, GitHub github) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
@@ -107,7 +107,18 @@ public enum ApiRateLimitChecker {
                 waitUntilRateLimit(listener, github, rateLimit, expiration);
             }
         }
-    };
+    },
+    /**
+     * Ignore GitHub API Rate limit. Useful for GitHub Enterprise instances that might not have a limit set up.
+     */
+    ThrottleNone(Messages.ApiRateLimitChecker_ThrottleNone()) {
+
+                @Override
+                public void checkApiRateLimit(@NonNull TaskListener listener, GitHub github) throws IOException, InterruptedException {
+                    // Nothing needed
+                }
+            }
+    ;
 
 
     private static final double MILLIS_PER_HOUR = TimeUnit.HOURS.toMillis(1);

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -23,7 +23,7 @@ GitHubBuildStatusNotification.CommitStatusSet=GitHub has been notified of this c
 
 ApiRateLimitChecker.ThrottleForNormalize=Normalize API requests
 ApiRateLimitChecker.ThrottleOnOver=Throttle at/near rate limit
-ApiRateLimitChecker.ThrottleNone=Ignore rate limit
+ApiRateLimitChecker.NoThrottle=Ignore rate limit
 
 GitHubLink.DisplayName=GitHub
 

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -23,7 +23,7 @@ GitHubBuildStatusNotification.CommitStatusSet=GitHub has been notified of this c
 
 ApiRateLimitChecker.ThrottleForNormalize=Normalize API requests
 ApiRateLimitChecker.ThrottleOnOver=Throttle at/near rate limit
-ApiRateLimitChecker.NoThrottle=Ignore rate limit
+ApiRateLimitChecker.NoThrottle=Never check rate limit (NOT RECOMMENDED)
 
 GitHubLink.DisplayName=GitHub
 

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -23,6 +23,7 @@ GitHubBuildStatusNotification.CommitStatusSet=GitHub has been notified of this c
 
 ApiRateLimitChecker.ThrottleForNormalize=Normalize API requests
 ApiRateLimitChecker.ThrottleOnOver=Throttle at/near rate limit
+ApiRateLimitChecker.ThrottleNone=Ignore rate limit
 
 GitHubLink.DisplayName=GitHub
 

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.github_branch_source;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.ScenarioMappingBuilder;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import hudson.util.LogTaskListener;
@@ -24,6 +25,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.resetAllScenarios;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
 public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
 
@@ -169,7 +171,7 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
     }
 
     /**
-     * Verify that "NoThrottle" does not throttle in any case.
+     * Verify that "NoThrottle" does not contact the GitHub api nor output any logs
      *
      * @author Marc Salles Navarro
      */
@@ -184,9 +186,10 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
         }
         setupStubs(scenarios);
         ApiRateLimitChecker.NoThrottle.checkApiRateLimit(listener, github);
-
-
-        assertEquals(0, countOfOutputLinesContaining("Sleeping"));
+        // there should be no output
+        assertEquals(0, countOfOutputLines(m -> m.matches("[sS]leeping")));
+        // github rate_limit endpoint should not be contacted
+        assertEquals(0, getRequestCount(githubApi));
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
@@ -169,12 +169,12 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
     }
 
     /**
-     * Verify that "ThrottleNone" does not throttle in any case.
+     * Verify that "NoThrottle" does not throttle in any case.
      *
      * @author Marc Salles Navarro
      */
     @Test
-    public void ThrottleNoneTestShouldNotThrottle() throws Exception {
+    public void NoThrottleTestShouldNotThrottle() throws Exception {
         // set up scenarios
         List<RateLimit> scenarios = new ArrayList<>();
         int limit = 5000;
@@ -183,7 +183,7 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
             scenarios.add(new RateLimit(limit, i, soon));
         }
         setupStubs(scenarios);
-        ApiRateLimitChecker.ThrottleNone.checkApiRateLimit(listener, github);
+        ApiRateLimitChecker.NoThrottle.checkApiRateLimit(listener, github);
 
 
         assertEquals(0, countOfOutputLinesContaining("Sleeping"));

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
@@ -169,6 +169,27 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
     }
 
     /**
+     * Verify that "ThrottleNone" does not throttle in any case.
+     *
+     * @author Marc Salles Navarro
+     */
+    @Test
+    public void ThrottleNoneTestShouldNotThrottle() throws Exception {
+        // set up scenarios
+        List<RateLimit> scenarios = new ArrayList<>();
+        int limit = 5000;
+         // Keep decreasing quota until there's none left
+        for (int i = 500; i >= 0; i--) {
+            scenarios.add(new RateLimit(limit, i, soon));
+        }
+        setupStubs(scenarios);
+        ApiRateLimitChecker.ThrottleNone.checkApiRateLimit(listener, github);
+
+
+        assertEquals(0, countOfOutputLinesContaining("Sleeping"));
+    }
+
+    /**
      * Verify exactly when the throttle is occurring in "OnOver"
      *
      * @author Julian V. Modesto


### PR DESCRIPTION
# Description

This adds ApiRateLimitChecker.NoThrottle, which avoids checking the GitHub rate limits. This is useful for GitHub Enterprise installations. See [JENKINS-63078](https://issues.jenkins-ci.org/browse/JENKINS-63078) for further information. 

When this change is included, a new strategy will appear on the **Github API usage rate limiting strategy** selector, called **NoThrottle**, with the description _Ignore rate limit_. No requests to the rate_limit endpoint should be performed if it is selected.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

