### PR TITLE
Add GithubSenderCause to PR and push GHEventSubscribers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSenderCause.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSenderCause.java
@@ -1,0 +1,101 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+import hudson.model.Cause;
+import java.util.Objects;
+import org.kohsuke.stapler.export.Exported;
+
+public final class GitHubSenderCause extends Cause {
+    private final long id;
+    private final String login;
+    private final String name;
+    private final Kind kind;
+
+    GitHubSenderCause(long id, String login, String name, Kind kind) {
+        this.id = id;
+        this.login = login;
+        this.name = name;
+        this.kind = kind;
+    }
+
+    @Exported(visibility = 3)
+    public long getId() {
+        return id;
+    }
+
+    @Exported(visibility = 3)
+    public String getLogin() {
+        return login;
+    }
+
+    @Exported(visibility = 3)
+    public String getName() {
+        return name;
+    }
+
+    @Exported(visibility = 3)
+    public Kind getKind() {
+        return kind;
+    }
+
+    @Override
+    public String getShortDescription() {
+        String user;
+        if (name == null) {
+            user = login;
+        } else {
+            user = String.format("%s (%s)", new Object[] {name, login});
+        }
+        return String.format("Caused by GitHub event \"%s\" due to user %s", new Object[] {kind, user});
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        GitHubSenderCause cause = (GitHubSenderCause) obj;
+        return id == cause.id &&
+            stringEquals(login, cause.login) &&
+            stringEquals(name, cause.name) &&
+            kind == cause.kind;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, login, name, kind);
+    }
+
+    private boolean stringEquals(String a, String b) {
+        if (a == null) {
+            return b == null;
+        }
+        return a.equals(b);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[id=%s] [login=%s] [name=%s] [kind=%s]", new Object[]{id, login, name, kind.name()});
+    }
+
+    public enum Kind {
+        BRANCH_CREATED("branch created"),
+        BRANCH_DELETED("branch deleted"),
+        BRANCH_UPDATED("branch updated"),
+        PULL_REQUEST_CREATED("pull request created"),
+        PULL_REQUEST_UPDATED("pull request updated"),
+        PULL_REQUEST_DELETED("pull request deleted"),
+        PULL_REQUEST_OTHER("pull request");
+
+        private String description;
+
+        Kind(String description) {
+            this.description = description;
+        }
+
+        public String toString() {
+            return description;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestGHEventSubscriber.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.github_branch_source;
 import com.cloudbees.jenkins.GitHubRepositoryName;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.model.Cause;
 import hudson.model.Item;
 import hudson.scm.SCM;
 import java.io.IOException;
@@ -54,6 +55,7 @@ import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import jenkins.scm.api.trait.SCMHeadPrefilter;
+import org.apache.commons.lang3.ArrayUtils;
 import org.jenkinsci.plugins.github.extension.GHEventsSubscriber;
 import org.jenkinsci.plugins.github.extension.GHSubscriberEvent;
 import org.kohsuke.github.GHEvent;
@@ -179,6 +181,33 @@ public class PullRequestGHEventSubscriber extends GHEventsSubscriber {
         private boolean isApiMatch(String apiUri) {
             return repoHost.equalsIgnoreCase(RepositoryUriResolver.hostnameFromApiUri(apiUri));
         }
+
+        @Override
+        public Cause[] asCauses() {
+            Cause[] causes = super.asCauses();
+            long senderId = getPayload().getSender().getId();
+            String senderLogin = getPayload().getSender().getLogin();
+            String senderName = null;
+            try {
+                senderName = getPayload().getSender().getName();
+            } catch (IOException e) {
+                LOGGER.warning("couldn't determine sender name");
+            }
+            GitHubSenderCause.Kind kind;
+            String action = getPayload().getAction();
+            if ("opened".equals(action)) {
+                kind = GitHubSenderCause.Kind.PULL_REQUEST_CREATED;
+            } else if ("reopened".equals(action) || "synchronize".equals(action) || "edited".equals(action)) {
+                kind = GitHubSenderCause.Kind.PULL_REQUEST_UPDATED;
+            } else if ("closed".equals(action)) {
+                kind = GitHubSenderCause.Kind.PULL_REQUEST_DELETED;
+            } else {
+                kind = GitHubSenderCause.Kind.PULL_REQUEST_OTHER;
+            }
+            causes = ArrayUtils.addAll(causes, new Cause[] {new GitHubSenderCause(senderId, senderLogin, senderName, kind)});
+            return causes;
+        }
+
 
         @Override
         public boolean isMatch(@NonNull SCMNavigator navigator) {


### PR DESCRIPTION
# Description
This allows us to infer the person responsible for opening a PR or
updating a branch which triggers a Jenkins build. We extract this info
inside a Jenkins pipeline like so:

```
def causes =
currentBuild.getBuildCauses('org.jenkinsci.plugins.github_branch_source.GitHubSenderCause')
if (!causes.isEmpty()) {
  return causes[0].login
}
```
Example pipeline utilizing above code:
![Screen Shot 2021-02-16 at 5 17 37 PM](https://user-images.githubusercontent.com/12738292/108133935-fabddd00-707a-11eb-8235-c2ce6984fc4c.png)

To run updated unit tests:
```
mvn test -Dtest=EventsTest.java
```

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] ~Link to JIRA ticket in description, if appropriate.~
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

