### PR TITLE
Ensure that HTTP client can authenticate with proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
         <dependency>
           <groupId>io.jenkins.plugins</groupId>
           <artifactId>okhttp-api</artifactId>
-          <version>4.9.2-20211102</version>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
             <artifactId>workflow-cps-global-lib</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>io.jenkins.plugins</groupId>
+          <artifactId>okhttp-api</artifactId>
+          <version>4.9.2-20211102</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -50,6 +50,7 @@ import hudson.model.TaskListener;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import io.jenkins.plugins.okhttp.api.JenkinsOkHttpClient;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -72,8 +73,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import io.jenkins.plugins.okhttp.api.JenkinsOkHttpClient;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.util.JenkinsJVM;
@@ -102,7 +101,8 @@ public class Connector {
 
   private static final Random ENTROPY = new Random();
   private static final String SALT = Long.toHexString(ENTROPY.nextLong());
-  private static final OkHttpClient baseClient = JenkinsOkHttpClient.newClientBuilder(new OkHttpClient()).build();
+  private static final OkHttpClient baseClient =
+      JenkinsOkHttpClient.newClientBuilder(new OkHttpClient()).build();
 
   private Connector() {
     throw new IllegalAccessError("Utility class");

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -72,6 +72,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import io.jenkins.plugins.okhttp.api.JenkinsOkHttpClient;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.util.JenkinsJVM;
@@ -100,7 +102,7 @@ public class Connector {
 
   private static final Random ENTROPY = new Random();
   private static final String SALT = Long.toHexString(ENTROPY.nextLong());
-  private static final OkHttpClient baseClient = new OkHttpClient();
+  private static final OkHttpClient baseClient = JenkinsOkHttpClient.newClientBuilder(new OkHttpClient()).build();
 
   private Connector() {
     throw new IllegalAccessError("Utility class");


### PR DESCRIPTION
The HTTP client can currently not use proxies which require authentication.
By using a pre-configured base client this error should be mitigated

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

