### PR TITLE
JENKINS-65970 Ability to ignore indexing errors and continue scanning

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/AbstractGitHubSCMHeadProcessErrorStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/AbstractGitHubSCMHeadProcessErrorStrategy.java
@@ -1,0 +1,13 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+import jenkins.scm.api.SCMHead;
+
+public abstract class AbstractGitHubSCMHeadProcessErrorStrategy {
+  public abstract boolean shouldIgnore(SCMHead head, Throwable t);
+
+  /** {@inheritDoc} */
+  public abstract boolean equals(Object o);
+
+  /** {@inheritDoc} */
+  public abstract int hashCode();
+}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMHeadProcessIgnoreErrorTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMHeadProcessIgnoreErrorTrait.java
@@ -1,0 +1,119 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMBuilder;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.Objects;
+
+public class GitHubSCMHeadProcessIgnoreErrorTrait extends SCMSourceTrait {
+  private boolean ignoreBranch;
+  private boolean ignorePR;
+  private boolean ignoreTag;
+
+  @DataBoundConstructor
+  public GitHubSCMHeadProcessIgnoreErrorTrait(boolean ignoreBranch, boolean ignorePR, boolean ignoreTag) {
+    this.ignoreBranch = ignoreBranch;
+    this.ignorePR = ignorePR;
+    this.ignoreTag = ignoreTag;
+  }
+
+
+  public boolean isIgnoreBranch() {
+    return ignoreBranch;
+  }
+
+  public boolean isIgnorePR() {
+    return ignorePR;
+  }
+
+  public boolean isIgnoreTag() {
+    return ignoreTag;
+  }
+
+  @Override
+  protected void decorateContext(SCMSourceContext<?, ?> context) {
+    GitHubSCMSourceContext githubContext = (GitHubSCMSourceContext) context;
+    githubContext.withHeadProcessErrorStrategy(new GitHubSCMHeadProcessIgnoreErrorStrategy(ignoreBranch, ignorePR, ignoreTag));
+  }
+
+  @Override
+  public boolean includeCategory(@NonNull SCMHeadCategory category) {
+    return category.isUncategorized();
+  }
+
+  @Extension
+  public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+      return "Ignore Indexing Errors";
+    }
+
+    @Override
+    public Class<? extends SCMBuilder> getBuilderClass() {
+      return GitHubSCMBuilder.class;
+    }
+
+    @Override
+    public Class<? extends SCMSourceContext> getContextClass() {
+      return GitHubSCMSourceContext.class;
+    }
+
+    @Override
+    public Class<? extends SCMSource> getSourceClass() {
+      return GitHubSCMSource.class;
+    }
+  }
+
+  private static final class GitHubSCMHeadProcessIgnoreErrorStrategy extends AbstractGitHubSCMHeadProcessErrorStrategy {
+
+    private boolean ignoreBranch;
+    private boolean ignorePR;
+    private boolean ignoreTag;
+
+    public GitHubSCMHeadProcessIgnoreErrorStrategy(boolean ignoreBranch, boolean ignorePR, boolean ignoreTag) {
+      this.ignoreBranch = ignoreBranch;
+      this.ignorePR = ignorePR;
+      this.ignoreTag = ignoreTag;
+    }
+
+    @Override
+    public boolean shouldIgnore(SCMHead head, Throwable t) {
+      if (head instanceof BranchSCMHead) {
+        return ignoreBranch;
+      }
+
+      if (head instanceof PullRequestSCMHead) {
+        return ignorePR;
+      }
+
+      if (head instanceof GitHubTagSCMHead) {
+        return ignoreTag;
+      }
+
+      return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      GitHubSCMHeadProcessIgnoreErrorStrategy that = (GitHubSCMHeadProcessIgnoreErrorStrategy) o;
+      return ignoreBranch == that.ignoreBranch && ignorePR == that.ignorePR && ignoreTag == that.ignoreTag;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(ignoreBranch, ignorePR, ignoreTag);
+    }
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbe.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbe.java
@@ -26,6 +26,7 @@
 package org.jenkinsci.plugins.github_branch_source;
 
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.FileNotFoundException;
@@ -142,7 +143,7 @@ class GitHubSCMProbe extends SCMProbe implements GitHubClosable {
     try {
       int index = path.lastIndexOf('/') + 1;
       List<GHContent> directoryContent =
-          repo.getDirectoryContent(path.substring(0, index), Constants.R_REFS + ref);
+        repo.getDirectoryContent(path.substring(0, index), Constants.R_REFS + ref);
       for (GHContent content : directoryContent) {
         if (content.getPath().equals(path)) {
           if (content.isFile()) {
@@ -163,6 +164,11 @@ class GitHubSCMProbe extends SCMProbe implements GitHubClosable {
       }
     } catch (FileNotFoundException fnf) {
       // means that does not exist and this is handled below this try/catch block.
+    //} catch (IOException e) {
+      //Throwable t = e.getCause();
+      //if (!(t instanceof MismatchedInputException)) {
+        //throw e;
+      //}
     }
     return SCMProbeStat.fromType(SCMFile.Type.NONEXISTENT);
   }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceContext.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceContext.java
@@ -58,6 +58,7 @@ public class GitHubSCMSourceContext
    * requests.
    */
   private boolean wantForkPRs;
+
   /** Set of {@link ChangeRequestCheckoutStrategy} to create for each origin pull request. */
   @NonNull
   private Set<ChangeRequestCheckoutStrategy> originPRStrategies =
@@ -74,6 +75,7 @@ public class GitHubSCMSourceContext
    * @since 2.3.2
    */
   private final List<AbstractGitHubNotificationStrategy> notificationStrategies = new ArrayList<>();
+  private final List<AbstractGitHubSCMHeadProcessErrorStrategy> headProcessErrorStrategies = new ArrayList<>();
 
   /**
    * Constructor.
@@ -171,6 +173,10 @@ public class GitHubSCMSourceContext
       return Collections.singletonList(new DefaultGitHubNotificationStrategy());
     }
     return Collections.unmodifiableList(notificationStrategies);
+  }
+
+  public final List<AbstractGitHubSCMHeadProcessErrorStrategy> headProcessErrorStrategies() {
+    return Collections.unmodifiableList(headProcessErrorStrategies);
   }
   /**
    * Returns {@code true} if notifications should be disabled.
@@ -293,6 +299,25 @@ public class GitHubSCMSourceContext
       AbstractGitHubNotificationStrategy strategy) {
     if (!notificationStrategies.contains(strategy)) {
       notificationStrategies.add(strategy);
+    }
+    return this;
+  }
+
+  public final GitHubSCMSourceContext withHeadProcessErrorStrategies(
+      List<AbstractGitHubSCMHeadProcessErrorStrategy> strategies) {
+    headProcessErrorStrategies.clear();
+    for (AbstractGitHubSCMHeadProcessErrorStrategy strategy : strategies) {
+      if (!headProcessErrorStrategies.contains(strategy)) {
+        headProcessErrorStrategies.add(strategy);
+      }
+    }
+    return this;
+  }
+
+  public final GitHubSCMSourceContext withHeadProcessErrorStrategy(
+      AbstractGitHubSCMHeadProcessErrorStrategy strategy) {
+    if (!headProcessErrorStrategies.contains(strategy)) {
+      headProcessErrorStrategies.add(strategy);
     }
     return this;
   }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceRequest.java
@@ -29,13 +29,8 @@ import hudson.Util;
 import hudson.model.TaskListener;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
+
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadOrigin;
 import jenkins.scm.api.SCMSource;
@@ -67,6 +62,7 @@ public class GitHubSCMSourceRequest extends SCMSourceRequest {
   @NonNull private final Set<ChangeRequestCheckoutStrategy> originPRStrategies;
   /** The {@link ChangeRequestCheckoutStrategy} to create for each fork pull request. */
   @NonNull private final Set<ChangeRequestCheckoutStrategy> forkPRStrategies;
+  private final List<AbstractGitHubSCMHeadProcessErrorStrategy> headProcessErrorStrategies;
   /**
    * The set of pull request numbers that the request is scoped to or {@code null} if the request is
    * not limited.
@@ -122,6 +118,7 @@ public class GitHubSCMSourceRequest extends SCMSourceRequest {
         fetchForkPRs && !context.forkPRStrategies().isEmpty()
             ? Collections.unmodifiableSet(EnumSet.copyOf(context.forkPRStrategies()))
             : Collections.emptySet();
+    headProcessErrorStrategies = context.headProcessErrorStrategies();
     Set<SCMHead> includes = context.observer().getIncludes();
     if (includes != null) {
       Set<Integer> pullRequestNumbers = new HashSet<>(includes.size());
@@ -479,5 +476,9 @@ public class GitHubSCMSourceRequest extends SCMSourceRequest {
    */
   public void setPermissionsSource(@CheckForNull GitHubPermissionsSource permissionsSource) {
     this.permissionsSource = permissionsSource;
+  }
+
+  public List<AbstractGitHubSCMHeadProcessErrorStrategy> headProcessErrorStrategies() {
+    return headProcessErrorStrategies;
   }
 }

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMHeadProcessIgnoreErrorTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMHeadProcessIgnoreErrorTrait/config.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="Ignore Branch Scanning Errors" field="ignoreBranch">
+    <f:checkbox />
+  </f:entry>
+  <f:entry title="Ignore Pull Request Scanning Errors" field="ignorePR">
+    <f:checkbox />
+  </f:entry>
+  <f:entry title="Ignore Tag Scanning Errors" field="ignoreTag">
+    <f:checkbox />
+  </f:entry>
+</j:jelly>


### PR DESCRIPTION
# Description

A brief summary describing the changes in this pull request. See 
[JENKINS-65970](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX) for further information.

The linked issue is about a specific case where this plugin is looking for a Jenkinsfile in a path which is a submodule root for a given SCMHead. Jackson tries to deserialize the response as an array and fails because a single submodule result is returned, which is also not currently handled in the github-api library. I tried to figure out what would be required to cover that case and found some discussion about needing submodule traversal support to properly handle it https://github.com/hub4j/github-api/issues/915.

One option is ignoring the specific MismatchedInputException in the `GitHubSCMProbe.stat` function which retrieves the contents of a directory, but that didn't seem great. I left it commented out in the draft.

I then saw that there was some error-ignoring logic for Pull Request heads already which had a comment implying the rationale behind interrupting scanning except in this case. I think there are probably cases where a user doesn't mind ignoring most errors and would rather complete the indexing job. I tried to implement similar error-ignoring logic for the other SCMHead types on an opt-in basis. 

I'm opening this PR for solution discussion as well as reviews of this implementation.
Not much of a java developer so any pointers are appreciated :)

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

