### PR TITLE
[JENKINS-64494] number of tries to get the mergeable status is now configurable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -116,6 +116,7 @@ import jenkins.scm.impl.form.NamedArrayList;
 import jenkins.scm.impl.trait.Discovery;
 import jenkins.scm.impl.trait.Selection;
 import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
+import jenkins.util.SystemProperties;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.Constants;
 import org.jenkinsci.Symbol;
@@ -1786,15 +1787,14 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
       GHPullRequest pr, TaskListener listener, GitHub github, GHRepository ghRepository)
       throws IOException, InterruptedException {
     final long sleep = 1000;
-    int retryCountdown = 4;
+    int retryCountdown = SystemProperties.getInteger(GitHubSCMSource.class.getName() + ".mergeableStatusRetries", Integer.valueOf(4));
 
     while (pr.getMergeable() == null && retryCountdown > 1) {
       listener
           .getLogger()
           .format(
               "Waiting for GitHub to create a merge commit for pull request %d.  Retrying %d more times...%n",
-              pr.getNumber(), retryCountdown);
-      retryCountdown -= 1;
+              pr.getNumber(), --retryCountdown);
       Thread.sleep(sleep);
     }
   }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -183,6 +183,11 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
    */
   private static final Object pullRequestSourceMapLock = new Object();
 
+  /** Number of times we will retry asking GitHub for the mergeable status of a PR. */
+  private static /* mostly final */ int mergeableStatusRetries =
+      SystemProperties.getInteger(
+          GitHubSCMSource.class.getName() + ".mergeableStatusRetries", Integer.valueOf(4));
+
   //////////////////////////////////////////////////////////////////////
   // Configuration fields
   //////////////////////////////////////////////////////////////////////
@@ -1787,9 +1792,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
       GHPullRequest pr, TaskListener listener, GitHub github, GHRepository ghRepository)
       throws IOException, InterruptedException {
     final long sleep = 1000;
-    int retryCountdown =
-        SystemProperties.getInteger(
-            GitHubSCMSource.class.getName() + ".mergeableStatusRetries", Integer.valueOf(4));
+    int retryCountdown = mergeableStatusRetries;
 
     while (pr.getMergeable() == null && retryCountdown > 1) {
       listener

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1787,7 +1787,9 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
       GHPullRequest pr, TaskListener listener, GitHub github, GHRepository ghRepository)
       throws IOException, InterruptedException {
     final long sleep = 1000;
-    int retryCountdown = SystemProperties.getInteger(GitHubSCMSource.class.getName() + ".mergeableStatusRetries", Integer.valueOf(4));
+    int retryCountdown =
+        SystemProperties.getInteger(
+            GitHubSCMSource.class.getName() + ".mergeableStatusRetries", Integer.valueOf(4));
 
     while (pr.getMergeable() == null && retryCountdown > 1) {
       listener


### PR DESCRIPTION


use a SystemProperty
`org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.mergeableStatusRetries`
to configure the number of times we retry to obtain the mergeable status
of a PR.  If GHE is slow (and sometime gh.com) then changing this from
the default value of 4 may help.

# Description

A brief summary describing the changes in this pull request. See 
[JENKINS-64494](https://issues.jenkins-ci.org/browse/JENKINS-64494) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

