### PR TITLE
Adding `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformatted: https://github.com/jenkinsci/github-branch-source-plugin/pull/392
+2b68b4b8b14afa36ee5e243ed8630e2c01a86e2c


### PR DESCRIPTION
To work around #392. https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

Compare
* Before: https://github.com/jenkinsci/github-branch-source-plugin/blame/7f7aa425a9eb650fe7b75574bd8898bbe7f2b37d/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java#L1794
* After: https://github.com/jenkinsci/github-branch-source-plugin/blame/7154585c000eeda448d05a552a1e7abd7d5d65a4/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java#L1794