### PR TITLE
[JENKINS-65071] PR events should not trigger tags examination

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1002,7 +1002,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
           // examination if the observer has any include event of each type BranchSCMHead, PullRequestSCMHead or GitHubTagSCMHead.
           // But when a project scan is triggered we don't have any event so a full examination should happen.
 
-          if (request.isFetchBranches() && !request.isComplete() && (event == null || checkObserverIncludesType(observer.getIncludes(), BranchSCMHead.class))) {
+          if (request.isFetchBranches() && !request.isComplete() && (event == null || this.checkObserverIncludesType(observer.getIncludes(), BranchSCMHead.class))) {
             listener.getLogger().format("%n  Checking branches...%n");
             int count = 0;
             for (final GHBranch branch : request.getBranches()) {
@@ -1037,7 +1037,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             }
             listener.getLogger().format("%n  %d branches were processed%n", count);
           }
-          if (request.isFetchPRs() && !request.isComplete() && (event == null || checkObserverIncludesType(observer.getIncludes(), PullRequestSCMHead.class))) {
+          if (request.isFetchPRs() && !request.isComplete() && (event == null || this.checkObserverIncludesType(observer.getIncludes(), PullRequestSCMHead.class))) {
             listener.getLogger().format("%n  Checking pull-requests...%n");
             int count = 0;
             int errorCount = 0;
@@ -1073,7 +1073,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                   .format("%n  %d pull requests encountered errors and were orphaned.%n", count);
             }
           }
-          if (request.isFetchTags() && !request.isComplete() && (event == null || checkObserverIncludesType(observer.getIncludes(), GitHubTagSCMHead.class))) {
+          if (request.isFetchTags() && !request.isComplete() && (event == null || this.checkObserverIncludesType(observer.getIncludes(), GitHubTagSCMHead.class))) {
             listener.getLogger().format("%n  Checking tags...%n");
             int count = 0;
             for (final GHRef tag : request.getTags()) {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -931,10 +931,12 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
    * @return true if the includes list contains at least one element with the provided class type.
    */
   private boolean checkObserverIncludesType(Set<SCMHead> includes, @NonNull Class t) {
-    Iterator iterator = includes.iterator();
-    while (iterator.hasNext()) {
-      if (t.isInstance(iterator.next())) {
-        return true;
+    if (includes != null) {
+      Iterator iterator = includes.iterator();
+      while (iterator.hasNext()) {
+        if (t.isInstance(iterator.next())) {
+          return true;
+        }
       }
     }
     return false;
@@ -1052,8 +1054,8 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
           if (request.isFetchPRs()
               && !request.isComplete()
               && (event == null
-                  || this.checkObserverIncludesType(
-                      observer.getIncludes(), PullRequestSCMHead.class))) {
+                  || (this.checkObserverIncludesType(
+                      observer.getIncludes(), PullRequestSCMHead.class)))) {
             listener.getLogger().format("%n  Checking pull-requests...%n");
             int count = 0;
             int errorCount = 0;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1006,7 +1006,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
           // and GitHub API requests,
           // it is necessary to check if this event contains a set of {@link SCMHead} instances of a
           // type.
-          // When we open or close a Pull request we don't need a TAG examination because the even
+          // When we open or close a Pull request we don't need a TAG examination because the event
           // doesn't have any TAG. So, we only trigger a
           // examination if the observer has any include event of each type BranchSCMHead,
           // PullRequestSCMHead or GitHubTagSCMHead.

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -928,8 +928,8 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
    */
   private boolean checkObserverIncludesType(Set<SCMHead> includes, @NonNull Class t) {
     Iterator iterator = includes.iterator();
-    while(iterator.hasNext()) {
-      if(t.isInstance(iterator.next())) {
+    while (iterator.hasNext()) {
+      if (t.isInstance(iterator.next())) {
         return true;
       }
     }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -930,7 +930,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
    * @param t Class type to compare the set elements to.
    * @return true if the includes list contains at least one element with the provided class type.
    */
-  private boolean checkObserverIncludesType(Set<SCMHead> includes, @NonNull Class t) {
+  public boolean checkObserverIncludesType(Set<SCMHead> includes, @NonNull Class t) {
     if (includes != null) {
       Iterator iterator = includes.iterator();
       while (iterator.hasNext()) {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -921,10 +921,10 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
   }
 
   /**
-   * Simple method to iterate a set and to check if  each element is an instance of a provided class.
-   * @param includes Observer includes list.
-   * @param t Class to compare instances.
-   * @return true if the includes list containes some element with the provided class type.
+   * Simple method to iterate a set of {@link SCMHeadObserver#getIncludes()} branches/tags/pr that will be possible observed and to check if at least one element is an instance of a provided class.
+   * @param includes set of {@link SCMHeadObserver#getIncludes()} that are possible going to be observed.
+   * @param t Class type to compare the set elements to.
+   * @return true if the includes list contains at least one element with the provided class type.
    */
   private boolean checkObserverIncludesType(Set<SCMHead> includes, @NonNull Class t) {
     Iterator iterator = includes.iterator();
@@ -997,8 +997,8 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
 
           // JENKINS-65071
           // Observer has information about the events to analyze. To avoid unnecessary processing and GitHub API requests,
-          // it is necessary to check if this event has the necessary includes to perform each examination.
-          // When we open or close a Pull request we don't need a TAG examination. So, we only trigger a
+          // it is necessary to check if this event contains a set of {@link SCMHead} instances of a type.
+          // When we open or close a Pull request we don't need a TAG examination because the even doesn't have any TAG. So, we only trigger a
           // examination if the observer has any include event of each type BranchSCMHead, PullRequestSCMHead or GitHubTagSCMHead.
           // But when a project scan is triggered we don't have any event so a full examination should happen.
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -921,8 +921,12 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
   }
 
   /**
-   * Simple method to iterate a set of {@link SCMHeadObserver#getIncludes()} branches/tags/pr that will be possible observed and to check if at least one element is an instance of a provided class.
-   * @param includes set of {@link SCMHeadObserver#getIncludes()} that are possible going to be observed.
+   * Simple method to iterate a set of {@link SCMHeadObserver#getIncludes()} branches/tags/pr that
+   * will be possible observed and to check if at least one element is an instance of a provided
+   * class.
+   *
+   * @param includes set of {@link SCMHeadObserver#getIncludes()} that are possible going to be
+   *     observed.
    * @param t Class type to compare the set elements to.
    * @return true if the includes list contains at least one element with the provided class type.
    */
@@ -996,13 +1000,21 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
               });
 
           // JENKINS-65071
-          // Observer has information about the events to analyze. To avoid unnecessary processing and GitHub API requests,
-          // it is necessary to check if this event contains a set of {@link SCMHead} instances of a type.
-          // When we open or close a Pull request we don't need a TAG examination because the even doesn't have any TAG. So, we only trigger a
-          // examination if the observer has any include event of each type BranchSCMHead, PullRequestSCMHead or GitHubTagSCMHead.
-          // But when a project scan is triggered we don't have any event so a full examination should happen.
+          // Observer has information about the events to analyze. To avoid unnecessary processing
+          // and GitHub API requests,
+          // it is necessary to check if this event contains a set of {@link SCMHead} instances of a
+          // type.
+          // When we open or close a Pull request we don't need a TAG examination because the even
+          // doesn't have any TAG. So, we only trigger a
+          // examination if the observer has any include event of each type BranchSCMHead,
+          // PullRequestSCMHead or GitHubTagSCMHead.
+          // But when a project scan is triggered we don't have any event so a full examination
+          // should happen.
 
-          if (request.isFetchBranches() && !request.isComplete() && (event == null || this.checkObserverIncludesType(observer.getIncludes(), BranchSCMHead.class))) {
+          if (request.isFetchBranches()
+              && !request.isComplete()
+              && (event == null
+                  || this.checkObserverIncludesType(observer.getIncludes(), BranchSCMHead.class))) {
             listener.getLogger().format("%n  Checking branches...%n");
             int count = 0;
             for (final GHBranch branch : request.getBranches()) {
@@ -1037,7 +1049,11 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             }
             listener.getLogger().format("%n  %d branches were processed%n", count);
           }
-          if (request.isFetchPRs() && !request.isComplete() && (event == null || this.checkObserverIncludesType(observer.getIncludes(), PullRequestSCMHead.class))) {
+          if (request.isFetchPRs()
+              && !request.isComplete()
+              && (event == null
+                  || this.checkObserverIncludesType(
+                      observer.getIncludes(), PullRequestSCMHead.class))) {
             listener.getLogger().format("%n  Checking pull-requests...%n");
             int count = 0;
             int errorCount = 0;
@@ -1073,7 +1089,11 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                   .format("%n  %d pull requests encountered errors and were orphaned.%n", count);
             }
           }
-          if (request.isFetchTags() && !request.isComplete() && (event == null || this.checkObserverIncludesType(observer.getIncludes(), GitHubTagSCMHead.class))) {
+          if (request.isFetchTags()
+              && !request.isComplete()
+              && (event == null
+                  || this.checkObserverIncludesType(
+                      observer.getIncludes(), GitHubTagSCMHead.class))) {
             listener.getLogger().format("%n  Checking tags...%n");
             int count = 0;
             for (final GHRef tag : request.getTags()) {

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -54,6 +54,7 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.model.User;
+import hudson.scm.SCM;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.security.AuthorizationStrategy;
@@ -79,6 +80,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.mockito.Mockito;
 
 @RunWith(Parameterized.class)
 public class GitHubSCMSourceTest extends GitSCMSourceBase {
@@ -133,6 +135,58 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
                     .withBodyFile("body-yolo-pulls-2-mergeable-true.json"))
             .willSetStateTo("Pull Request Merge Hash - retry 2"));
   }
+
+  SCMHeadEvent<PushGHEventSubscriber> pushEvent =
+      new SCMHeadEvent<PushGHEventSubscriber>(
+          SCMEvent.Type.CREATED, System.currentTimeMillis(), null, null) {
+        @Override
+        public boolean isMatch(@NonNull SCMNavigator scmNavigator) {
+          return false;
+        }
+
+        @NonNull
+        @Override
+        public String getSourceName() {
+          return null;
+        }
+
+        @NonNull
+        @Override
+        public Map<SCMHead, SCMRevision> heads(@NonNull SCMSource scmSource) {
+          return null;
+        }
+
+        @Override
+        public boolean isMatch(@NonNull SCM scm) {
+          return false;
+        }
+      };
+
+  SCMHeadEvent<PullRequestGHEventSubscriber> pullRequestEvent =
+      new SCMHeadEvent<PullRequestGHEventSubscriber>(
+          SCMEvent.Type.CREATED, System.currentTimeMillis(), null, null) {
+        @Override
+        public boolean isMatch(@NonNull SCMNavigator scmNavigator) {
+          return false;
+        }
+
+        @NonNull
+        @Override
+        public String getSourceName() {
+          return null;
+        }
+
+        @NonNull
+        @Override
+        public Map<SCMHead, SCMRevision> heads(@NonNull SCMSource scmSource) {
+          return null;
+        }
+
+        @Override
+        public boolean isMatch(@NonNull SCM scm) {
+          return false;
+        }
+      };
 
   @Test
   @Issue("JENKINS-48035")
@@ -822,59 +876,152 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
   @Test
   @Issue("JENKINS-65071")
   public void testCheckIncludesBranchSCMHeadType() throws Exception {
-    Set<SCMHead> includes = Collections.singleton(new BranchSCMHead("non-existent-branch"));
+    SCMHeadObserver mockSCMHeadObserver = Mockito.mock(SCMHeadObserver.class);
+    Mockito.when(mockSCMHeadObserver.getIncludes())
+        .thenReturn(Collections.singleton(new BranchSCMHead("existent-branch")));
 
-    assertTrue(this.source.checkObserverIncludesType(includes, BranchSCMHead.class));
-    assertFalse(this.source.checkObserverIncludesType(includes, PullRequestSCMHead.class));
-    assertFalse(this.source.checkObserverIncludesType(includes, GitHubTagSCMHead.class));
+    assertTrue(this.source.checkObserverIncludesType(mockSCMHeadObserver, BranchSCMHead.class));
+    assertFalse(
+        this.source.checkObserverIncludesType(mockSCMHeadObserver, PullRequestSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(mockSCMHeadObserver, GitHubTagSCMHead.class));
   }
 
   @Test
   @Issue("JENKINS-65071")
   public void testCheckIncludesPullRequestSCMHeadType() throws Exception {
-    Set<SCMHead> includes =
-        Collections.singleton(
-            new PullRequestSCMHead(
-                "PR-1",
-                "rfvm",
-                "http://localhost:" + githubApi.port(),
-                "master",
-                1,
-                new BranchSCMHead("master"),
-                SCMHeadOrigin.DEFAULT,
-                ChangeRequestCheckoutStrategy.MERGE));
+    SCMHeadObserver mockSCMHeadObserver = Mockito.mock(SCMHeadObserver.class);
+    Mockito.when(mockSCMHeadObserver.getIncludes())
+        .thenReturn(
+            Collections.singleton(
+                new PullRequestSCMHead(
+                    "PR-1",
+                    "rfvm",
+                    "http://localhost:" + githubApi.port(),
+                    "master",
+                    1,
+                    new BranchSCMHead("master"),
+                    SCMHeadOrigin.DEFAULT,
+                    ChangeRequestCheckoutStrategy.MERGE)));
 
-    assertTrue(this.source.checkObserverIncludesType(includes, PullRequestSCMHead.class));
-    assertFalse(this.source.checkObserverIncludesType(includes, BranchSCMHead.class));
-    assertFalse(this.source.checkObserverIncludesType(includes, GitHubTagSCMHead.class));
+    assertTrue(
+        this.source.checkObserverIncludesType(mockSCMHeadObserver, PullRequestSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(mockSCMHeadObserver, BranchSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(mockSCMHeadObserver, GitHubTagSCMHead.class));
   }
 
   @Test
   @Issue("JENKINS-65071")
   public void testCheckIncludesGitHubTagSCMHeadType() throws Exception {
-    Set<SCMHead> includes =
-        Collections.singleton(new GitHubTagSCMHead("non-existent-tag", System.currentTimeMillis()));
+    SCMHeadObserver mockSCMHeadObserver = Mockito.mock(SCMHeadObserver.class);
+    Mockito.when(mockSCMHeadObserver.getIncludes())
+        .thenReturn(
+            Collections.singleton(
+                new GitHubTagSCMHead("non-existent-tag", System.currentTimeMillis())));
 
-    assertTrue(this.source.checkObserverIncludesType(includes, GitHubTagSCMHead.class));
-    assertFalse(this.source.checkObserverIncludesType(includes, PullRequestSCMHead.class));
-    assertFalse(this.source.checkObserverIncludesType(includes, BranchSCMHead.class));
+    assertTrue(this.source.checkObserverIncludesType(mockSCMHeadObserver, GitHubTagSCMHead.class));
+    assertFalse(
+        this.source.checkObserverIncludesType(mockSCMHeadObserver, PullRequestSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(mockSCMHeadObserver, BranchSCMHead.class));
   }
 
   @Test
   @Issue("JENKINS-65071")
   public void testCheckIncludesEmpty() throws Exception {
-    Set<SCMHead> includes = Collections.emptySet();
+    SCMHeadObserver mockSCMHeadObserver = Mockito.mock(SCMHeadObserver.class);
+    Mockito.when(mockSCMHeadObserver.getIncludes()).thenReturn(Collections.emptySet());
 
-    assertFalse(this.source.checkObserverIncludesType(includes, GitHubTagSCMHead.class));
-    assertFalse(this.source.checkObserverIncludesType(includes, PullRequestSCMHead.class));
-    assertFalse(this.source.checkObserverIncludesType(includes, BranchSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(mockSCMHeadObserver, GitHubTagSCMHead.class));
+    assertFalse(
+        this.source.checkObserverIncludesType(mockSCMHeadObserver, PullRequestSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(mockSCMHeadObserver, BranchSCMHead.class));
   }
 
   @Test
   @Issue("JENKINS-65071")
   public void testCheckIncludesNull() throws Exception {
-    assertFalse(this.source.checkObserverIncludesType(null, GitHubTagSCMHead.class));
-    assertFalse(this.source.checkObserverIncludesType(null, PullRequestSCMHead.class));
-    assertFalse(this.source.checkObserverIncludesType(null, BranchSCMHead.class));
+    SCMHeadObserver mockSCMHeadObserver = Mockito.mock(SCMHeadObserver.class);
+    Mockito.when(mockSCMHeadObserver.getIncludes()).thenReturn(null);
+
+    assertFalse(this.source.checkObserverIncludesType(mockSCMHeadObserver, GitHubTagSCMHead.class));
+    assertFalse(
+        this.source.checkObserverIncludesType(mockSCMHeadObserver, PullRequestSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(mockSCMHeadObserver, BranchSCMHead.class));
+  }
+
+  @Test
+  @Issue("JENKINS-65071")
+  public void testShouldRetrieveBranchSCMHeadType() throws Exception {
+    SCMHeadObserver mockSCMHeadObserver = Mockito.mock(SCMHeadObserver.class);
+    Mockito.when(mockSCMHeadObserver.getIncludes())
+        .thenReturn(Collections.singleton(new BranchSCMHead("existent-branch")));
+
+    assertTrue(
+        this.source.shouldRetrieve(mockSCMHeadObserver, this.pushEvent, BranchSCMHead.class));
+    assertFalse(
+        this.source.shouldRetrieve(mockSCMHeadObserver, this.pushEvent, PullRequestSCMHead.class));
+    assertFalse(
+        this.source.shouldRetrieve(mockSCMHeadObserver, this.pushEvent, GitHubTagSCMHead.class));
+  }
+
+  @Test
+  @Issue("JENKINS-65071")
+  public void testShouldRetrievePullRequestSCMHeadType() throws Exception {
+    SCMHeadObserver mockSCMHeadObserver = Mockito.mock(SCMHeadObserver.class);
+    Mockito.when(mockSCMHeadObserver.getIncludes())
+        .thenReturn(
+            Collections.singleton(
+                new PullRequestSCMHead(
+                    "PR-1",
+                    "rfvm",
+                    "http://localhost:" + githubApi.port(),
+                    "master",
+                    1,
+                    new BranchSCMHead("master"),
+                    SCMHeadOrigin.DEFAULT,
+                    ChangeRequestCheckoutStrategy.MERGE)));
+
+    assertTrue(
+        this.source.shouldRetrieve(
+            mockSCMHeadObserver, this.pullRequestEvent, PullRequestSCMHead.class));
+    assertFalse(
+        this.source.shouldRetrieve(
+            mockSCMHeadObserver, this.pullRequestEvent, BranchSCMHead.class));
+    assertFalse(
+        this.source.shouldRetrieve(
+            mockSCMHeadObserver, this.pullRequestEvent, GitHubTagSCMHead.class));
+  }
+
+  @Test
+  @Issue("JENKINS-65071")
+  public void testShouldRetrieveTagSCMHeadType() throws Exception {
+    SCMHeadObserver mockSCMHeadObserver = Mockito.mock(SCMHeadObserver.class);
+    Mockito.when(mockSCMHeadObserver.getIncludes())
+        .thenReturn(
+            Collections.singleton(
+                new GitHubTagSCMHead("non-existent-tag", System.currentTimeMillis())));
+
+    assertTrue(
+        this.source.shouldRetrieve(
+            mockSCMHeadObserver, this.pullRequestEvent, GitHubTagSCMHead.class));
+    assertFalse(
+        this.source.shouldRetrieve(
+            mockSCMHeadObserver, this.pullRequestEvent, PullRequestSCMHead.class));
+    assertFalse(
+        this.source.shouldRetrieve(
+            mockSCMHeadObserver, this.pullRequestEvent, BranchSCMHead.class));
+  }
+
+  @Test
+  @Issue("JENKINS-65071")
+  public void testShouldRetrieveNullEvent() throws Exception {
+    SCMHeadObserver mockSCMHeadObserver = Mockito.mock(SCMHeadObserver.class);
+    Mockito.when(mockSCMHeadObserver.getIncludes())
+        .thenReturn(
+            Collections.singleton(
+                new GitHubTagSCMHead("non-existent-tag", System.currentTimeMillis())));
+
+    assertTrue(this.source.shouldRetrieve(mockSCMHeadObserver, null, GitHubTagSCMHead.class));
+    assertTrue(this.source.shouldRetrieve(mockSCMHeadObserver, null, PullRequestSCMHead.class));
+    assertTrue(this.source.shouldRetrieve(mockSCMHeadObserver, null, BranchSCMHead.class));
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -818,4 +818,63 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
       r.jenkins.remove(dummy);
     }
   }
+
+  @Test
+  @Issue("JENKINS-65071")
+  public void testCheckIncludesBranchSCMHeadType() throws Exception {
+    Set<SCMHead> includes = Collections.singleton(new BranchSCMHead("non-existent-branch"));
+
+    assertTrue(this.source.checkObserverIncludesType(includes, BranchSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(includes, PullRequestSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(includes, GitHubTagSCMHead.class));
+  }
+
+  @Test
+  @Issue("JENKINS-65071")
+  public void testCheckIncludesPullRequestSCMHeadType() throws Exception {
+    Set<SCMHead> includes =
+        Collections.singleton(
+            new PullRequestSCMHead(
+                "PR-1",
+                "rfvm",
+                "http://localhost:" + githubApi.port(),
+                "master",
+                1,
+                new BranchSCMHead("master"),
+                SCMHeadOrigin.DEFAULT,
+                ChangeRequestCheckoutStrategy.MERGE));
+
+    assertTrue(this.source.checkObserverIncludesType(includes, PullRequestSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(includes, BranchSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(includes, GitHubTagSCMHead.class));
+  }
+
+  @Test
+  @Issue("JENKINS-65071")
+  public void testCheckIncludesGitHubTagSCMHeadType() throws Exception {
+    Set<SCMHead> includes =
+        Collections.singleton(new GitHubTagSCMHead("non-existent-tag", System.currentTimeMillis()));
+
+    assertTrue(this.source.checkObserverIncludesType(includes, GitHubTagSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(includes, PullRequestSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(includes, BranchSCMHead.class));
+  }
+
+  @Test
+  @Issue("JENKINS-65071")
+  public void testCheckIncludesEmpty() throws Exception {
+    Set<SCMHead> includes = Collections.emptySet();
+
+    assertFalse(this.source.checkObserverIncludesType(includes, GitHubTagSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(includes, PullRequestSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(includes, BranchSCMHead.class));
+  }
+
+  @Test
+  @Issue("JENKINS-65071")
+  public void testCheckIncludesNull() throws Exception {
+    assertFalse(this.source.checkObserverIncludesType(null, GitHubTagSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(null, PullRequestSCMHead.class));
+    assertFalse(this.source.checkObserverIncludesType(null, BranchSCMHead.class));
+  }
 }


### PR DESCRIPTION
# Description
Branch discover strategies have a different behavior on repository examination. If you set **Exclude branches that are also filed as PRs** or **Only branches that are also filed as PRs** a TAG examination is triggered when you open a Pull Request but if you select **All Branches** does not. However, when you close a pull request a TAG examination is triggered in every strategy. 

So, this pull request tries to prevent this useless examination in order to optimize the plugin performance and to avoid unnecessary requests to GitHub API.  

A brief summary describing the changes in this pull request. See 
[JENKINS-65071](https://issues.jenkins-ci.org/browse/JENKINS-65071) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

@bitwiseman