### PR TITLE
Diagnostics for GHFileNotFoundException from retrieve

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -35,6 +35,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.Extension;
+import hudson.Functions;
 import hudson.RestrictedSince;
 import hudson.Util;
 import hudson.console.HyperlinkNote;
@@ -1037,7 +1038,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                                 retrievePullRequest(github, ghRepository, pr, strategies, request, listener);
                             } catch (FileNotFoundException e) {
                                 listener.getLogger().format("%n  Error while processing pull request %d%n", number);
-                                listener.getLogger().format("%n  Reason: %s%n", e);
+                                Functions.printStackTrace(e, listener.getLogger());
                                 errorCount++;
                             }
                             count++;


### PR DESCRIPTION
https://github.com/jenkinsci/github-label-filter-plugin/pull/4 got as far as printing

```
Reason: org.kohsuke.github.GHFileNotFoundException: https://api.github.com/repos/…/…/issues/… {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/reference/issues#get-an-issue"}
```

CC @jvz
