### PR TITLE
Support underscores in user names

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -151,7 +151,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
 
   public static final String VALID_GITHUB_REPO_NAME = "^[0-9A-Za-z._-]+$";
   public static final String VALID_GITHUB_USER_NAME =
-      "^[A-Za-z0-9](?:[A-Za-z0-9]|-_(?=[A-Za-z0-9])){0,38}$";
+      "^[A-Za-z0-9](?:[A-Za-z0-9_]|-(?=[A-Za-z0-9])){0,38}$";
   public static final String VALID_GIT_SHA1 = "^[a-fA-F0-9]{40}$";
   public static final String GITHUB_URL = GitHubServerConfig.GITHUB_URL;
   public static final String GITHUB_COM = "github.com";

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -151,7 +151,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
 
   public static final String VALID_GITHUB_REPO_NAME = "^[0-9A-Za-z._-]+$";
   public static final String VALID_GITHUB_USER_NAME =
-      "^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$";
+      "^[A-Za-z0-9](?:[A-Za-z0-9]|-_(?=[A-Za-z0-9])){0,38}$";
   public static final String VALID_GIT_SHA1 = "^[a-fA-F0-9]{40}$";
   public static final String GITHUB_URL = GitHubServerConfig.GITHUB_URL;
   public static final String GITHUB_COM = "github.com";


### PR DESCRIPTION
GitHub is in specific limited cases producing a single underscore in an account name.

# Description

A brief summary describing the changes in this pull request. See 
[JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed
_This is to support existing Jenkins and GitHub users who brought this blocker to our attention and will require this modification._

# Users/aliases to notify

