### PR TITLE
Use specific version of google java format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,10 @@
                     <java>
                         <googleJavaFormat>
                             <style>GOOGLE</style>
+                            <!-- Last version that supports Java 8, the plugin does handle this internally
+                                 but it will give different versions based off of the JVM version, not good for CI
+                             -->
+                            <version>1.7</version>
                         </googleJavaFormat>
                     </java>
                 </configuration>


### PR DESCRIPTION
See https://github.com/diffplug/spotless/blob/a7f25eb51c6d4006591ea911157e62d0213e320b/lib/src/main/java/com/diffplug/spotless/java/GoogleJavaFormatStep.java#L99

Versions differ depending on your JVM version.
I was adding this to one of my plugins based off of the config here, locally I was getting no failures but on CI I had a failure...

I tracked it down to the above

cc @bitwiseman @jtnord 