### PR TITLE
Stop specifying the core version in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(configurations: [
     [ platform: "linux", jdk: "8"],
     [ platform: "windows", jdk: "8"],
-    [ platform: "linux", jdk: "11", jenkins: "2.176.4", javaLevel: "8" ]
+    [ platform: "linux", jdk: "11", javaLevel: "8" ]
 ])


### PR DESCRIPTION
https://github.com/jenkinsci/github-branch-source-plugin/pull/360#pullrequestreview-549550534

The current config does absolutely nothing as that's what the pom is pointing to