### PR TITLE
Store token as Secret instead of String

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsAppInstallationTokenTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsAppInstallationTokenTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.github_branch_source;
 
+import hudson.util.Secret;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -17,24 +18,25 @@ public class GithubAppCredentialsAppInstallationTokenTest {
         long now;
 
         now = Instant.now().getEpochSecond();
-        token = new GitHubAppCredentials.AppInstallationToken("", now);
+        Secret secret = Secret.fromString("secret-token");
+        token = new GitHubAppCredentials.AppInstallationToken(secret, now);
         assertThat(token.isStale(), is(false));
         assertThat(token.getTokenStaleEpochSeconds(), equalTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS));
 
         now = Instant.now().getEpochSecond();
-        token = new GitHubAppCredentials.AppInstallationToken("",
+        token = new GitHubAppCredentials.AppInstallationToken(secret,
             now + Duration.ofMinutes(15).getSeconds());
         assertThat(token.isStale(), is(false));
         assertThat(token.getTokenStaleEpochSeconds(), equalTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS));
 
         now = Instant.now().getEpochSecond();
-        token = new GitHubAppCredentials.AppInstallationToken("",
+        token = new GitHubAppCredentials.AppInstallationToken(secret,
             now + GitHubAppCredentials.AppInstallationToken.STALE_BEFORE_EXPIRATION_SECONDS + 2);
         assertThat(token.isStale(), is(false));
         assertThat(token.getTokenStaleEpochSeconds(), equalTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS));
 
         now = Instant.now().getEpochSecond();
-        token = new GitHubAppCredentials.AppInstallationToken("",
+        token = new GitHubAppCredentials.AppInstallationToken(secret,
             now + GitHubAppCredentials.AppInstallationToken.STALE_BEFORE_EXPIRATION_SECONDS + Duration
                 .ofMinutes(7)
                 .getSeconds());
@@ -43,7 +45,7 @@ public class GithubAppCredentialsAppInstallationTokenTest {
             equalTo(now + Duration.ofMinutes(7).getSeconds()));
 
         now = Instant.now().getEpochSecond();
-        token = new GitHubAppCredentials.AppInstallationToken("",
+        token = new GitHubAppCredentials.AppInstallationToken(secret,
             now + Duration.ofMinutes(90).getSeconds());
         assertThat(token.isStale(), is(false));
         assertThat(token.getTokenStaleEpochSeconds(),
@@ -55,7 +57,7 @@ public class GithubAppCredentialsAppInstallationTokenTest {
             GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = -10;
 
             now = Instant.now().getEpochSecond();
-            token = new GitHubAppCredentials.AppInstallationToken("", now);
+            token = new GitHubAppCredentials.AppInstallationToken(secret, now);
             assertThat(token.isStale(), is(false));
             assertThat(token.getTokenStaleEpochSeconds(), equalTo(now + 1));
 


### PR DESCRIPTION
# Description
Follow on to #326. We shouldn't keep the app installation token as a bare `String`.  
I don't think this is a huge deal given how `Secret` is actually stored and serialized, but this is more correct regardless.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

