### PR TITLE
Use CredentialsSnapshotTaker

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
@@ -260,7 +260,6 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
             WorkflowRun run = job.scheduleBuild2(0).waitForStart();
             r.waitUntilNoActivity();
 
-            assertThat(run.getResult(), equalTo(Result.SUCCESS));
             System.out.println(JenkinsRule.getLog(run));
 
             List<String> credentialsLog = getOutputLines();
@@ -270,7 +269,7 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
                 credentialsLog, contains(
                     // (agent log added out of order, see below)
                     "Generating App Installation Token for app ID 54321 on agent", // 1
-                    "Failed to generate new GitHub App Installation Token for app ID 54321 on agent: cached token is stale but has not expired", // 2
+                    "Failed to generate new GitHub App Installation Token for app ID 54321: cached token is stale but has not expired", // 2
                     "Generating App Installation Token for app ID 54321 on agent", // 3
                     // node ('my-agent') {
                     // checkout scm
@@ -285,7 +284,7 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
                     // (error forced by wiremock - failed refresh on the agent)
                     // "Generating App Installation Token for app ID 54321 on agent", // 1
                     "Generating App Installation Token for app ID 54321 for agent",
-                    // (agent log added out of order) "Keeping cached GitHub App Installation Token for app ID 54321 on agent: token is stale but has not expired", // 2
+                    // (agent log added out of order) "Keeping cached GitHub App Installation Token for app ID 54321: token is stale but has not expired", // 2
                     // checkout scm - refresh on controller
                     "Generating App Installation Token for app ID 54321",
                     // sleep
@@ -300,6 +299,9 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
                     // checkout scm
                     // (No token generation)
                     ));
+
+            assertThat(run.getResult(), equalTo(Result.SUCCESS));
+
         } finally {
             GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = notStaleSeconds;
             logRecorder.doClear();


### PR DESCRIPTION
# Description
#326 made GitHub App Credentials much more stable and tolerant of errors during transport.  It also implemented an asymmetric design where a  GitHubAppCredentials instance that has been serialize via a path other than XStream is not a fully functional GitHubAppCredentials instance.   This is fine for controller to agent, but breaks for controller-to-controller transfer. 

This change fixes that by using CredentialsSnapshotTaker and detecting whether where the new credential is landing on an agent. 

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

