### PR TITLE
[JENKINS-62220] Automatically select `owner` for `GitHubAppCredentials` acc. to context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
             <version>1.34.3</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>1078.v80a_fc6a_267e1</version> <!-- TODO https://github.com/jenkinsci/credentials-plugin/pull/293 -->
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.29</version>
+        <version>4.38</version>
         <relativePath />
     </parent>
     <artifactId>github-branch-source</artifactId>
@@ -123,7 +123,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.289.x</artifactId>
-                <version>1090.v0a_33df40457a_</version>
+                <version>1210.vcd41f6657f03</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>1078.v80a_fc6a_267e1</version> <!-- TODO https://github.com/jenkinsci/credentials-plugin/pull/293 -->
+            <version>1087.v16065d268466</version> <!-- TODO until in BOM -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -150,7 +150,7 @@ public class Connector {
    * @param apiUri the api endpoint.
    * @param scanCredentialsId the credentials ID.
    * @return the {@link FormValidation} results.
-   * @deprecated use {@link #checkScanCredentials(Item, String, String)}
+   * @deprecated use {@link #checkScanCredentials(Item, String, String, String)}
    */
   @Deprecated
   public static FormValidation checkScanCredentials(
@@ -166,9 +166,29 @@ public class Connector {
    * @param apiUri the api endpoint.
    * @param scanCredentialsId the credentials ID.
    * @return the {@link FormValidation} results.
+   * @deprecated use {@link #checkScanCredentials(Item, String, String, String)}
    */
+  @Deprecated
   public static FormValidation checkScanCredentials(
       @CheckForNull Item context, String apiUri, String scanCredentialsId) {
+    return checkScanCredentials(context, apiUri, scanCredentialsId, null);
+  }
+
+  /**
+   * Checks the credential ID for use as scan credentials in the supplied context against the
+   * supplied API endpoint.
+   *
+   * @param context the context.
+   * @param apiUri the api endpoint.
+   * @param scanCredentialsId the credentials ID.
+   * @param repoOwner the org/user
+   * @return the {@link FormValidation} results.
+   */
+  public static FormValidation checkScanCredentials(
+      @CheckForNull Item context,
+      String apiUri,
+      String scanCredentialsId,
+      @CheckForNull String repoOwner) {
     if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
         || context != null && !context.hasPermission(Item.EXTENDED_READ)) {
       return FormValidation.ok();
@@ -192,7 +212,8 @@ public class Connector {
           Connector.lookupScanCredentials(
               context,
               StringUtils.defaultIfEmpty(apiUri, GitHubServerConfig.GITHUB_URL),
-              scanCredentialsId);
+              scanCredentialsId,
+              repoOwner);
       if (credentials == null) {
         return FormValidation.error("Credentials not found");
       } else {
@@ -239,7 +260,7 @@ public class Connector {
    * @param apiUri the API endpoint.
    * @param scanCredentialsId the credentials to resolve.
    * @return the {@link StandardCredentials} or {@code null}
-   * @deprecated use {@link #lookupScanCredentials(Item, String, String)}
+   * @deprecated use {@link #lookupScanCredentials(Item, String, String, String)}
    */
   @Deprecated
   @CheckForNull
@@ -258,25 +279,52 @@ public class Connector {
    * @param apiUri the API endpoint.
    * @param scanCredentialsId the credentials to resolve.
    * @return the {@link StandardCredentials} or {@code null}
+   * @deprecated use {@link #lookupScanCredentials(Item, String, String, String)}
    */
+  @Deprecated
   @CheckForNull
   public static StandardCredentials lookupScanCredentials(
       @CheckForNull Item context,
       @CheckForNull String apiUri,
       @CheckForNull String scanCredentialsId) {
+    return lookupScanCredentials(context, apiUri, scanCredentialsId, null);
+  }
+
+  /**
+   * Resolves the specified scan credentials in the specified context for use against the specified
+   * API endpoint.
+   *
+   * @param context the context.
+   * @param apiUri the API endpoint.
+   * @param scanCredentialsId the credentials to resolve.
+   * @param repoOwner the org/user
+   * @return the {@link StandardCredentials} or {@code null}
+   */
+  @CheckForNull
+  public static StandardCredentials lookupScanCredentials(
+      @CheckForNull Item context,
+      @CheckForNull String apiUri,
+      @CheckForNull String scanCredentialsId,
+      @CheckForNull String repoOwner) {
     if (Util.fixEmpty(scanCredentialsId) == null) {
       return null;
     } else {
-      return CredentialsMatchers.firstOrNull(
-          CredentialsProvider.lookupCredentials(
-              StandardUsernameCredentials.class,
-              context,
-              context instanceof Queue.Task
-                  ? ((Queue.Task) context).getDefaultAuthentication()
-                  : ACL.SYSTEM,
-              githubDomainRequirements(apiUri)),
-          CredentialsMatchers.allOf(
-              CredentialsMatchers.withId(scanCredentialsId), githubScanCredentialsMatcher()));
+      StandardCredentials c =
+          CredentialsMatchers.firstOrNull(
+              CredentialsProvider.lookupCredentials(
+                  StandardUsernameCredentials.class,
+                  context,
+                  context instanceof Queue.Task
+                      ? ((Queue.Task) context).getDefaultAuthentication()
+                      : ACL.SYSTEM,
+                  githubDomainRequirements(apiUri)),
+              CredentialsMatchers.allOf(
+                  CredentialsMatchers.withId(scanCredentialsId), githubScanCredentialsMatcher()));
+      if (c instanceof GitHubAppCredentials && repoOwner != null) {
+        return ((GitHubAppCredentials) c).withOwner(repoOwner);
+      } else {
+        return c;
+      }
     }
   }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -81,6 +81,9 @@ public class GitHubAppCredentials extends BaseStandardCredentials
 
   private String apiUri;
 
+  @SuppressFBWarnings(
+      value = "IS2_INCONSISTENT_SYNC",
+      justification = "#withOwner locking only for #byOwner")
   private String owner;
 
   private transient AppInstallationToken cachedToken;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -323,8 +323,14 @@ public class GitHubAppCredentials extends BaseStandardCredentials
     return appID;
   }
 
-  private synchronized GitHubAppCredentials withOwner(String owner) {
-    assert this.owner == null;
+  @NonNull
+  public synchronized GitHubAppCredentials withOwner(@NonNull String owner) {
+    if (this.owner != null) {
+      if (!owner.equals(this.owner)) {
+        throw new IllegalArgumentException("Owner mismatch: " + this.owner + " vs. " + owner);
+      }
+      return this;
+    }
     if (byOwner == null) {
       byOwner = new HashMap<>();
     }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
@@ -191,7 +191,7 @@ public class GitHubBuildStatusNotification {
         return Connector.connect(
             source.getApiUri(),
             Connector.lookupScanCredentials(
-                job, source.getApiUri(), source.getScanCredentialsId()));
+                job, source.getApiUri(), source.getScanCredentialsId(), source.getRepoOwner()));
       }
     }
     return null;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFileSystem.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMFileSystem.java
@@ -241,7 +241,7 @@ public class GitHubSCMFileSystem extends SCMFileSystem implements GitHubClosable
       String apiUri = src.getApiUri();
       StandardCredentials credentials =
           Connector.lookupScanCredentials(
-              (Item) src.getOwner(), apiUri, src.getScanCredentialsId());
+              (Item) src.getOwner(), apiUri, src.getScanCredentialsId(), src.getRepoOwner());
 
       // Github client and validation
       GitHub github = Connector.connect(apiUri, credentials);

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -934,7 +934,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
     }
 
     StandardCredentials credentials =
-        Connector.lookupScanCredentials((Item) observer.getContext(), apiUri, credentialsId);
+        Connector.lookupScanCredentials(
+            (Item) observer.getContext(), apiUri, credentialsId, repoOwner);
 
     // Github client and validation
     GitHub github = Connector.connect(apiUri, credentials);
@@ -1261,7 +1262,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
     }
 
     StandardCredentials credentials =
-        Connector.lookupScanCredentials((Item) observer.getContext(), apiUri, credentialsId);
+        Connector.lookupScanCredentials(
+            (Item) observer.getContext(), apiUri, credentialsId, repoOwner);
 
     // Github client and validation
     GitHub github;
@@ -1575,7 +1577,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
     listener.getLogger().printf("Looking up details of %s...%n", getRepoOwner());
     List<Action> result = new ArrayList<>();
     StandardCredentials credentials =
-        Connector.lookupScanCredentials((Item) owner, getApiUri(), credentialsId);
+        Connector.lookupScanCredentials((Item) owner, getApiUri(), credentialsId, repoOwner);
     GitHub hub = Connector.connect(getApiUri(), credentials);
     try {
       Connector.configureLocalRateLimitChecker(listener, hub);
@@ -1607,7 +1609,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
     try {
       // FIXME MINOR HACK ALERT
       StandardCredentials credentials =
-          Connector.lookupScanCredentials((Item) owner, getApiUri(), credentialsId);
+          Connector.lookupScanCredentials((Item) owner, getApiUri(), credentialsId, repoOwner);
       GitHub hub = Connector.connect(getApiUri(), credentials);
       try {
         GitHubOrgWebHook.register(hub, repoOwner);
@@ -1733,8 +1735,9 @@ public class GitHubSCMNavigator extends SCMNavigator {
     public FormValidation doCheckCredentialsId(
         @CheckForNull @AncestorInPath Item context,
         @QueryParameter String apiUri,
-        @QueryParameter String credentialsId) {
-      return Connector.checkScanCredentials(context, apiUri, credentialsId);
+        @QueryParameter String credentialsId,
+        @QueryParameter String repoOwner) {
+      return Connector.checkScanCredentials(context, apiUri, credentialsId, repoOwner);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -986,7 +986,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
       @NonNull final TaskListener listener)
       throws IOException, InterruptedException {
     StandardCredentials credentials =
-        Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId);
+        Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId, repoOwner);
     // Github client and validation
     final GitHub github = Connector.connect(apiUri, credentials);
     try {
@@ -1296,7 +1296,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
   protected Set<String> retrieveRevisions(@NonNull TaskListener listener, Item retrieveContext)
       throws IOException, InterruptedException {
     StandardCredentials credentials =
-        Connector.lookupScanCredentials(retrieveContext, apiUri, credentialsId);
+        Connector.lookupScanCredentials(retrieveContext, apiUri, credentialsId, repoOwner);
     // Github client and validation
     final GitHub github = Connector.connect(apiUri, credentials);
     try {
@@ -1406,7 +1406,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
       @NonNull String headName, @NonNull TaskListener listener, Item retrieveContext)
       throws IOException, InterruptedException {
     StandardCredentials credentials =
-        Connector.lookupScanCredentials(retrieveContext, apiUri, credentialsId);
+        Connector.lookupScanCredentials(retrieveContext, apiUri, credentialsId, repoOwner);
     // Github client and validation
     final GitHub github = Connector.connect(apiUri, credentials);
     try {
@@ -1654,7 +1654,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
   protected SCMProbe createProbe(@NonNull SCMHead head, @CheckForNull final SCMRevision revision)
       throws IOException {
     StandardCredentials credentials =
-        Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId);
+        Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId, repoOwner);
     // Github client and validation
     GitHub github = Connector.connect(apiUri, credentials);
     try {
@@ -1673,7 +1673,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
   protected SCMRevision retrieve(SCMHead head, TaskListener listener)
       throws IOException, InterruptedException {
     StandardCredentials credentials =
-        Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId);
+        Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId, repoOwner);
 
     // Github client and validation
     GitHub github = Connector.connect(apiUri, credentials);
@@ -1825,7 +1825,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
           String fullName = repoOwner + "/" + repository;
           LOGGER.log(Level.INFO, "Getting remote pull requests from {0}", fullName);
           StandardCredentials credentials =
-              Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId);
+              Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId, repoOwner);
           LogTaskListener listener = new LogTaskListener(LOGGER, Level.INFO);
           try {
             GitHub github = Connector.connect(apiUri, credentials);
@@ -1995,7 +1995,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
     String repository = this.repository;
 
     StandardCredentials credentials =
-        Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId);
+        Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId, repoOwner);
     GitHub hub = Connector.connect(apiUri, credentials);
     try {
       Connector.checkConnectionValidity(apiUri, listener, credentials, hub);
@@ -2129,8 +2129,9 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
     public FormValidation doCheckCredentialsId(
         @CheckForNull @AncestorInPath Item context,
         @QueryParameter String apiUri,
+        @QueryParameter String repoOwner,
         @QueryParameter String value) {
-      return Connector.checkScanCredentials(context, apiUri, value);
+      return Connector.checkScanCredentials(context, apiUri, value, repoOwner);
     }
 
     @RequirePOST
@@ -2138,7 +2139,8 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
     public FormValidation doValidateRepositoryUrlAndCredentials(
         @CheckForNull @AncestorInPath Item context,
         @QueryParameter String repositoryUrl,
-        @QueryParameter String credentialsId) {
+        @QueryParameter String credentialsId,
+        @QueryParameter String repoOwner) {
       if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
           || context != null && !context.hasPermission(Item.EXTENDED_READ)) {
         return FormValidation.error(
@@ -2158,7 +2160,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
       }
 
       StandardCredentials credentials =
-          Connector.lookupScanCredentials(context, info.getApiUri(), credentialsId);
+          Connector.lookupScanCredentials(context, info.getApiUri(), credentialsId, repoOwner);
       StringBuilder sb = new StringBuilder();
       try {
         GitHub github = Connector.connect(info.getApiUri(), credentials);
@@ -2197,8 +2199,9 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
     public FormValidation doCheckScanCredentialsId(
         @CheckForNull @AncestorInPath Item context,
         @QueryParameter String apiUri,
-        @QueryParameter String scanCredentialsId) {
-      return doCheckCredentialsId(context, apiUri, scanCredentialsId);
+        @QueryParameter String scanCredentialsId,
+        @QueryParameter String repoOwner) {
+      return doCheckCredentialsId(context, apiUri, scanCredentialsId, repoOwner);
     }
 
     @Restricted(NoExternalUse.class)
@@ -2282,7 +2285,8 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
     public ListBoxModel doFillOrganizationItems(
         @CheckForNull @AncestorInPath Item context,
         @QueryParameter String apiUri,
-        @QueryParameter String credentialsId)
+        @QueryParameter String credentialsId,
+        @QueryParameter String repoOwner)
         throws IOException {
       if (credentialsId == null) {
         return new ListBoxModel();
@@ -2296,7 +2300,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
       }
       try {
         StandardCredentials credentials =
-            Connector.lookupScanCredentials(context, apiUri, credentialsId);
+            Connector.lookupScanCredentials(context, apiUri, credentialsId, repoOwner);
         GitHub github = Connector.connect(apiUri, credentials);
         try {
           if (!github.isAnonymous()) {
@@ -2344,7 +2348,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
       }
       try {
         StandardCredentials credentials =
-            Connector.lookupScanCredentials(context, apiUri, credentialsId);
+            Connector.lookupScanCredentials(context, apiUri, credentialsId, repoOwner);
         GitHub github = Connector.connect(apiUri, credentials);
         try {
 
@@ -2918,7 +2922,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
               "Connecting to %s to obtain list of collaborators for %s/%s%n",
               apiUri, repoOwner, repository);
       StandardCredentials credentials =
-          Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId);
+          Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId, repoOwner);
       // Github client and validation
       try {
         GitHub github = Connector.connect(apiUri, credentials);
@@ -2986,7 +2990,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                 "Connecting to %s to check permissions of obtain list of %s for %s/%s%n",
                 apiUri, username, repoOwner, repository);
         StandardCredentials credentials =
-            Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId);
+            Connector.lookupScanCredentials((Item) getOwner(), apiUri, credentialsId, repoOwner);
         github = Connector.connect(apiUri, credentials);
         String fullName = repoOwner + "/" + repository;
         repo = github.getRepository(fullName);

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials/help-owner.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials/help-owner.html
@@ -1,3 +1,6 @@
 <p>
-    The organisation or user that this app is to be used for. Only required if this app is installed to multiple organisations.
+    The organisation or user that this app is to be used for.
+    Only required if this app is installed to multiple organisations.
+    May be omitted in case credentials are used from GitHub multibranch projects
+    (in that case the account is determined from the branch source where the credentials are used).
 </p>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/config-detail.jelly
@@ -17,7 +17,7 @@
       <f:entry title="${%Repository HTTPS URL}" field="repositoryUrl">
         <f:textbox/>
       </f:entry>
-      <f:validateButton method="validateRepositoryUrlAndCredentials" title="${%Validate}" with="repositoryUrl,credentialsId" />
+      <f:validateButton method="validateRepositoryUrlAndCredentials" title="${%Validate}" with="repositoryUrl,credentialsId,repoOwner"/>
     </f:nested>
   </f:radioBlock>
   <f:radioBlock name="configuredByUrlRadio" value="false" checked="false" title="${%Repository Scan - Deprecated Visualization}" inline="true">

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsAppInstallationTokenTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsAppInstallationTokenTest.java
@@ -1,11 +1,16 @@
 package org.jenkinsci.plugins.github_branch_source;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
 
 import hudson.util.Secret;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.number.BigDecimalCloseTo;
 import org.junit.Test;
 
 public class GithubAppCredentialsAppInstallationTokenTest {
@@ -22,7 +27,7 @@ public class GithubAppCredentialsAppInstallationTokenTest {
     assertThat(token.isStale(), is(false));
     assertThat(
         token.getTokenStaleEpochSeconds(),
-        equalTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS));
+        closeTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS, 3));
 
     now = Instant.now().getEpochSecond();
     token =
@@ -31,7 +36,7 @@ public class GithubAppCredentialsAppInstallationTokenTest {
     assertThat(token.isStale(), is(false));
     assertThat(
         token.getTokenStaleEpochSeconds(),
-        equalTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS));
+        closeTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS, 3));
 
     now = Instant.now().getEpochSecond();
     token =
@@ -41,7 +46,7 @@ public class GithubAppCredentialsAppInstallationTokenTest {
     assertThat(token.isStale(), is(false));
     assertThat(
         token.getTokenStaleEpochSeconds(),
-        equalTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS));
+        closeTo(now + GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS, 3));
 
     now = Instant.now().getEpochSecond();
     token =
@@ -52,7 +57,7 @@ public class GithubAppCredentialsAppInstallationTokenTest {
                 + Duration.ofMinutes(7).getSeconds());
     assertThat(token.isStale(), is(false));
     assertThat(
-        token.getTokenStaleEpochSeconds(), equalTo(now + Duration.ofMinutes(7).getSeconds()));
+        token.getTokenStaleEpochSeconds(), closeTo(now + Duration.ofMinutes(7).getSeconds(), 3));
 
     now = Instant.now().getEpochSecond();
     token =
@@ -61,8 +66,9 @@ public class GithubAppCredentialsAppInstallationTokenTest {
     assertThat(token.isStale(), is(false));
     assertThat(
         token.getTokenStaleEpochSeconds(),
-        equalTo(now + GitHubAppCredentials.AppInstallationToken.STALE_AFTER_SECONDS + 1));
+        closeTo(now + GitHubAppCredentials.AppInstallationToken.STALE_AFTER_SECONDS + 1, 3));
 
+    // TODO use FlagRule
     long notStaleSeconds = GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS;
     try {
       // Should revert to 1 second minimum
@@ -71,7 +77,7 @@ public class GithubAppCredentialsAppInstallationTokenTest {
       now = Instant.now().getEpochSecond();
       token = new GitHubAppCredentials.AppInstallationToken(secret, now);
       assertThat(token.isStale(), is(false));
-      assertThat(token.getTokenStaleEpochSeconds(), equalTo(now + 1));
+      assertThat(token.getTokenStaleEpochSeconds(), closeTo(now + 1, 3));
 
       // Verify goes stale
       Thread.sleep(1000);
@@ -79,5 +85,26 @@ public class GithubAppCredentialsAppInstallationTokenTest {
     } finally {
       GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = notStaleSeconds;
     }
+  }
+
+  private static Matcher<Long> closeTo(long operand, long error) {
+    BigDecimalCloseTo delegate =
+        new BigDecimalCloseTo(new BigDecimal(operand), new BigDecimal(error));
+    return new TypeSafeMatcher<Long>(Long.class) {
+      @Override
+      protected boolean matchesSafely(Long item) {
+        return delegate.matches(new BigDecimal(item));
+      }
+
+      @Override
+      protected void describeMismatchSafely(Long item, Description mismatchDescription) {
+        delegate.describeMismatchSafely(new BigDecimal(item), mismatchDescription);
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        delegate.describeTo(description);
+      }
+    };
   }
 }


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-62220

Uses https://github.com/jenkinsci/credentials-plugin/pull/293 to ensure that the `owner` field may be left blank yet the appropriate org will still be selected for a particular build. (At least assuming the lookup is via `CredentialsProvider.findCredentialById`, which passes a `Run`, as it would be for example in a `withCredentials` block.)

See discussions e.g. at https://github.com/jenkinsci/github-branch-source-plugin/pull/290#discussion_r401115617 or https://github.com/jenkinsci/github-branch-source-plugin/pull/269#discussion_r396535799.

Tested with https://github.com/jenkinsci/git-plugin/pull/1242 and an App installed on my account as well as a test org. Was able to create a multibranch project on a private repo in my account

```groovy
node {
  checkout scm
  withCredentials([usernamePassword(credentialsId: '…', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'xxx')]) {
    sh 'gh repo view'
  }
}
```

and run builds and get commit statuses.

When creating the App credentials, if you want to use the **Test Connection** button, you need to temporarily enter an **Owner** since otherwise there is no context, but you do not need to save it. When selecting the credentials in a dropdown on a branch source, the automatic connection check (which shows the remaining rate limit) will work so long as you have typed in an owner (org folder) or repo URL (multibranch folder).