### PR TITLE
Fix connection caching - too many calls to release()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
@@ -208,9 +208,8 @@ public class GitHubBuildStatusNotification {
             Computer.threadPoolForRemoting.submit(new Runnable() {
                 @Override
                 public void run() {
-                    GitHub gitHub = null;
                     try {
-                        gitHub = lookUpGitHub(job);
+                        GitHub gitHub = lookUpGitHub(job);
                         try {
                             if (gitHub == null || gitHub.rateLimit().remaining < 8) {
                                 // we are an optimization to signal commit status early, no point waiting for
@@ -253,7 +252,8 @@ public class GitHubBuildStatusNotification {
                                     }
                                 }
                             }
-                        } finally {
+                        }
+                        finally {
                             Connector.release(gitHub);
                         }
                     } catch (FileNotFoundException e) {
@@ -269,8 +269,6 @@ public class GitHubBuildStatusNotification {
                                 "Could not update commit status to PENDING. Rate limit exhausted",
                                 LOGGER.isLoggable(Level.FINE) ? e : null);
                         LOGGER.log(Level.FINE, null, e);
-                    } finally {
-                        Connector.release(gitHub);
                     }
                 }
             });

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
@@ -252,8 +252,7 @@ public class GitHubBuildStatusNotification {
                                     }
                                 }
                             }
-                        }
-                        finally {
+                        } finally {
                             Connector.release(gitHub);
                         }
                     } catch (FileNotFoundException e) {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbe.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbe.java
@@ -25,6 +25,7 @@
 
 package org.jenkinsci.plugins.github_branch_source;
 
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.plugins.git.AbstractGitSCMSource;
@@ -57,8 +58,12 @@ class GitHubSCMProbe extends SCMProbe implements GitHubClosable {
     private final String name;
     private transient boolean open = true;
 
-    public GitHubSCMProbe(GitHub github, GHRepository repo, SCMHead head, SCMRevision revision) {
-        this.gitHub = github;
+    public GitHubSCMProbe(String apiUri,
+                          StandardCredentials credentials,
+                          GHRepository repo,
+                          SCMHead head,
+                          SCMRevision revision) throws IOException {
+        this.gitHub = Connector.connect(apiUri, credentials);
         this.revision = revision;
         this.repo = repo;
         this.name = head.getName();

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbeTest.java
@@ -56,9 +56,9 @@ public class GitHubSCMProbeTest {
 
         final GHRepository repo = github.getRepository("cloudbeers/yolo");
         final PullRequestSCMHead head = new PullRequestSCMHead("PR-" + number, "cloudbeers", "yolo", "b", number, new BranchSCMHead("master"), new SCMHeadOrigin.Fork("rsandell"), ChangeRequestCheckoutStrategy.MERGE);
-        probe = new GitHubSCMProbe(github, repo,
-            head,
-            new PullRequestSCMRevision(head, "a", "b"));
+        probe = new GitHubSCMProbe("http://localhost:" + githubApi.port(), null,
+            repo,
+            head, new PullRequestSCMRevision(head, "a", "b"));
     }
 
     @Issue("JENKINS-54126")


### PR DESCRIPTION

# Description

The calls to connect and release for GitHub connections were not matched up.
We ended up having a few code paths with multiple release calls, resulting in errors.

This change fixes the mismatches and makes it less likely that future changes will break this.
it also makes the cache cleaning less aggressive, so that if this does occur again connections will be
less likely to get closed while still in use.

@timja Please try this as an incremental build to see if it addresses the issue. 

See 
[JENKINS-64595](https://issues.jenkins-ci.org/browse/JENKINS-64595) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

