### PR TITLE
Account for Windows line endings in private key

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/JwtHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/JwtHelper.java
@@ -67,7 +67,9 @@ class JwtHelper {
             );
         }
 
-        String privateKeyContent = key.replaceAll("\\n", "")
+        String privateKeyContent = key
+                .replaceAll("\\n", "")
+                .replaceAll("\\r", "")
                 .replace("-----BEGIN PRIVATE KEY-----", "")
                 .replace("-----END PRIVATE KEY-----", "");
 

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/JwtHelperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/JwtHelperTest.java
@@ -24,8 +24,10 @@ public class JwtHelperTest {
 
     // https://stackoverflow.com/a/22176759/4951015
     private static final String PKCS8_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----\n" +
-            "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQD7vHsVwyDV8cj7\n" +
-            "5yR4WWl6rlgf/e5zmeBgtm0PCgnitcSbD5FU33301DPY5a7AtqVBOwEnE14L9XS7\n" +
+            // Windows line ending
+            "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQD7vHsVwyDV8cj7\r\n" +
+            // This should also work
+            "5yR4WWl6rlgf/e5zmeBgtm0PCgnitcSbD5FU33301DPY5a7AtqVBOwEnE14L9XS7\r" +
             "ov61U+x1m4aQmqR/dPQaA2ayh2cYPszWNQMp42ArDIfg7DhSrvsRJKHsbPXlPjqe\n" +
             "c0udLqhSLVIO9frNLf+dAsLsgYk8O39PKGb33akGG7tWTe0J+akNQjgbS7vOi8sS\n" +
             "NLwHIdYfz/Am+6Xmm+J4yVs6+Xt3kOeLdFBkz8H/HGsJq854MbIAK/HuId1MOPS0\n" +


### PR DESCRIPTION
# Description

I am running Windows with a local K8s cluster, which is running Jenkins. As part of the bootstrapping, I am loading up a .pem that was created in Windows. After much trial and error I realized this lib was not sanitizing the windows specific line endings. This change fixes that.

I tested this change on my own Jenkins instance by running the following script successfully:
```groovy
import jenkins.model.*
import hudson.util.Secret
import org.jenkinsci.plugins.github_branch_source.*
import com.cloudbees.plugins.credentials.*
  
def getContent(filePath) {
    return new File(filePath).text
}

def token = new GitHubAppCredentials(CredentialsScope.GLOBAL, 'github-app', '', 1234, Secret.fromString(getContent('test.pem').replaceAll("\\n", "").replaceAll("\\r", "").replace("-----BEGIN PRIVATE KEY-----", "").replace("-----END PRIVATE KEY-----", "")))

println(token.getPassword())
```

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate. (Found this issue in my own troubleshooting)
- [x] Change is code complete and matches issue description
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
No documentation changes needed, as I think this functionality is what a user would expect.
