### PR TITLE
Don't pull avatar if remote GitHub Enterprise uses private mode.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1576,7 +1576,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
     // trusted source
     listener.getLogger().printf("Looking up details of %s...%n", getRepoOwner());
     List<Action> result = new ArrayList<>();
-    String apiUri = getApiUri();
+    String apiUri = Util.fixEmptyAndTrim(getApiUri());
     StandardCredentials credentials =
         Connector.lookupScanCredentials((Item) owner, apiUri, credentialsId);
     GitHub hub = Connector.connect(apiUri, credentials);
@@ -1609,10 +1609,13 @@ public class GitHubSCMNavigator extends SCMNavigator {
   }
 
   private static boolean determinePrivateMode(String apiUri) {
+    if (apiURL == null || apiURL.equals(GitHubServerConfig.GITHUB_URL)) {
+      return false;
+    }
     try {
-      GitHub.connectToEnterpriseAnonymously(new URL(apiUri).toString()).checkApiUrlValidity();
+      GitHub.connectToEnterpriseAnonymously(apiUri).checkApiUrlValidity();
     } catch (MalformedURLException e) {
-      // Ignored
+      return true;  // URL is bogus so there is never going to be an avatar - or anything else come to think of it
     } catch (IOException e) {
       if (e.getMessage().contains("private mode enabled")) {
         return true;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1580,7 +1580,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
     StandardCredentials credentials =
         Connector.lookupScanCredentials((Item) owner, apiUri, credentialsId);
     GitHub hub = Connector.connect(apiUri, credentials);
-    boolean privateMode = apiUri == null ? false : determinePrivateMode(apiUri);
+    boolean privateMode = determinePrivateMode(apiUri);
     try {
       Connector.configureLocalRateLimitChecker(listener, hub);
       GHUser u = hub.getUser(getRepoOwner());

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -47,7 +47,6 @@ import hudson.util.ListBoxModel;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -1609,13 +1608,14 @@ public class GitHubSCMNavigator extends SCMNavigator {
   }
 
   private static boolean determinePrivateMode(String apiUri) {
-    if (apiUri== null || apiUri.equals(GitHubServerConfig.GITHUB_URL)) {
+    if (apiUri == null || apiUri.equals(GitHubServerConfig.GITHUB_URL)) {
       return false;
     }
     try {
       GitHub.connectToEnterpriseAnonymously(apiUri).checkApiUrlValidity();
     } catch (MalformedURLException e) {
-      return true;  // URL is bogus so there is never going to be an avatar - or anything else come to think of it
+      // URL is bogus so there is never going to be an avatar - or anything else come to think of it
+      return true;
     } catch (IOException e) {
       if (e.getMessage().contains("private mode enabled")) {
         return true;

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1609,7 +1609,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
   }
 
   private static boolean determinePrivateMode(String apiUri) {
-    if (apiURL == null || apiURL.equals(GitHubServerConfig.GITHUB_URL)) {
+    if (apiUri== null || apiUri.equals(GitHubServerConfig.GITHUB_URL)) {
       return false;
     }
     try {


### PR DESCRIPTION
# Description

When defining a GitHub organization pointing at a Github Enterprise instance running in private mode, the avatar URL can't be accessed directly. This is causing a broken icon to be displayed as well as layout problems in list view in recent Jenkins versions.

This patch detects if the remote instance is in private mode and fallbacks to the standard github icon in that case.
The organization folder needs to be saved after upgrading to apply the new logic.

Before
![Capture d’écran 2022-04-06 à 11 58 39](https://user-images.githubusercontent.com/171459/161979279-7ca22ddc-82b0-439c-a0d5-cb292830dc34.png)

After
![Capture d’écran 2022-04-06 à 14 59 49](https://user-images.githubusercontent.com/171459/161980234-a67c41d8-af18-4283-80e0-d9d3bf36008d.png)


<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

