### PR TITLE
Bump baseline to 2.176

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <changelist>-SNAPSHOT</changelist>
         <hpi.compatibleSinceVersion>2.2.0</hpi.compatibleSinceVersion>
         <java.level>8</java.level>
-        <jenkins.version>2.164.3</jenkins.version>
+        <jenkins.version>2.176.4</jenkins.version>
         <useBeta>true</useBeta>
         <jcasc.version>1.35</jcasc.version>
         <jjwt.version>0.10.5</jjwt.version>
@@ -47,12 +47,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
             <version>1.115</version>
-        </dependency>
-        <!-- TODO: after upgrading jenkins.version >= 2.171, migrate dependency -->
-        <dependency>
-            <groupId>io.jenkins.temp.jelly</groupId>
-            <artifactId>multiline-secrets-ui</artifactId>
-            <version>1.0</version>
         </dependency>
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
@@ -123,15 +117,10 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.164.x</artifactId>
-                <version>9</version>
+                <artifactId>bom-2.176.x</artifactId>
+                <version>11</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials/config.jelly
@@ -18,10 +18,7 @@
   </j:choose>
 
   <f:entry title="${%Key}" field="privateKey">
-    <!-- TODO: after upgrading jenkins.version >= 2.171, remove xmlns below and use f:secretTextArea
-     e.g. https://github.com/jenkinsci/ssh-credentials-plugin/commit/68ce416ec00b88a13579285df5cacaea8f39d435
-     -->
-    <secretTextarea xmlns="/io/jenkins/temp/jelly"/>
+    <f:secretTextarea />
   </f:entry>
 
   <f:advanced>


### PR DESCRIPTION
# Description

Alternative to https://github.com/jenkinsci/lib-multiline-secrets-ui/pull/1

Fixes Dark theme compatibility with GitHub app credentials

A brief summary describing the changes in this pull request. See 
[JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

