### PR TITLE
[JENKINS-64911] Streamline validity check

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -79,6 +79,7 @@ import org.jenkinsci.plugins.github.config.GitHubServerConfig;
 import org.kohsuke.github.GHAppInstallationToken;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
+import org.kohsuke.github.HttpException;
 import org.kohsuke.github.RateLimitHandler;
 import org.kohsuke.github.authorization.ImmutableAuthorizationProvider;
 import org.kohsuke.github.extras.okhttp3.OkHttpConnector;
@@ -97,13 +98,7 @@ public class Connector {
 
     private static final Map<TaskListener, Map<GitHub,Void>> checked = new WeakHashMap<>();
     private static final long API_URL_REVALIDATE_MILLIS = TimeUnit.MINUTES.toMillis(5);
-    private static final Map<String,Long> apiUrlValid = new LinkedHashMap<String,Long>(){
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<String,Long> eldest) {
-            Long t = eldest.getValue();
-            return t == null || t < System.currentTimeMillis() - API_URL_REVALIDATE_MILLIS;
-        }
-    };
+
     private static final Random ENTROPY = new Random();
     private static final String SALT = Long.toHexString(ENTROPY.nextLong());
     private static final OkHttpClient baseClient = new OkHttpClient();
@@ -314,29 +309,8 @@ public class Connector {
         );
     }
 
-    public static void checkApiUrlValidity(@Nonnull GitHub gitHub, @CheckForNull StandardCredentials credentials) throws IOException {
-        String hash;
-        if (credentials == null) {
-            hash = "anonymous";
-        } else if (credentials instanceof StandardUsernamePasswordCredentials) {
-            StandardUsernamePasswordCredentials c = (StandardUsernamePasswordCredentials) credentials;
-            hash = Util.getDigestOf(c.getPassword().getPlainText() + SALT);
-        } else {
-            // TODO OAuth support
-            throw new IOException("Unsupported credential type: " + credentials.getClass().getName());
-        }
-        String key = gitHub.getApiUrl() + "::" + hash;
-        synchronized (apiUrlValid) {
-            Long last = apiUrlValid.get(key);
-            if (last != null && last > System.currentTimeMillis() - API_URL_REVALIDATE_MILLIS) {
-                return;
-            }
-            gitHub.checkApiUrlValidity();
-            apiUrlValid.put(key, System.currentTimeMillis());
-        }
-    }
-
-    public static @Nonnull GitHub connect(@CheckForNull String apiUri, @CheckForNull StandardCredentials credentials) throws IOException {
+    public static @Nonnull GitHub connect(@CheckForNull String apiUri, @CheckForNull StandardCredentials credentials)
+            throws IOException {
         String apiUrl = Util.fixEmptyAndTrim(apiUri);
         apiUrl = apiUrl != null ? apiUrl : GitHubServerConfig.GITHUB_URL;
         String username;
@@ -383,8 +357,9 @@ public class Connector {
                     gb.withAuthorizationProvider(ImmutableAuthorizationProvider.fromLoginAndPassword(username, password));
                 }
 
+                record = GitHubConnection
+                        .connect(connectionId, gb.build(), cache, credentials instanceof GitHubAppCredentials);
 
-                record = GitHubConnection.connect(connectionId, gb.build(), cache, credentials instanceof GitHubAppCredentials);
             }
 
             return record.getGitHub();
@@ -621,6 +596,7 @@ public class Connector {
         private final boolean cleanupCacheFolder;
         private int usageCount = 1;
         private long lastUsed = System.currentTimeMillis();
+        private long lastVerified = Long.MIN_VALUE;
 
         private GitHubConnection(GitHub gitHub, Cache cache, boolean cleanupCacheFolder) {
             this.gitHub = gitHub;
@@ -638,10 +614,11 @@ public class Connector {
         }
 
         @CheckForNull
-        private static GitHubConnection lookup(@NonNull ConnectionId connectionId) {
+        private static GitHubConnection lookup(@NonNull ConnectionId connectionId) throws IOException {
             GitHubConnection record;
             record = connections.get(connectionId);
             if (record != null) {
+                record.verifyConnection();
                 record.usageCount += 1;
                 record.lastUsed = System.currentTimeMillis();
             }
@@ -649,8 +626,13 @@ public class Connector {
         }
 
         @NonNull
-        private static GitHubConnection connect(@NonNull ConnectionId connectionId, @NonNull GitHub gitHub, @CheckForNull Cache cache, boolean cleanupCacheFolder) {
+        private static GitHubConnection connect(
+                @NonNull ConnectionId connectionId,
+                @NonNull GitHub gitHub,
+                @CheckForNull Cache cache,
+                boolean cleanupCacheFolder) throws IOException {
             GitHubConnection record = new GitHubConnection(gitHub, cache, cleanupCacheFolder);
+            record.verifyConnection();
             connections.put(connectionId, record);
             reverseLookup.put(record.gitHub, record);
             return record;
@@ -684,6 +666,21 @@ public class Connector {
                 } catch (IOException | NullPointerException e) {
                     LOGGER.log(WARNING, "Exception removing cache directory for unused connection: " + entry.getKey(), e);
                 }
+            }
+        }
+
+        public void verifyConnection() throws IOException {
+            synchronized (this) {
+                if (lastVerified > System.currentTimeMillis() - API_URL_REVALIDATE_MILLIS) {
+                    return;
+                }
+                try {
+                    gitHub.checkApiUrlValidity();
+                } catch (HttpException e) {
+                    String message = String.format("It seems %s is unreachable", gitHub.getApiUrl());
+                    throw new IOException(message, e);
+                }
+                lastVerified = System.currentTimeMillis();
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -19,6 +19,7 @@ import java.security.GeneralSecurityException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -126,7 +127,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
 
     @SuppressWarnings("deprecation")
     AuthorizationProvider getAuthorizationProvider() {
-        return new TokenProvider(this);
+        return new CredentialsTokenProvider(this);
     }
 
     private static AuthorizationProvider createJwtProvider(String appId, String appPrivateKey) {
@@ -137,16 +138,49 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
         }
     }
 
-    private static class TokenProvider extends GitHub.DependentAuthorizationProvider {
+
+    private static abstract class TokenProvider extends GitHub.DependentAuthorizationProvider {
+
+        protected TokenProvider(String appID, String privateKey) {
+            super(createJwtProvider(appID, privateKey));
+        }
+
+        /**
+         * Create and return the specialized GitHub instance to be used for refreshing AppInstallationToken
+         *
+         * The {@link GitHub.DependentAuthorizationProvider} provides a specialized GitHub instance
+         * that uses JWT for authorization and does not check rate limit since it doesn't apply for
+         * the App endpoints when using JWT.
+         */
+        static GitHub createTokenRefreshGitHub(String appId,
+                                               String appPrivateKey,
+                                               String apiUrl) throws IOException {
+            TokenProvider provider = new TokenProvider(appId, appPrivateKey) {
+                @Override
+                public String getEncodedAuthorization() throws IOException {
+                    // Will never be called
+                    return null;
+                }
+            };
+            Connector
+                .createGitHubBuilder(apiUrl)
+                .withAuthorizationProvider(provider)
+                .build();
+
+            return provider.gitHub();
+        }
+    }
+
+    private static class CredentialsTokenProvider extends TokenProvider {
         private final GitHubAppCredentials credentials;
 
-        TokenProvider(GitHubAppCredentials credentials) {
-            super(createJwtProvider(credentials.appID, credentials.privateKey.getPlainText()));
+        CredentialsTokenProvider(GitHubAppCredentials credentials) {
+            super(credentials.appID, credentials.privateKey.getPlainText());
             this.credentials = credentials;
         }
 
         public String getEncodedAuthorization() throws IOException {
-            Secret token = credentials.getPassword(gitHub());
+            Secret token = credentials.getToken(gitHub()).getToken();
             return String.format("token %s", token.getPlainText());
         }
     }
@@ -158,10 +192,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
 
         try (Timeout ignored = Timeout.limit(30, TimeUnit.SECONDS)) {
             if (gitHubApp == null) {
-                gitHubApp = Connector
-                    .createGitHubBuilder(apiUrl)
-                    .withAuthorizationProvider(createJwtProvider(appId, appPrivateKey))
-                    .build();
+                gitHubApp = TokenProvider.createTokenRefreshGitHub(appId, appPrivateKey, apiUrl);
             }
 
             GHApp app;
@@ -230,7 +261,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
         return Util.fixEmpty(apiUri) == null ? "https://api.github.com" : apiUri;
     }
 
-    private Secret getPassword(GitHub gitHub) {
+    private AppInstallationToken getToken(GitHub gitHub) {
         synchronized (this) {
             try {
                 if (cachedToken == null || cachedToken.isStale()) {
@@ -257,7 +288,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
             }
             LOGGER.log(Level.FINEST, "Returned GitHub App Installation Token for app ID {0}", appID);
 
-            return cachedToken.getToken();
+            return cachedToken;
         }
     }
 
@@ -267,7 +298,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
     @NonNull
     @Override
     public Secret getPassword() {
-        return this.getPassword(null);
+        return this.getToken(null).getToken();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFileSystem.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFileSystem.java
@@ -260,13 +260,6 @@ public class GitHubSCMFileSystem extends SCMFileSystem implements GitHubClosable
             // Github client and validation
             GitHub github = Connector.connect(apiUri, credentials);
             try {
-                try {
-                    Connector.checkApiUrlValidity(github, credentials);
-                } catch (HttpException e) {
-                    String message = String.format("It seems %s is unreachable",
-                            apiUri);
-                    throw new IOException(message);
-                }
                 String refName;
 
                 if (head instanceof BranchSCMHead) {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1104,16 +1104,14 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 Connector.lookupScanCredentials((Item)observer.getContext(), apiUri, credentialsId);
 
         // Github client and validation
-        GitHub github = Connector.connect(apiUri, credentials);
+        GitHub github;
         try {
-            try {
-                Connector.checkApiUrlValidity(github, credentials);
-            } catch (HttpException e) {
-                String message = String.format("It seems %s is unreachable",
-                        apiUri == null ? GitHubSCMSource.GITHUB_URL : apiUri);
-                throw new AbortException(message);
-            }
+            github = Connector.connect(apiUri, credentials);
+        } catch (HttpException e) {
+            throw new AbortException(e.getMessage());
+        }
 
+        try {
             // Input data validation
             if (credentials != null && !isCredentialValid(github)) {
                 String message = String.format("Invalid scan credentials %s to connect to %s, skipping",

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -948,7 +948,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         // Github client and validation
         final GitHub github = Connector.connect(apiUri, credentials);
         try {
-            checkApiUrlValidity(github, credentials);
             Connector.configureLocalRateLimitChecker(listener, github);
 
             try {
@@ -1238,7 +1237,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         // Github client and validation
         final GitHub github = Connector.connect(apiUri, credentials);
         try {
-            checkApiUrlValidity(github, credentials);
             Connector.configureLocalRateLimitChecker(listener, github);
             Set<String> result = new TreeSet<>();
 
@@ -1331,7 +1329,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         // Github client and validation
         final GitHub github = Connector.connect(apiUri, credentials);
         try {
-            checkApiUrlValidity(github, credentials);
             Connector.configureLocalRateLimitChecker(listener, github);
             // Input data validation
             if (isBlank(repository)) {
@@ -1536,15 +1533,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         }
     }
 
-    private void checkApiUrlValidity(GitHub github, StandardCredentials credentials) throws IOException {
-        try {
-            Connector.checkApiUrlValidity(github, credentials);
-        } catch (HttpException e) {
-            String message = String.format("It seems %s is unreachable", apiUri);
-            throw new IOException(message, e);
-        }
-    }
-
     private static class WrappedException extends RuntimeException {
 
         public WrappedException(Throwable cause) {
@@ -1593,8 +1581,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         // Github client and validation
         GitHub github = Connector.connect(apiUri, credentials);
         try {
-            checkApiUrlValidity(github, credentials);
-
             try {
                 Connector.checkConnectionValidity(apiUri, listener, credentials, github);
                 Connector.configureLocalRateLimitChecker(listener, github);
@@ -1733,7 +1719,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                     try {
                         GitHub github = Connector.connect(apiUri, credentials);
                         try {
-                            checkApiUrlValidity(github, credentials);
                             Connector.configureLocalRateLimitChecker(listener, github);
                             ghRepository = github.getRepository(fullName);
                             LOGGER.log(Level.INFO, "Got remote pull requests from {0}", fullName);
@@ -2736,7 +2721,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             try {
                 GitHub github = Connector.connect(apiUri, credentials);
                 try {
-                    checkApiUrlValidity(github, credentials);
                     Connector.configureLocalRateLimitChecker(listener, github);
 
                     // Input data validation

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubOrgWebHookTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubOrgWebHookTest.java
@@ -47,6 +47,13 @@ public class GitHubOrgWebHookTest {
                 .withStatus(404)
             ));
 
+        // validate api url
+        wireMockRule.stubFor(get(urlEqualTo("/api/"))
+            .willReturn(aResponse()
+                .withBody("{\"rate_limit_url\": \"https://localhost/placeholder/\"}")
+            ));
+
+
         wireMockRule.stubFor(get(urlEqualTo("/api/users/myorg")).willReturn(aResponse().withBody("{\"login\":\"myorg\"}")));
         wireMockRule.stubFor(get(urlEqualTo("/api/orgs/myorg")).willReturn(aResponse().withBody("{\"login\":\"myorg\",\"html_url\":\"https://github.com/myorg\"}")));
         wireMockRule.stubFor(get(urlEqualTo("/api/orgs/myorg/hooks")).willReturn(aResponse().withBody("[]")));

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbeTest.java
@@ -56,6 +56,12 @@ public class GitHubSCMProbeTest {
             .willReturn(aResponse()
                 .withStatus(404)
             ));
+
+        // validate api url
+        githubApi.stubFor(get(urlEqualTo("/"))
+            .willReturn(aResponse()
+                .withBody("{\"rate_limit_url\": \"https://localhost/placeholder/\"}")
+            ));
     }
 
     void createProbeForPR(int number) throws IOException {

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
@@ -109,6 +109,13 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
 
     @Before
     public void setUpWireMock() throws Exception {
+        // At no point during credential refreshes should we ever check rate_limit
+        githubApi.stubFor(
+            get(urlEqualTo("/rate_limit"))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                ));
+
         //Add wiremock responses for App, App Installation, and App Installation Token
         githubApi.stubFor(
             get(urlEqualTo("/app"))


### PR DESCRIPTION
# Description
See [JENKINS-64911](https://issues.jenkins-ci.org/browse/JENKINS-64911) for further information. 

Check validity was following its own special path, getting the password to create a hash, this resulted in a new call to `gitHub.checkApiUrlValidity()` each time the app password needed to be refreshed.  This resulted in users encountering the GitHub App issue we've seen with failure to authenticate much more often.

This change removes that special path and dependence on `getPassword()`. This still does address the underlying issue with App credentials, but so it goes.


# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify
@timja

