### PR TITLE
Update log recorder API (test only)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <hpi.compatibleSinceVersion>2.2.0</hpi.compatibleSinceVersion>
         <java.level>8</java.level>
-        <jenkins.version>2.323-rc31756.82cf54ab0e2f</jenkins.version>
+        <jenkins.version>2.323</jenkins.version>
         <useBeta>true</useBeta>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <hpi.compatibleSinceVersion>2.2.0</hpi.compatibleSinceVersion>
         <java.level>8</java.level>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.323-rc31756.82cf54ab0e2f</jenkins.version>
         <useBeta>true</useBeta>
     </properties>
 

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
@@ -118,9 +118,9 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
     // Would use LoggerRule, but need to get agent logs as well
     LogRecorderManager mgr = r.jenkins.getLog();
     logRecorder = new LogRecorder(GitHubAppCredentials.class.getName());
-    mgr.logRecorders.put(GitHubAppCredentials.class.getName(), logRecorder);
+    mgr.getRecorders().add(logRecorder);
     LogRecorder.Target t = new LogRecorder.Target(GitHubAppCredentials.class.getName(), Level.FINE);
-    logRecorder.targets.add(t);
+    logRecorder.getLoggers().add(t);
     logRecorder.save();
     t.enable();
   }


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/4538

The old API is restricted now and shouldn't be used next time baseline is updated.

No rush though