### PR TITLE
JENKINS-66401 Use configured GitHub endpoint for default

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
@@ -6,11 +6,13 @@ import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.util.LogTaskListener;
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.github.config.GitHubServerConfig;
 import org.kohsuke.github.GHRateLimit;
 import org.kohsuke.github.GitHub;
@@ -231,13 +233,22 @@ public enum ApiRateLimitChecker {
         throws InterruptedException {
       LocalChecker checker = getLocalChecker();
       if (checker == null) {
-        // If a checker was not configured for this thread, try our best and continue.
-        configureThreadLocalChecker(
-            new LogTaskListener(LOGGER, Level.INFO), GitHubServerConfig.GITHUB_URL);
+        // If a checker was not configured for this thread, try our best by attempting to get the
+        // URL from the first configured GitHub endpoint, else default to the public endpoint.
+        // NOTE: Defaulting to the public GitHub endpoint is insufficient for those using GitHub
+        // enterprise as it forces rate limit checking in those cases.
+        String apiUrl = GitHubServerConfig.GITHUB_URL;
+        List<Endpoint> endpoints = GitHubConfiguration.get().getEndpoints();
+        if (endpoints.size() > 0 && !StringUtils.isBlank(endpoints.get(0).getApiUri())) {
+          apiUrl = endpoints.get(0).getApiUri();
+        }
+        configureThreadLocalChecker(new LogTaskListener(LOGGER, Level.INFO), apiUrl);
         checker = getLocalChecker();
         checker.writeLog(
             "LocalChecker for rate limit was not set for this thread. "
-                + "Configured using system settings.");
+                + "Configured using system settings with API URL '"
+                + apiUrl
+                + "'.");
       }
       return checker.checkRateLimit(rateLimitRecord, count);
     }


### PR DESCRIPTION
# Description

See [JENKINS-66401](https://issues.jenkins-ci.org/browse/JENKINS-66401) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer instructions
- Test 1) ensure there are no GitHub servers/endpoints configured, then trigger an operation that uses the branch source without the api rate limit configured explicitly. An easy operation I've found is `readTrusted`, which will trigger this behavior the *first* time it is called for a commit. After that, it seems to cache the commit and doesn't need to actually call the GitHub API. I've been using a single PR and amending the commit to trigger it each time, that seems to work well. The message in the System logs (not the job logs) should state that the API URL used is the public github endpoint.
- Test 2) add a custom endpoint to the Jenkins configuration. Perform the same action as above to trigger the behavior and observe the message in the system logs, it should be using the configured endpoint. This also means that is no throttling is configured in the system, it should also perform no throttling on the request since the public GitHub endpoint is not being used.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [x] Link to jenkins.io PR, or an explanation for why no doc changes are needed

I don't believe any doc changes are needed. I believe the current behavior is actually a bug and was surprising to me and others. I figure people will not be configuring github endpoints unless they are not using the public github endpoint at all (or very much), since it typically is for enterprise usage.

# Users/aliases to notify

