### PR TITLE
fix: can't delete GitHub Enterprise servers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubConfiguration.java
@@ -59,6 +59,7 @@ public class GitHubConfiguration extends GlobalConfiguration {
 
   @Override
   public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+    endpoints = null;
     req.bindJSON(this, json);
     return true;
   }


### PR DESCRIPTION
# Description

can't delete GitHub Enterprise servers in Jenkins configuration

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

