### PR TITLE
Don't persist topics twice

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorContext.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorContext.java
@@ -42,7 +42,7 @@ public class GitHubSCMNavigatorContext
   private String teamSlug = "";
 
   /** The topic which the repositories must have. */
-  private ArrayList<String> topics = new ArrayList<String>();
+  private List<String> topics = new ArrayList<>();
 
   /** If true, archived repositories will be ignored. */
   private boolean excludeArchivedRepositories;
@@ -76,7 +76,7 @@ public class GitHubSCMNavigatorContext
   }
 
   /** Sets the topics which the repositories must have. */
-  public void setTopics(ArrayList<String> topics) {
+  public void setTopics(List<String> topics) {
     this.topics = topics;
   }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/TopicsTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/TopicsTrait.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.github_branch_source;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import java.util.ArrayList;
+import java.util.List;
 import jenkins.scm.api.trait.SCMNavigatorContext;
 import jenkins.scm.api.trait.SCMNavigatorTrait;
 import jenkins.scm.api.trait.SCMNavigatorTraitDescriptor;
@@ -14,7 +15,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class TopicsTrait extends SCMNavigatorTrait {
 
   /** The topics */
-  @NonNull private final ArrayList<String> topics;
+  @NonNull private transient List<String> topics;
 
   private final String topicList;
 
@@ -26,7 +27,7 @@ public class TopicsTrait extends SCMNavigatorTrait {
   @DataBoundConstructor
   public TopicsTrait(@NonNull String topicList) {
     this.topicList = topicList;
-    this.topics = new ArrayList<String>();
+    this.topics = new ArrayList<>();
 
     for (String topic : topicList.split(",")) {
       this.topics.add(topic.trim());
@@ -39,7 +40,7 @@ public class TopicsTrait extends SCMNavigatorTrait {
    * @return the topics
    */
   @NonNull
-  public ArrayList<String> getTopics() {
+  public List<String> getTopics() {
     return topics;
   }
 
@@ -52,6 +53,18 @@ public class TopicsTrait extends SCMNavigatorTrait {
   protected void decorateContext(final SCMNavigatorContext<?, ?> context) {
     super.decorateContext(context);
     ((GitHubSCMNavigatorContext) context).setTopics(topics);
+  }
+
+  private Object readResolve() {
+    if (this.topicList != null) {
+      List<String> tmpTopics = new ArrayList<>();
+      for (String topic : topicList.split(",")) {
+        tmpTopics.add(topic.trim());
+      }
+      topics = tmpTopics;
+    }
+
+    return this;
   }
 
   /** Topics descriptor. */


### PR DESCRIPTION
# Description

A brief summary describing the changes in this pull request. See 
[JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX) for further information. 

Otherwise job-dsl users have to write this 😢 
https://github.com/hmcts/cnp-jenkins-config/blob/53615434932d02a6ee4e7abb04df88831138f911/jobdsl/organisations-beta.groovy#L169-L172

I've tested this manually, just create a topic, save, check xml config, restart and make sure everything still loads properly

I also put a breakpoint in to make sure it's called

After this change the job-dsl config will become:
```groovy
traits << 'org.jenkinsci.plugins.github__branch__source.TopicsTrait' {
  topicList(config.topic)
}
```

naming isn't the best but probably a bit late

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- ~[ ] Automated tests have been added to exercise the changes~ - I don't see a useful test here
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

