### PR TITLE
[github-app-auth] Only subscribe to supported events

### DIFF
--- a/docs/github-app.adoc
+++ b/docs/github-app.adoc
@@ -51,7 +51,30 @@ Permissions this plugin uses:
 - Metadata: Read-only
 - Pull requests: Read-only
 
-Under _Subscribe to events_, enable all events.
+Under _Subscribe to events_, enable the following events:
+
+- Meta
+- Security advisory
+- Commit comment
+- Create
+- Delete
+- Fork
+- Gollum
+- Label
+- Milestone
+- Public
+- Pull request
+- Pull request review
+- Pull request review comment
+- Push
+- Release
+- Repository
+- Repository dispatch
+- Star
+- Status
+- Watch
+- Workflow dispatch
+- Workflow run
 
 Click 'Create GitHub app'
 


### PR DESCRIPTION
# Description

Subscribing to `workflow_job`, `"Merge queue entry"` and `"Pull request review thread"` causes errors listed below:
- ``com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `org.kohsuke.github.GHEvent` from String "merge_queue_entry":``
- ``com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `org.kohsuke.github.GHEvent` from String "pull_request_review_thread":``
- ``com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `org.kohsuke.github.GHEvent` from String "workflow_job":``
<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

