### PR TITLE
Extension: RepositorySizeGithubAPI to get size of a repo

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1922,7 +1922,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
      * to return the size of repository.
      */
     @Extension
-    public static class RepositorySizeAPI extends GitToolChooser.RepositorySizeAPI {
+    public static class RepositorySizeGithubAPI extends GitToolChooser.RepositorySizeAPI {
 
         @Override
         public boolean isApplicableTo(String repoUrl) {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1922,7 +1922,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
      * to return the size of repository.
      */
     @Extension
-    public static class RepositoryAPI extends GitToolChooser.RepositorySizeAPI {
+    public static class RepositorySizeAPI extends GitToolChooser.RepositorySizeAPI {
 
         @Override
         public boolean isApplicableTo(String repoUrl) {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -80,7 +80,7 @@ import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.AbstractGitSCMSource;
-import jenkins.plugins.git.GitRepoSizeEstimator;
+import jenkins.plugins.git.GitToolChooser;
 import jenkins.plugins.git.GitTagSCMRevision;
 import jenkins.plugins.git.MergeWithGitSCMExtension;
 import jenkins.plugins.git.traits.GitBrowserSCMSourceTrait;


### PR DESCRIPTION
# RepositorySizeGithubAPI

This class intends to implement an extension point provided by the Git Plugin
which should return the size of a repository if the provided URL is applicable
to the Github Branch Source Plugin.

Please refer to https://github.com/jenkinsci/git-plugin/pull/931 for further description on this extension and why does the Git Plugin needs it.

The extension point in the Git Plugin: https://github.com/jenkinsci/git-plugin/blob/6dfacf73ea73f94edbedd83fc09336a03ac15659/src/main/java/jenkins/plugins/git/GitToolChooser.java#L169-L178

**Note**: Since this extension would require a dependency from a git plugin class which hasn't been released yet, I believe we can't merge this PR until [PR-931](https://github.com/jenkinsci/git-plugin/pull/931) is merged.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

