### PR TITLE
[JENKINS-63711] Cleanup GitHub App Credential cache folders 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -56,7 +56,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -74,7 +73,6 @@ import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.util.JenkinsJVM;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.github.config.GitHubServerConfig;
@@ -109,8 +107,6 @@ public class Connector {
     private static final Random ENTROPY = new Random();
     private static final String SALT = Long.toHexString(ENTROPY.nextLong());
     private static final OkHttpClient baseClient = new OkHttpClient();
-    private static final File cacheBase = new File(Jenkins.get().getRootDir(),
-        GitHubSCMProbe.class.getName() + ".cache");
 
 
     private Connector() {
@@ -430,6 +426,8 @@ public class Connector {
         Cache cache = null;
         int cacheSize = GitHubSCMSource.getCacheSize();
         if (cacheSize > 0) {
+            File cacheBase = new File(jenkins.getRootDir(),
+                    GitHubSCMProbe.class.getName() + ".cache");
             File cacheDir = null;
             try {
                 MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
@@ -580,8 +578,6 @@ public class Connector {
     @Extension
     public static class UnusedConnectionDestroyer extends PeriodicWork {
 
-        private static boolean hasRun = false;
-
         @Override
         public long getRecurrencePeriod() {
             return TimeUnit.MINUTES.toMillis(2);
@@ -591,8 +587,9 @@ public class Connector {
         protected void doRun() throws Exception {
             // free any connection unused for the last 5 minutes
             long threshold = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5);
-            GitHubConnection.removeAllUnused(threshold, !hasRun);
-            hasRun = true;
+            synchronized (connections) {
+                GitHubConnection.removeAllUnused(threshold);
+            }
         }
     }
 
@@ -651,52 +648,23 @@ public class Connector {
             }
         }
 
-        /**
-         * Remove all unused connections from the connection cache and delete their cache folders.
-         *
-         * @param threshold connections should be removed if their the last used time was before
-         *                  this system time in milliseconds.
-         * @param removeUntracked if true, also delete any cache folders that do not have
-         *                        corresponding connections. This operation can be expensive so it
-         *                        should be run as rarely as possible.
-         */
-        private static void removeAllUnused(long threshold, boolean removeUntracked) {
-            Map<String, File> validCaches = new HashMap<>();
-            synchronized (connections) {
-                for (Iterator<Map.Entry<ConnectionId, GitHubConnection>> iterator = connections.entrySet()
-                    .iterator();
-                     iterator.hasNext(); ) {
-                    Map.Entry<ConnectionId, GitHubConnection> entry = iterator.next();
-                    try {
-                        GitHubConnection record = Objects.requireNonNull(entry.getValue());
-                        if (record.cache != null) {
-                            long lastUse = record.lastUsed;
-                            if (record.usageCount == 0 && lastUse < threshold) {
-                                iterator.remove();
-                                reverseLookup.remove(record.gitHub);
-                                if (record.cleanupCacheFolder) {
-                                    record.cache.delete();
-                                    record.cache.close();
-                                }
-                            } else if (removeUntracked) {
-                                validCaches.put(record.cache.directory().getAbsolutePath(),
-                                    record.cache.directory());
-                            }
-                        }
-                    } catch (IOException | NullPointerException e) {
-                        LOGGER.log(WARNING, "Exception for cache directory: " + entry.getKey(), e);
-                    }
-                }
-            }
-
-            if (removeUntracked) {
-                File[] directories = cacheBase.listFiles(File::isDirectory);
-                if (directories != null) {
-                    for (File dir : directories) {
-                        if(!validCaches.containsKey(dir.getAbsolutePath())) {
-                            FileUtils.deleteQuietly(dir);
+        private static void removeAllUnused(long threshold) throws IOException {
+            for (Iterator<Map.Entry<ConnectionId, GitHubConnection>> iterator = connections.entrySet().iterator();
+                 iterator.hasNext(); ) {
+                Map.Entry<ConnectionId, GitHubConnection> entry = iterator.next();
+                try {
+                    GitHubConnection record = Objects.requireNonNull(entry.getValue());
+                    long lastUse = record.lastUsed;
+                    if (record.usageCount == 0 && lastUse < threshold) {
+                        iterator.remove();
+                        reverseLookup.remove(record.gitHub);
+                        if (record.cache != null && record.cleanupCacheFolder) {
+                            record.cache.delete();
+                            record.cache.close();
                         }
                     }
+                } catch (IOException | NullPointerException e) {
+                    LOGGER.log(WARNING, "Exception removing cache directory for unused connection: " + entry.getKey(), e);
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -90,9 +90,9 @@ import static java.util.logging.Level.FINE;
 public class Connector {
     private static final Logger LOGGER = Logger.getLogger(Connector.class.getName());
 
-    private static final Map<GitHub,Long> lastUsed = new HashMap<>();
-    private static final Map<ConnectionId, GitHub> githubs = new HashMap<>();
-    private static final Map<GitHub, Integer> usage = new HashMap<>();
+    private static final Map<ConnectionId, GitHubConnection> connections = new HashMap<>();
+    private static final Map<GitHub, GitHubConnection> reverseLookup = new HashMap<>();
+
     private static final Map<TaskListener, Map<GitHub,Void>> checked = new WeakHashMap<>();
     private static final long API_URL_REVALIDATE_MILLIS = TimeUnit.MINUTES.toMillis(5);
     private static final Map<String,Long> apiUrlValid = new LinkedHashMap<String,Long>(){
@@ -357,28 +357,24 @@ public class Connector {
             // TODO OAuth support
             throw new IOException("Unsupported credential type: " + credentials.getClass().getName());
         }
-        synchronized (githubs) {
-            ConnectionId connectionId = new ConnectionId(apiUrl, hash);
-            GitHub hub = githubs.get(connectionId);
-            if (hub != null) {
-                Integer count = usage.get(hub);
-                usage.put(hub, count == null ? 1 : Math.max(count + 1, 1));
-                return hub;
+
+        ConnectionId connectionId = new ConnectionId(apiUrl, hash);
+
+        synchronized (connections) {
+            GitHubConnection record = GitHubConnection.lookup(connectionId);
+            if (record == null) {
+                Cache cache = getCache(jenkins, apiUrl, authHash, username);
+
+                GitHubBuilder gb = createGitHubBuilder(apiUrl, cache);
+
+                if (username != null) {
+                    gb.withPassword(username, password);
+                }
+
+                record = GitHubConnection.connect(connectionId, gb.build(), cache);
             }
 
-            Cache cache = getCache(jenkins, apiUrl, authHash, username);
-
-            GitHubBuilder gb = createGitHubBuilder(apiUrl, cache);
-
-            if (username != null) {
-                gb.withPassword(username, password);
-            }
-
-            hub = gb.build();
-            githubs.put(connectionId, hub);
-            usage.put(hub, 1);
-            lastUsed.remove(hub);
-            return hub;
+            return record.getGitHub();
         }
     }
 
@@ -455,44 +451,11 @@ public class Connector {
         if (hub == null) {
             return;
         }
-        synchronized (githubs) {
-            Integer count = usage.get(hub);
-            if (count == null) {
-                // it was untracked, forget about it
-                return;
-            }
-            if (count <= 1) {
-                // exclusive
-                usage.put(hub, 0);
-                lastUsed.put(hub, System.currentTimeMillis());
-            } else {
-                // shared
-                usage.put(hub, count - 1);
-            }
-        }
-    }
 
-    private static void unused(@Nonnull GitHub hub) {
-        synchronized (githubs) {
-            Integer count = usage.get(hub);
-            if (count == null) {
-                // it was untracked, forget about it
-                return;
-            }
-            if (count <= 1) {
-                // only remove if it is actually unused now
-                // exclusive
-                usage.remove(hub);
-                // we could use multiple maps, but we expect only a handful of entries and mostly the shared path
-                // so we can just walk the forward map
-                for (Iterator<Map.Entry<ConnectionId, GitHub>> iterator = githubs.entrySet().iterator();
-                     iterator.hasNext(); ) {
-                    Map.Entry<ConnectionId, GitHub> entry = iterator.next();
-                    if (hub == entry.getValue()) {
-                        iterator.remove();
-                        break;
-                    }
-                }
+        synchronized (connections) {
+            GitHubConnection record = reverseLookup.get(hub);
+            if (record != null) {
+                record.release();
             }
         }
     }
@@ -571,7 +534,7 @@ public class Connector {
                                                     StandardCredentials credentials,
                                                     GitHub github)
             throws IOException {
-        synchronized (githubs) {
+        synchronized (checked) {
             Map<GitHub,Void> hubs = checked.get(listener);
             if (hubs != null && hubs.containsKey(github)) {
                 // only check if not already in use
@@ -615,22 +578,80 @@ public class Connector {
 
         @Override
         public long getRecurrencePeriod() {
-            return TimeUnit.SECONDS.toMillis(15);
+            return TimeUnit.MINUTES.toMillis(2);
         }
 
         @Override
         protected void doRun() throws Exception {
             // free any connection unused for the last 5 minutes
             long threshold = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5);
-            synchronized (githubs) {
-                for (Iterator<Map.Entry<GitHub, Long>> iterator = lastUsed.entrySet().iterator();
-                     iterator.hasNext(); ) {
-                    Map.Entry<GitHub, Long> entry = iterator.next();
-                    Long lastUse = entry.getValue();
-                    if (lastUse == null || lastUse < threshold) {
-                        iterator.remove();
-                        unused(entry.getKey());
-                    }
+            synchronized (connections) {
+                GitHubConnection.removeAllUnused(threshold);
+            }
+        }
+    }
+
+    private static class GitHubConnection {
+        @NonNull
+        private final GitHub gitHub;
+
+        @CheckForNull
+        private final Cache cache;
+
+        private int usageCount = 1;
+        private Long lastUsed = System.currentTimeMillis();
+
+        private GitHubConnection(GitHub gitHub, Cache cache) {
+            this.gitHub = gitHub;
+            this.cache = cache;
+        }
+
+        /**
+         * Gets the {@link GitHub} instance for this connection
+         *
+         * @return the {@link GitHub} instance
+         */
+        public GitHub getGitHub() {
+            return gitHub;
+        }
+
+        @CheckForNull
+        private static GitHubConnection lookup(@NonNull ConnectionId connectionId) {
+            GitHubConnection record;
+            record = connections.get(connectionId);
+            if (record != null) {
+                record.usageCount += 1;
+                record.lastUsed = System.currentTimeMillis();
+            }
+            return record;
+        }
+
+        @NonNull
+        private static GitHubConnection connect(@NonNull ConnectionId connectionId, @NonNull GitHub gitHub, @CheckForNull Cache cache) {
+            GitHubConnection record = new GitHubConnection(gitHub, cache);
+            connections.put(connectionId, record);
+            reverseLookup.put(record.gitHub, record);
+            return record;
+        }
+
+
+        private void release() {
+            if (this.usageCount <= 1) {
+                this.usageCount = 0;
+                this.lastUsed = System.currentTimeMillis();
+            } else {
+                this.usageCount -= 1;
+            }
+        }
+
+        private static void removeAllUnused(long threshold) {
+            for (Iterator<Map.Entry<ConnectionId, GitHubConnection>> iterator = connections.entrySet().iterator();
+                 iterator.hasNext(); ) {
+                GitHubConnection record = Objects.requireNonNull(iterator.next().getValue());
+                Long lastUse = record.lastUsed;
+                if (record.usageCount == 0 && lastUse < threshold) {
+                    iterator.remove();
+                    reverseLookup.remove(record.gitHub);
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -644,7 +644,7 @@ public class Connector {
             }
         }
 
-        private static void removeAllUnused(long threshold) {
+        private static void removeAllUnused(long threshold) throws IOException {
             for (Iterator<Map.Entry<ConnectionId, GitHubConnection>> iterator = connections.entrySet().iterator();
                  iterator.hasNext(); ) {
                 GitHubConnection record = Objects.requireNonNull(iterator.next().getValue());
@@ -652,6 +652,10 @@ public class Connector {
                 if (record.usageCount == 0 && lastUse < threshold) {
                     iterator.remove();
                     reverseLookup.remove(record.gitHub);
+                    if (record.cache != null) {
+                        record.cache.delete();
+                        record.cache.close();
+                    }
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -601,7 +601,7 @@ public class Connector {
 
         private final boolean cleanupCacheFolder;
         private int usageCount = 1;
-        private Long lastUsed = System.currentTimeMillis();
+        private long lastUsed = System.currentTimeMillis();
 
         private GitHubConnection(GitHub gitHub, Cache cache, boolean cleanupCacheFolder) {
             this.gitHub = gitHub;
@@ -651,7 +651,7 @@ public class Connector {
             for (Iterator<Map.Entry<ConnectionId, GitHubConnection>> iterator = connections.entrySet().iterator();
                  iterator.hasNext(); ) {
                 GitHubConnection record = Objects.requireNonNull(iterator.next().getValue());
-                Long lastUse = record.lastUsed;
+                long lastUse = record.lastUsed;
                 if (record.usageCount == 0 && lastUse < threshold) {
                     iterator.remove();
                     reverseLookup.remove(record.gitHub);


### PR DESCRIPTION
# Description
Before GitHub App Credentials, cache folders not being cleaned up was okay.  It was sometimes even an advantage since cached values that were extremely stable didn't have to be reloaded even across connection instances.  However, with  GitHub App Credentials the password (token) is regenerated on a regular basis, resulting in new connections with new caches.  

This change cleans up cache folders when GitHub App connections are no longer used. Behavior for non-GitHubAppCredential connections is unchanged to preserve the advantages of the existing behavior for standard credentials.

See [JENKINS-63711](https://issues.jenkins-ci.org/browse/JENKINS-63711) for further information. 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

