### PR TITLE
Always call Connector.release after Connector.connect

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -291,7 +291,11 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
 
             try {
                 GitHub connect = Connector.connect(apiUri, gitHubAppCredential);
-                return FormValidation.ok("Success, Remaining rate limit: " + connect.getRateLimit().getRemaining());
+                try {
+                    return FormValidation.ok("Success, Remaining rate limit: " + connect.getRateLimit().getRemaining());
+                } finally {
+                    Connector.release(connect);
+                }
             } catch (Exception e) {
                 return FormValidation.error(e, String.format(ERROR_AUTHENTICATING_GITHUB_APP, appID));
             }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -2025,15 +2025,19 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             StringBuilder sb = new StringBuilder();
             try {
                 GitHub github = Connector.connect(info.getApiUri(), credentials);
-                if (github.isCredentialValid()){
-                    sb.append("Credentials ok.");
-                }
+                try {
+                    if (github.isCredentialValid()){
+                        sb.append("Credentials ok.");
+                    }
 
-                GHRepository repo = github.getRepository(info.getRepoOwner() + "/" + info.getRepository());
-                if (repo != null) {
-                    sb.append(" Connected to ");
-                    sb.append(repo.getHtmlUrl());
-                    sb.append(".");
+                    GHRepository repo = github.getRepository(info.getRepoOwner() + "/" + info.getRepository());
+                    if (repo != null) {
+                        sb.append(" Connected to ");
+                        sb.append(repo.getHtmlUrl());
+                        sb.append(".");
+                    }
+                } finally {
+                    Connector.release(github);
                 }
             } catch (IOException e) {
                 return FormValidation.error(e, "Error validating repository information. " + sb.toString());
@@ -2133,12 +2137,16 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             try {
                 StandardCredentials credentials = Connector.lookupScanCredentials(context, apiUri, credentialsId);
                 GitHub github = Connector.connect(apiUri, credentials);
-                if (!github.isAnonymous()) {
-                    ListBoxModel model = new ListBoxModel();
-                    for (Map.Entry<String,GHOrganization> entry : github.getMyOrganizations().entrySet()) {
-                        model.add(entry.getKey(), entry.getValue().getAvatarUrl());
+                try {
+                    if (!github.isAnonymous()) {
+                        ListBoxModel model = new ListBoxModel();
+                        for (Map.Entry<String,GHOrganization> entry : github.getMyOrganizations().entrySet()) {
+                            model.add(entry.getKey(), entry.getValue().getAvatarUrl());
+                        }
+                        return model;
                     }
-                    return model;
+                } finally {
+                    Connector.release(github);
                 }
             }
              catch (FillErrorResponse e) {


### PR DESCRIPTION
# Description

I noticed that there are a few places in form validation and autocompletion code where `Connector.connect` is called without being paired with `Connector.release`, which breaks usage tracking logic in `Connector`, and I think causes `Connector.UnusedConnectionDestroyer` to not work correctly.

I don't think this PR on its own will fix any issues that users could be seeing, but it should make the usage-tracking logic consistent.

For now, I did not add any tests. I am not sure if these validation methods are covered by existing tests, but if so, I could add some assertions around `Connector.usages` pretty easily if desired.

The [whitespace-reduced diff](https://github.com/jenkinsci/github-branch-source-plugin/pull/328/files?w=1) is easiest to review.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

