### PR TITLE
Remove rechecking/refreshed rate limit functionality

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
@@ -70,7 +70,6 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
 
     @Before
     public void setUp() throws Exception {
-        ApiRateLimitChecker.setExpiration(Long.MIN_VALUE);
         github = Connector.connect("http://localhost:" + githubApi.port(), null);
 
         resetAllScenarios();


### PR DESCRIPTION
The ApiRateLimitChecker included functionality to handle when the rate limit is reset "before expected".
If a real world scenario exists for this behavior, it is an extreme edge case. Meanwhile, the functionality
add unneeded complexity to the checkers and is not supported by the github-api RateLimitChecker class.

This change remove this extraneous functionality and fixes the test match.

This change in need to move to using the built-in github-api `RateLimitChecker` functionality.