### PR TITLE
fix: use constants not magic numbers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchDiscoveryTrait.java
@@ -53,6 +53,23 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class BranchDiscoveryTrait extends SCMSourceTrait {
     /**
+     * None strategy.
+    */
+    public static final int NONE = 0;
+    /**
+     * Exclude branches that are also filed as PRs.
+    */
+    public static final int EXCLUDE_PRS = 1;
+    /**
+     * Only branches that are also filed as PRs.
+    */
+    public static final int ONLYP_RS = 2;
+    /**
+     * All branches.
+    */
+    public static final int ALL_BRANCHES = 3;
+    
+    /**
      * The strategy encoded as a bit-field.
      */
     private final int strategyId;
@@ -74,7 +91,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
      * @param buildBranchWithPr build branches that are also PRs.
      */
     public BranchDiscoveryTrait(boolean buildBranch, boolean buildBranchWithPr) {
-        this.strategyId = (buildBranch ? 1 : 0) + (buildBranchWithPr ? 2 : 0);
+        this.strategyId = (buildBranch ? EXCLUDE_PRS : NONE) + (buildBranchWithPr ? ONLYP_RS : NONE);
     }
 
     /**
@@ -93,7 +110,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
      */
     @Restricted(NoExternalUse.class)
     public boolean isBuildBranch() {
-        return (strategyId & 1) != 0;
+        return (strategyId & EXCLUDE_PRS) != NONE;
     }
 
     /**
@@ -103,7 +120,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
      */
     @Restricted(NoExternalUse.class)
     public boolean isBuildBranchesWithPR() {
-        return (strategyId & 2) != 0;
+        return (strategyId & ONLYP_RS) != NONE;
     }
 
     /**
@@ -115,15 +132,15 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
         ctx.wantBranches(true);
         ctx.withAuthority(new BranchSCMHeadAuthority());
         switch (strategyId) {
-            case 1:
+            case BranchDiscoveryTrait.EXCLUDE_PRS:
                 ctx.wantOriginPRs(true);
                 ctx.withFilter(new ExcludeOriginPRBranchesSCMHeadFilter());
                 break;
-            case 2:
+            case BranchDiscoveryTrait.ONLYP_RS:
                 ctx.wantOriginPRs(true);
                 ctx.withFilter(new OnlyOriginPRBranchesSCMHeadFilter());
                 break;
-            case 3:
+            case BranchDiscoveryTrait.ALL_BRANCHES:
             default:
                 // we don't care if it is a PR or not, we're taking them all, no need to ask for PRs and no need
                 // to filter
@@ -181,9 +198,9 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
         @SuppressWarnings("unused") // stapler
         public ListBoxModel doFillStrategyIdItems() {
             ListBoxModel result = new ListBoxModel();
-            result.add(Messages.BranchDiscoveryTrait_excludePRs(), "1");
-            result.add(Messages.BranchDiscoveryTrait_onlyPRs(), "2");
-            result.add(Messages.BranchDiscoveryTrait_allBranches(), "3");
+            result.add(Messages.BranchDiscoveryTrait_excludePRs(), String.valueOf(EXCLUDE_PRS));
+            result.add(Messages.BranchDiscoveryTrait_onlyPRs(), String.valueOf(ONLYP_RS));
+            result.add(Messages.BranchDiscoveryTrait_allBranches(), String.valueOf(ALL_BRANCHES));
             return result;
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait.java
@@ -57,6 +57,22 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
     /**
+     * None strategy.
+    */
+    public static final int NONE = 0;
+    /**
+     * Merging the pull request with the current target branch revision.
+    */
+    public static final int MERGE = 1;
+    /**
+     * The current pull request revision.
+    */
+    public static final int HEAD = 2;
+    /**
+     * Both the current pull request revision and the pull request merged with the current target branch revision.
+    */
+    public static final int HEAD_AND_MERGE = 3;
+    /**
      * The strategy encoded as a bit-field.
      */
     private final int strategyId;
@@ -87,8 +103,8 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
      */
     public ForkPullRequestDiscoveryTrait(@NonNull Set<ChangeRequestCheckoutStrategy> strategies,
                                          @NonNull SCMHeadAuthority<? super GitHubSCMSourceRequest, ? extends ChangeRequestSCMHead2, ? extends SCMRevision> trust) {
-        this((strategies.contains(ChangeRequestCheckoutStrategy.MERGE) ? 1 : 0)
-                + (strategies.contains(ChangeRequestCheckoutStrategy.HEAD) ? 2 : 0), trust);
+        this((strategies.contains(ChangeRequestCheckoutStrategy.MERGE) ? MERGE : NONE)
+                + (strategies.contains(ChangeRequestCheckoutStrategy.HEAD) ? HEAD : NONE), trust);
     }
 
     /**
@@ -108,11 +124,11 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
     @NonNull
     public Set<ChangeRequestCheckoutStrategy> getStrategies() {
         switch (strategyId) {
-            case 1:
+            case ForkPullRequestDiscoveryTrait.MERGE:
                 return EnumSet.of(ChangeRequestCheckoutStrategy.MERGE);
-            case 2:
+            case ForkPullRequestDiscoveryTrait.HEAD:
                 return EnumSet.of(ChangeRequestCheckoutStrategy.HEAD);
-            case 3:
+            case ForkPullRequestDiscoveryTrait.HEAD_AND_MERGE:
                 return EnumSet.of(ChangeRequestCheckoutStrategy.HEAD, ChangeRequestCheckoutStrategy.MERGE);
             default:
                 return EnumSet.noneOf(ChangeRequestCheckoutStrategy.class);
@@ -190,9 +206,9 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
         @SuppressWarnings("unused") // stapler
         public ListBoxModel doFillStrategyIdItems() {
             ListBoxModel result = new ListBoxModel();
-            result.add(Messages.ForkPullRequestDiscoveryTrait_mergeOnly(), "1");
-            result.add(Messages.ForkPullRequestDiscoveryTrait_headOnly(), "2");
-            result.add(Messages.ForkPullRequestDiscoveryTrait_headAndMerge(), "3");
+            result.add(Messages.ForkPullRequestDiscoveryTrait_mergeOnly(), String.valueOf(MERGE));
+            result.add(Messages.ForkPullRequestDiscoveryTrait_headOnly(), String.valueOf(HEAD));
+            result.add(Messages.ForkPullRequestDiscoveryTrait_headAndMerge(), String.valueOf(HEAD_AND_MERGE));
             return result;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait.java
@@ -55,6 +55,23 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class OriginPullRequestDiscoveryTrait extends SCMSourceTrait {
     /**
+     * None strategy.
+    */
+    public static final int NONE = 0;
+    /**
+     * Merging the pull request with the current target branch revision.
+    */
+    public static final int MERGE = 1;
+    /**
+     * The current pull request revision.
+    */
+    public static final int HEAD = 2;
+    /**
+     * Both the current pull request revision and the pull request merged with the current target branch revision.
+    */
+    public static final int HEAD_AND_MERGE = 3;
+    
+    /**
      * The strategy encoded as a bit-field.
      */
     private final int strategyId;
@@ -75,8 +92,8 @@ public class OriginPullRequestDiscoveryTrait extends SCMSourceTrait {
      * @param strategies the {@link ChangeRequestCheckoutStrategy} instances.
      */
     public OriginPullRequestDiscoveryTrait(Set<ChangeRequestCheckoutStrategy> strategies) {
-        this((strategies.contains(ChangeRequestCheckoutStrategy.MERGE) ? 1 : 0)
-                + (strategies.contains(ChangeRequestCheckoutStrategy.HEAD) ? 2 : 0));
+        this((strategies.contains(ChangeRequestCheckoutStrategy.MERGE) ? MERGE : NONE)
+                + (strategies.contains(ChangeRequestCheckoutStrategy.HEAD) ? HEAD : NONE));
     }
 
     /**
@@ -96,11 +113,11 @@ public class OriginPullRequestDiscoveryTrait extends SCMSourceTrait {
     @NonNull
     public Set<ChangeRequestCheckoutStrategy> getStrategies() {
         switch (strategyId) {
-            case 1:
+            case OriginPullRequestDiscoveryTrait.MERGE:
                 return EnumSet.of(ChangeRequestCheckoutStrategy.MERGE);
-            case 2:
+            case OriginPullRequestDiscoveryTrait.HEAD:
                 return EnumSet.of(ChangeRequestCheckoutStrategy.HEAD);
-            case 3:
+            case OriginPullRequestDiscoveryTrait.HEAD_AND_MERGE:
                 return EnumSet.of(ChangeRequestCheckoutStrategy.HEAD, ChangeRequestCheckoutStrategy.MERGE);
             default:
                 return EnumSet.noneOf(ChangeRequestCheckoutStrategy.class);
@@ -168,9 +185,9 @@ public class OriginPullRequestDiscoveryTrait extends SCMSourceTrait {
         @SuppressWarnings("unused") // stapler
         public ListBoxModel doFillStrategyIdItems() {
             ListBoxModel result = new ListBoxModel();
-            result.add(Messages.ForkPullRequestDiscoveryTrait_mergeOnly(), "1");
-            result.add(Messages.ForkPullRequestDiscoveryTrait_headOnly(), "2");
-            result.add(Messages.ForkPullRequestDiscoveryTrait_headAndMerge(), "3");
+            result.add(Messages.ForkPullRequestDiscoveryTrait_mergeOnly(), String.valueOf(MERGE));
+            result.add(Messages.ForkPullRequestDiscoveryTrait_headOnly(), String.valueOf(HEAD));
+            result.add(Messages.ForkPullRequestDiscoveryTrait_headAndMerge(), String.valueOf(HEAD_AND_MERGE));
             return result;
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTraitsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTraitsTest.java
@@ -1641,7 +1641,7 @@ public class GitHubSCMNavigatorTraitsTest {
     @Test
     public void given__instance__when__setTraits__then__traitsSet() {
         GitHubSCMNavigator instance = new GitHubSCMNavigator("test");
-        instance.setTraits(Arrays.asList(new BranchDiscoveryTrait(1),
+        instance.setTraits(Arrays.asList(new BranchDiscoveryTrait(BranchDiscoveryTrait.EXCLUDE_PRS),
                 new SSHCheckoutTrait(null)));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
@@ -540,7 +540,7 @@ public class GitHubSCMSourceTraitsTest {
     @Test
     public void given__instance__when__setTraits__then__traitsSet() {
         GitHubSCMSource instance = new GitHubSCMSource("testing", "test-repo");
-        instance.setTraits(Arrays.asList(new BranchDiscoveryTrait(1),
+        instance.setTraits(Arrays.asList(new BranchDiscoveryTrait(BranchDiscoveryTrait.EXCLUDE_PRS),
                 new SSHCheckoutTrait("value")));
         assertThat(instance.getTraits(),
                 containsInAnyOrder(


### PR DESCRIPTION
# Description

Minor refactor replace magic numbers with constants. They will appear in the Java docs making it easier to know which value is for what.

A brief summary describing the changes in this pull request. See 
[JENKINS-64718](https://issues.jenkins-ci.org/browse/JENKINS-64718) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- ~[ ] Automated tests have been added to exercise the changes~
- ~[ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.~

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- ~[ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed~

# Users/aliases to notify

@timja @bitwiseman 