### PR TITLE
JENKINS-64662 Create GitHub App Credentials Binding to support owner override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
             <version>1.122</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials-binding</artifactId>
+        </dependency>        
+        <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
             <version>1.32.0</version>

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding.java
@@ -1,0 +1,121 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
+import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:naresh.rayapati@gmail.com">Naresh Rayapati</a>
+ */
+public class GitHubAppCredentialsBinding extends MultiBinding<GitHubAppCredentials> {
+
+    private final static String DEFAULT_GITHUB_APP_ID_VARIABLE_NAME = "GITHUB_APP_ID";
+    private final static String DEFAULT_GITHUB_TOKEN_VARIABLE_NAME = "GITHUB_TOKEN";
+    private final static String DEFAULT_GITHUB_OWNER_VARIABLE_NAME = "GITHUB_OWNER";
+
+    @NonNull
+    private final String appIdVariable;
+
+    @NonNull
+    private final String tokenVariable;
+
+    @NonNull
+    private final String ownerVariable;
+
+    private final String owner;
+
+    /**
+     *
+     * @param appIdVariable if {@code null}, {@value DEFAULT_GITHUB_APP_ID_VARIABLE_NAME} will be used.
+     * @param tokenVariable if {@code null}, {@value DEFAULT_GITHUB_TOKEN_VARIABLE_NAME} will be used.
+     * @param owner if {@code null}, that default value configured at credentials level will be used if any.
+     * @param credentialsId identifier which should be referenced when accessing the credentials from a job/pipeline.
+     */
+    @DataBoundConstructor
+    public GitHubAppCredentialsBinding(@Nullable String appIdVariable, @Nullable String tokenVariable, @Nullable String ownerVariable, @Nullable String owner, String credentialsId) {
+        super(credentialsId);
+        this.appIdVariable = StringUtils.defaultIfBlank(appIdVariable, DEFAULT_GITHUB_APP_ID_VARIABLE_NAME);
+        this.tokenVariable = StringUtils.defaultIfBlank(tokenVariable, DEFAULT_GITHUB_TOKEN_VARIABLE_NAME);
+        this.ownerVariable = StringUtils.defaultIfBlank(ownerVariable, DEFAULT_GITHUB_OWNER_VARIABLE_NAME);
+        this.owner = owner;
+    }
+
+    @NonNull
+    public String getAppIdVariable() {
+        return appIdVariable;
+    }
+
+    @NonNull
+    public String getTokenVariable() {
+        return tokenVariable;
+    }
+
+    @NonNull
+    public String getOwnerVariable() {
+        return ownerVariable;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    @Override
+    protected Class<GitHubAppCredentials> type() {
+        return GitHubAppCredentials.class;
+    }
+
+    @Override
+    public MultiEnvironment bind(@Nonnull Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException {
+        GitHubAppCredentials credentials = getCredentials(build);
+        Map<String,String> m = new HashMap<String,String>();
+        m.put(appIdVariable, credentials.getAppID());
+        if(StringUtils.isNotEmpty(owner)) {
+            m.put(tokenVariable, credentials.getPassword(owner).getPlainText());
+            m.put(ownerVariable, owner);
+        } else {
+            m.put(tokenVariable, credentials.getPassword().getPlainText());
+            m.put(ownerVariable, credentials.getOwner());
+        }
+
+        return new MultiEnvironment(m);
+    }
+
+    @Override
+    public Set<String> variables() {
+        return new HashSet<String>(Arrays.asList(appIdVariable, tokenVariable, ownerVariable));
+    }
+
+    @Symbol("gitHubApp")
+    @Extension
+    public static class DescriptorImpl extends BindingDescriptor<GitHubAppCredentials> {
+
+        @Override protected Class<GitHubAppCredentials> type() {
+            return GitHubAppCredentials.class;
+        }
+
+        @Override public String getDisplayName() {
+            return "GitHub App Credentials";
+        }
+
+        @Override public boolean requiresWorkspace() {
+            return false;
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/config-variables.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/config-variables.jelly
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:c="/lib/credentials">
+  <f:entry title="${%GitHub App Id Variable}" field="appIdVariable">
+    <f:textbox default="GITHUB_APP_ID"/>
+  </f:entry>
+  <f:entry title="${%GitHub Token Variable}" field="tokenVariable">
+    <f:textbox default="GITHUB_TOKEN"/>
+  </f:entry>
+  <f:entry title="${%GitHub Owner Variable}" field="ownerVariable">
+    <f:textbox default="GITHUB_OWNER"/>
+  </f:entry>
+  <f:entry title="${%GitHub Owner Override}" field="owner">
+     <f:textbox default=""/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/help-appIdVariable.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/help-appIdVariable.html
@@ -1,0 +1,3 @@
+<div>
+    Environment variable name for the GitHub App Id. If empty, <code>GITHUB_APP_ID</code> will be used.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/help-owner.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/help-owner.html
@@ -1,0 +1,3 @@
+<div>
+    Input to override the default owner name configured for the given GitHub App credentials.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/help-ownerVariable.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/help-ownerVariable.html
@@ -1,0 +1,3 @@
+<div>
+    Environment variable name for the GitHub App Owner. If empty, <code>GITHUB_OWNER</code> will be used.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/help-tokenVariable.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/help-tokenVariable.html
@@ -1,0 +1,3 @@
+<div>
+    Environment variable name for the GitHub token for given App. If empty, <code>GITHUB_TOKEN</code> will be used.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsBinding/help.html
@@ -1,0 +1,3 @@
+<div>
+    Sets GitHup App Id, Token and Owner from the given in the credentials. Owner is input to override the default configured with credentials.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsAppInstallationTokenTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsAppInstallationTokenTest.java
@@ -18,25 +18,26 @@ public class GithubAppCredentialsAppInstallationTokenTest {
         long now;
 
         now = Instant.now().getEpochSecond();
+        String owner = "test";
         Secret secret = Secret.fromString("secret-token");
-        token = new GitHubAppCredentials.AppInstallationToken(secret, now);
+        token = new GitHubAppCredentials.AppInstallationToken(owner, secret, now);
         assertThat(token.isStale(), is(false));
         assertThat(token.getTokenStaleEpochSeconds(), equalTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS));
 
         now = Instant.now().getEpochSecond();
-        token = new GitHubAppCredentials.AppInstallationToken(secret,
+        token = new GitHubAppCredentials.AppInstallationToken(owner, secret,
             now + Duration.ofMinutes(15).getSeconds());
         assertThat(token.isStale(), is(false));
         assertThat(token.getTokenStaleEpochSeconds(), equalTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS));
 
         now = Instant.now().getEpochSecond();
-        token = new GitHubAppCredentials.AppInstallationToken(secret,
+        token = new GitHubAppCredentials.AppInstallationToken(owner, secret,
             now + GitHubAppCredentials.AppInstallationToken.STALE_BEFORE_EXPIRATION_SECONDS + 2);
         assertThat(token.isStale(), is(false));
         assertThat(token.getTokenStaleEpochSeconds(), equalTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS));
 
         now = Instant.now().getEpochSecond();
-        token = new GitHubAppCredentials.AppInstallationToken(secret,
+        token = new GitHubAppCredentials.AppInstallationToken(owner, secret,
             now + GitHubAppCredentials.AppInstallationToken.STALE_BEFORE_EXPIRATION_SECONDS + Duration
                 .ofMinutes(7)
                 .getSeconds());
@@ -45,7 +46,7 @@ public class GithubAppCredentialsAppInstallationTokenTest {
             equalTo(now + Duration.ofMinutes(7).getSeconds()));
 
         now = Instant.now().getEpochSecond();
-        token = new GitHubAppCredentials.AppInstallationToken(secret,
+        token = new GitHubAppCredentials.AppInstallationToken(owner, secret,
             now + Duration.ofMinutes(90).getSeconds());
         assertThat(token.isStale(), is(false));
         assertThat(token.getTokenStaleEpochSeconds(),
@@ -57,7 +58,7 @@ public class GithubAppCredentialsAppInstallationTokenTest {
             GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = -10;
 
             now = Instant.now().getEpochSecond();
-            token = new GitHubAppCredentials.AppInstallationToken(secret, now);
+            token = new GitHubAppCredentials.AppInstallationToken(owner, secret, now);
             assertThat(token.isStale(), is(false));
             assertThat(token.getTokenStaleEpochSeconds(), equalTo(now + 1));
 


### PR DESCRIPTION
# Description

Create GitHub App Credentials Binding to support owner override
See [JENKINS-64662](https://issues.jenkins-ci.org/browse/JENKINS-64662) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [x] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

![Screen Shot 2021-01-22 at 8 47 08 PM](https://user-images.githubusercontent.com/4974191/105566744-636f9f00-5cf3-11eb-88a0-7cff9030eeea.png)
