### PR TITLE
Exclude Forks (Source != null) so original repos can be discovered and PR repos could be ignored

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ExcludeForkedRepositoriesTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ExcludeForkedRepositoriesTrait.java
@@ -9,7 +9,6 @@ import jenkins.scm.impl.trait.Selection;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-
 /**
  * A {@link Selection} trait that will restrict the discovery of repositories that have been forked.
  */
@@ -17,7 +16,7 @@ public class ExcludeForkedRepositoriesTrait extends SCMNavigatorTrait {
 
   /** Constructor for stapler. */
   @DataBoundConstructor
-  public ExcludeForkedRepositoriesTrait() { }
+  public ExcludeForkedRepositoriesTrait() {}
 
   /** {@inheritDoc} */
   @Override

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ExcludeForkedRepositoriesTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ExcludeForkedRepositoriesTrait.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+import hudson.Extension;
+import javax.annotation.Nonnull;
+import jenkins.scm.api.trait.SCMNavigatorContext;
+import jenkins.scm.api.trait.SCMNavigatorTrait;
+import jenkins.scm.api.trait.SCMNavigatorTraitDescriptor;
+import jenkins.scm.impl.trait.Selection;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+
+/**
+ * A {@link Selection} trait that will restrict the discovery of repositories that have been forked.
+ */
+public class ExcludeForkedRepositoriesTrait extends SCMNavigatorTrait {
+
+  /** Constructor for stapler. */
+  @DataBoundConstructor
+  public ExcludeForkedRepositoriesTrait() { }
+
+  /** {@inheritDoc} */
+  @Override
+  protected void decorateContext(SCMNavigatorContext<?, ?> context) {
+    super.decorateContext(context);
+    GitHubSCMNavigatorContext ctx = (GitHubSCMNavigatorContext) context;
+    ctx.setExcludeForkedRepositories(true);
+  }
+
+  /** Exclude forked repositories filter */
+  @Symbol("gitHubExcludeForkedRepositories")
+  @Extension
+  @Selection
+  public static class DescriptorImpl extends SCMNavigatorTraitDescriptor {
+
+    @Override
+    public Class<? extends SCMNavigatorContext> getContextClass() {
+      return GitHubSCMNavigatorContext.class;
+    }
+
+    @Nonnull
+    @Override
+    public String getDisplayName() {
+      return Messages.ExcludeForkedRepositoriesTrait_displayName();
+    }
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1009,7 +1009,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                             System.currentTimeMillis(),
                             String.format(
                                 "Skipping repository %s because it is public", repo.getName())));
-              } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories() 
+              } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories()
                   && repo.getSource() != null) {
                 witness.record(repo.getName(), false);
                 listener

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1009,8 +1009,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
                             System.currentTimeMillis(),
                             String.format(
                                 "Skipping repository %s because it is public", repo.getName())));
-              } else if (repo.getSource() != null
-                  && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+              } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories() 
+                  && repo.getSource() != null) {
                 witness.record(repo.getName(), false);
                 listener
                     .getLogger()

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1396,8 +1396,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
                           System.currentTimeMillis(),
                           String.format(
                               "Skipping repository %s because it is public", repo.getName())));
-            } else if (repo.getSource() != null
-                && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+            } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories()
+                && repo.getSource() != null) {
               witness.record(repo.getName(), false);
               listener
                   .getLogger()

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1101,8 +1101,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
                           String.format(
                               "Skipping repository %s because it is public", repo.getName())));
 
-            } else if (repo.getSource() != null
-                && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+            } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories()
+                && repo.getSource() != null) {
               witness.record(repo.getName(), false);
               listener
                   .getLogger()

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1009,6 +1009,16 @@ public class GitHubSCMNavigator extends SCMNavigator {
                             System.currentTimeMillis(),
                             String.format(
                                 "Skipping repository %s because it is public", repo.getName())));
+              } else if (repo.getSource() != null
+                  && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+                witness.record(repo.getName(), false);
+                listener
+                    .getLogger()
+                    .println(
+                        GitHubConsoleNote.create(
+                            System.currentTimeMillis(),
+                            String.format(
+                                "Skipping repository %s because it is a fork", repo.getName())));
               } else if (request.process(repo.getName(), sourceFactory, null, witness)) {
                 listener
                     .getLogger()
@@ -1091,6 +1101,16 @@ public class GitHubSCMNavigator extends SCMNavigator {
                           String.format(
                               "Skipping repository %s because it is public", repo.getName())));
 
+            } else if (repo.getSource() != null
+                && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+              witness.record(repo.getName(), false);
+              listener
+                .getLogger()
+                .println(
+                    GitHubConsoleNote.create(
+                      System.currentTimeMillis(),
+                      String.format(
+                        "Skipping repository %s because it is a fork", repo.getName())));
             } else if (request.process(repo.getName(), sourceFactory, null, witness)) {
               listener
                   .getLogger()
@@ -1144,6 +1164,16 @@ public class GitHubSCMNavigator extends SCMNavigator {
                           String.format(
                               "Skipping repository %s because it is missing one or more of the following topics: '%s'",
                               repo.getName(), gitHubSCMNavigatorContext.getTopics())));
+            } else if (repo.getSource() != null
+                && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+              witness.record(repo.getName(), false);
+              listener
+                .getLogger()
+                .println(
+                    GitHubConsoleNote.create(
+                      System.currentTimeMillis(),
+                      String.format(
+                        "Skipping repository %s because it is a fork", repo.getName())));
             } else if (request.process(repo.getName(), sourceFactory, null, witness)) {
               listener
                   .getLogger()
@@ -1285,6 +1315,16 @@ public class GitHubSCMNavigator extends SCMNavigator {
                             String.format(
                                 "Skipping repository %s because it is public", repo.getName())));
 
+              } else if (repo.getSource() != null
+                  && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+                witness.record(repo.getName(), false);
+                listener
+                  .getLogger()
+                  .println(
+                      GitHubConsoleNote.create(
+                        System.currentTimeMillis(),
+                        String.format(
+                          "Skipping repository %s because it is a fork", repo.getName())));
               } else if (request.process(repo.getName(), sourceFactory, null, witness)) {
                 listener
                     .getLogger()
@@ -1356,6 +1396,16 @@ public class GitHubSCMNavigator extends SCMNavigator {
                           System.currentTimeMillis(),
                           String.format(
                               "Skipping repository %s because it is public", repo.getName())));
+            } else if (repo.getSource() != null
+                && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+              witness.record(repo.getName(), false);
+              listener
+                .getLogger()
+                .println(
+                    GitHubConsoleNote.create(
+                      System.currentTimeMillis(),
+                      String.format(
+                        "Skipping repository %s because it is a fork", repo.getName())));
 
             } else if (request.process(repo.getName(), sourceFactory, null, witness)) {
               listener
@@ -1424,6 +1474,17 @@ public class GitHubSCMNavigator extends SCMNavigator {
                           System.currentTimeMillis(),
                           String.format(
                               "Skipping repository %s because it is public", repo.getName())));
+
+            } else if (repo.getSource() != null
+                && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+              witness.record(repo.getName(), false);
+              listener
+                .getLogger()
+                .println(
+                    GitHubConsoleNote.create(
+                      System.currentTimeMillis(),
+                      String.format(
+                        "Skipping repository %s because it is a fork", repo.getName())));
 
             } else if (request.process(repo.getName(), sourceFactory, null, witness)) {
               listener

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1105,12 +1105,12 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
               witness.record(repo.getName(), false);
               listener
-                .getLogger()
-                .println(
-                    GitHubConsoleNote.create(
-                      System.currentTimeMillis(),
-                      String.format(
-                        "Skipping repository %s because it is a fork", repo.getName())));
+                  .getLogger()
+                  .println(
+                      GitHubConsoleNote.create(
+                          System.currentTimeMillis(),
+                          String.format(
+                              "Skipping repository %s because it is a fork", repo.getName())));
             } else if (request.process(repo.getName(), sourceFactory, null, witness)) {
               listener
                   .getLogger()
@@ -1168,12 +1168,12 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
               witness.record(repo.getName(), false);
               listener
-                .getLogger()
-                .println(
-                    GitHubConsoleNote.create(
-                      System.currentTimeMillis(),
-                      String.format(
-                        "Skipping repository %s because it is a fork", repo.getName())));
+                  .getLogger()
+                  .println(
+                      GitHubConsoleNote.create(
+                          System.currentTimeMillis(),
+                          String.format(
+                              "Skipping repository %s because it is a fork", repo.getName())));
             } else if (request.process(repo.getName(), sourceFactory, null, witness)) {
               listener
                   .getLogger()
@@ -1319,12 +1319,12 @@ public class GitHubSCMNavigator extends SCMNavigator {
                   && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
                 witness.record(repo.getName(), false);
                 listener
-                  .getLogger()
-                  .println(
-                      GitHubConsoleNote.create(
-                        System.currentTimeMillis(),
-                        String.format(
-                          "Skipping repository %s because it is a fork", repo.getName())));
+                    .getLogger()
+                    .println(
+                        GitHubConsoleNote.create(
+                            System.currentTimeMillis(),
+                            String.format(
+                                "Skipping repository %s because it is a fork", repo.getName())));
               } else if (request.process(repo.getName(), sourceFactory, null, witness)) {
                 listener
                     .getLogger()
@@ -1400,12 +1400,12 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
               witness.record(repo.getName(), false);
               listener
-                .getLogger()
-                .println(
-                    GitHubConsoleNote.create(
-                      System.currentTimeMillis(),
-                      String.format(
-                        "Skipping repository %s because it is a fork", repo.getName())));
+                  .getLogger()
+                  .println(
+                      GitHubConsoleNote.create(
+                          System.currentTimeMillis(),
+                          String.format(
+                              "Skipping repository %s because it is a fork", repo.getName())));
 
             } else if (request.process(repo.getName(), sourceFactory, null, witness)) {
               listener
@@ -1479,12 +1479,12 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
               witness.record(repo.getName(), false);
               listener
-                .getLogger()
-                .println(
-                    GitHubConsoleNote.create(
-                      System.currentTimeMillis(),
-                      String.format(
-                        "Skipping repository %s because it is a fork", repo.getName())));
+                  .getLogger()
+                  .println(
+                      GitHubConsoleNote.create(
+                          System.currentTimeMillis(),
+                          String.format(
+                              "Skipping repository %s because it is a fork", repo.getName())));
 
             } else if (request.process(repo.getName(), sourceFactory, null, witness)) {
               listener

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1315,8 +1315,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
                             String.format(
                                 "Skipping repository %s because it is public", repo.getName())));
 
-              } else if (repo.getSource() != null
-                  && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+              } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories()
+                  && repo.getSource() != null) {
                 witness.record(repo.getName(), false);
                 listener
                     .getLogger()

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1475,8 +1475,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
                           String.format(
                               "Skipping repository %s because it is public", repo.getName())));
 
-            } else if (repo.getSource() != null
-                && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+            } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories()
+                && repo.getSource() != null) {
               witness.record(repo.getName(), false);
               listener
                   .getLogger()

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1164,8 +1164,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
                           String.format(
                               "Skipping repository %s because it is missing one or more of the following topics: '%s'",
                               repo.getName(), gitHubSCMNavigatorContext.getTopics())));
-            } else if (repo.getSource() != null
-                && gitHubSCMNavigatorContext.isExcludeForkedRepositories()) {
+            } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories()
+                && repo.getSource() != null) {
               witness.record(repo.getName(), false);
               listener
                   .getLogger()

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorContext.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorContext.java
@@ -50,6 +50,9 @@ public class GitHubSCMNavigatorContext
   /** If true, public repositories will be ignored. */
   private boolean excludePublicRepositories;
 
+  /** If true, forked repositories will be ignored. */
+  private boolean excludeForkedRepositories;
+
   /** {@inheritDoc} */
   @NonNull
   @Override
@@ -96,6 +99,11 @@ public class GitHubSCMNavigatorContext
     return excludePublicRepositories;
   }
 
+  /** @return True if forked repositories should be ignored, false if they should be included. */
+  public boolean isExcludeForkedRepositories() {
+    return excludeForkedRepositories;
+  }
+
   /** @param excludeArchivedRepositories Set true to exclude archived repositories */
   public void setExcludeArchivedRepositories(boolean excludeArchivedRepositories) {
     this.excludeArchivedRepositories = excludeArchivedRepositories;
@@ -104,5 +112,10 @@ public class GitHubSCMNavigatorContext
   /** @param excludePublicRepositories Set true to exclude public repositories */
   public void setExcludePublicRepositories(boolean excludePublicRepositories) {
     this.excludePublicRepositories = excludePublicRepositories;
+  }
+
+  /** @param excludeForkedRepositories Set true to exclude archived repositories */
+  public void setExcludeForkedRepositories(boolean excludeForkedRepositories) {
+    this.excludeForkedRepositories = excludeForkedRepositories;
   }
 }

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -66,7 +66,7 @@ TagDiscoveryTrait.authorityDisplayName=Trust origin tags
 TagDiscoveryTrait.displayName=Discover tags
 ExcludeArchivedRepositoriesTrait.displayName=Exclude archived repositories
 ExcludePublicRepositoriesTrait.displayName=Exclude public repositories
-ExcludeForkedRepositoriesTrait.displayName=Exclude forked repositories
+ExcludeForkedRepositoriesTrait.displayName=Exclude repositories that are forks of another repository
 
 GitHubSCMNavigator.general=General
 GitHubSCMNavigator.withinRepository=Within repository

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -66,6 +66,7 @@ TagDiscoveryTrait.authorityDisplayName=Trust origin tags
 TagDiscoveryTrait.displayName=Discover tags
 ExcludeArchivedRepositoriesTrait.displayName=Exclude archived repositories
 ExcludePublicRepositoriesTrait.displayName=Exclude public repositories
+ExcludeForkedRepositoriesTrait.displayName=Exclude forked repositories
 
 GitHubSCMNavigator.general=General
 GitHubSCMNavigator.withinRepository=Within repository

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -254,6 +254,19 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
   }
 
   @Test
+  public void fetchOneRepo_ExcludingForked() throws Exception {
+    setCredentials(Collections.singletonList(credentials));
+    navigator = navigatorForRepoOwner("stephenc", credentials.getId());
+    navigator.setTraits(Collections.singletonList(new ExcludeForkedRepositoriesTrait()));
+    final Set<String> projectNames = new HashSet<>();
+    final SCMSourceObserver observer = getObserver(projectNames);
+
+    navigator.visitSources(SCMSourceObserver.filter(observer, "yolo-original"));
+
+    assertThat(projectNames, containsInAnyOrder("yolo-original"));
+  }
+
+  @Test
   public void fetchOneRepo_BelongingToOrg() throws Exception {
     final Set<String> projectNames = new HashSet<>();
     final SCMSourceObserver observer = getObserver(projectNames);

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -261,9 +261,9 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
     final Set<String> projectNames = new HashSet<>();
     final SCMSourceObserver observer = getObserver(projectNames);
 
-    navigator.visitSources(SCMSourceObserver.filter(observer, "yolo-original"));
+    navigator.visitSources(SCMSourceObserver.filter(observer, "yolo-private"));
 
-    assertThat(projectNames, containsInAnyOrder("yolo-original"));
+    assertThat(projectNames, containsInAnyOrder("yolo-private"));
   }
 
   @Test


### PR DESCRIPTION
# Description

I want to be able to point jenkins at my personal github account, but ignore all the repos i've forked to submit PRs. I only want to build original repositories.

Reviewer things to note:
* ~Spacing is inconsitent between files. Sometimes its 4 sometimes its 2. I'm going to make another PR (#418) that adds an .editorconfig with spacing set to 2.~ spotless has apparently handled this
* I couldn't figure out how to generate the test files, they seem very much stephenc and cloudbees
* Enforcer is complaining about plugin versions, but I didn't change any of that
<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [/] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

