### PR TITLE
Add `ExcludePrivateRepositoriesTrait`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ExcludePrivateRepositoriesTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ExcludePrivateRepositoriesTrait.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.scm.api.trait.SCMNavigatorContext;
+import jenkins.scm.api.trait.SCMNavigatorTrait;
+import jenkins.scm.api.trait.SCMNavigatorTraitDescriptor;
+import jenkins.scm.impl.trait.Selection;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/** A {@link Selection} trait that will restrict the discovery of repositories that are private. */
+public class ExcludePrivateRepositoriesTrait extends SCMNavigatorTrait {
+
+  /** Constructor for stapler. */
+  @DataBoundConstructor
+  public ExcludePrivateRepositoriesTrait() {}
+
+  /** {@inheritDoc} */
+  @Override
+  protected void decorateContext(SCMNavigatorContext<?, ?> context) {
+    super.decorateContext(context);
+    GitHubSCMNavigatorContext ctx = (GitHubSCMNavigatorContext) context;
+    ctx.setExcludePrivateRepositories(true);
+  }
+
+  /** Exclude private repositories filter */
+  @Symbol("gitHubExcludePrivateRepositories")
+  @Extension
+  @Selection
+  public static class DescriptorImpl extends SCMNavigatorTraitDescriptor {
+
+    @Override
+    public Class<? extends SCMNavigatorContext> getContextClass() {
+      return GitHubSCMNavigatorContext.class;
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+      return Messages.ExcludePrivateRepositoriesTrait_displayName();
+    }
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1030,6 +1030,16 @@ public class GitHubSCMNavigator extends SCMNavigator {
                             System.currentTimeMillis(),
                             String.format(
                                 "Skipping repository %s because it is public", repo.getName())));
+              } else if (repo.isPrivate()
+                  && gitHubSCMNavigatorContext.isExcludePrivateRepositories()) {
+                witness.record(repo.getName(), false);
+                listener
+                    .getLogger()
+                    .println(
+                        GitHubConsoleNote.create(
+                            System.currentTimeMillis(),
+                            String.format(
+                                "Skipping repository %s because it is private", repo.getName())));
               } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories()
                   && repo.getSource() != null) {
                 witness.record(repo.getName(), false);
@@ -1124,6 +1134,17 @@ public class GitHubSCMNavigator extends SCMNavigator {
                           System.currentTimeMillis(),
                           String.format(
                               "Skipping repository %s because it is public", repo.getName())));
+
+            } else if (repo.isPrivate()
+                && gitHubSCMNavigatorContext.isExcludePrivateRepositories()) {
+              witness.record(repo.getName(), false);
+              listener
+                  .getLogger()
+                  .println(
+                      GitHubConsoleNote.create(
+                          System.currentTimeMillis(),
+                          String.format(
+                              "Skipping repository %s because it is private", repo.getName())));
 
             } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories()
                 && repo.getSource() != null) {
@@ -1353,6 +1374,16 @@ public class GitHubSCMNavigator extends SCMNavigator {
                             System.currentTimeMillis(),
                             String.format(
                                 "Skipping repository %s because it is public", repo.getName())));
+              } else if (repo.isPrivate()
+                  && gitHubSCMNavigatorContext.isExcludePrivateRepositories()) {
+                witness.record(repo.getName(), false);
+                listener
+                    .getLogger()
+                    .println(
+                        GitHubConsoleNote.create(
+                            System.currentTimeMillis(),
+                            String.format(
+                                "Skipping repository %s because it is private", repo.getName())));
 
               } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories()
                   && repo.getSource() != null) {
@@ -1435,6 +1466,16 @@ public class GitHubSCMNavigator extends SCMNavigator {
                           System.currentTimeMillis(),
                           String.format(
                               "Skipping repository %s because it is public", repo.getName())));
+            } else if (repo.isPrivate()
+                && gitHubSCMNavigatorContext.isExcludePrivateRepositories()) {
+              witness.record(repo.getName(), false);
+              listener
+                  .getLogger()
+                  .println(
+                      GitHubConsoleNote.create(
+                          System.currentTimeMillis(),
+                          String.format(
+                              "Skipping repository %s because it is private", repo.getName())));
             } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories()
                 && repo.getSource() != null) {
               witness.record(repo.getName(), false);
@@ -1513,6 +1554,16 @@ public class GitHubSCMNavigator extends SCMNavigator {
                           System.currentTimeMillis(),
                           String.format(
                               "Skipping repository %s because it is public", repo.getName())));
+            } else if (repo.isPrivate()
+                && gitHubSCMNavigatorContext.isExcludePrivateRepositories()) {
+              witness.record(repo.getName(), false);
+              listener
+                  .getLogger()
+                  .println(
+                      GitHubConsoleNote.create(
+                          System.currentTimeMillis(),
+                          String.format(
+                              "Skipping repository %s because it is private", repo.getName())));
 
             } else if (gitHubSCMNavigatorContext.isExcludeForkedRepositories()
                 && repo.getSource() != null) {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorContext.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorContext.java
@@ -50,6 +50,9 @@ public class GitHubSCMNavigatorContext
   /** If true, public repositories will be ignored. */
   private boolean excludePublicRepositories;
 
+  /** If true, private repositories will be ignored. */
+  private boolean excludePrivateRepositories;
+
   /** If true, forked repositories will be ignored. */
   private boolean excludeForkedRepositories;
 
@@ -99,6 +102,11 @@ public class GitHubSCMNavigatorContext
     return excludePublicRepositories;
   }
 
+  /** @return True if private repositories should be ignored, false if they should be included. */
+  public boolean isExcludePrivateRepositories() {
+    return excludePrivateRepositories;
+  }
+
   /** @return True if forked repositories should be ignored, false if they should be included. */
   public boolean isExcludeForkedRepositories() {
     return excludeForkedRepositories;
@@ -112,6 +120,11 @@ public class GitHubSCMNavigatorContext
   /** @param excludePublicRepositories Set true to exclude public repositories */
   public void setExcludePublicRepositories(boolean excludePublicRepositories) {
     this.excludePublicRepositories = excludePublicRepositories;
+  }
+
+  /** @param excludePrivateRepositories Set true to exclude private repositories */
+  public void setExcludePrivateRepositories(boolean excludePrivateRepositories) {
+    this.excludePrivateRepositories = excludePrivateRepositories;
   }
 
   /** @param excludeForkedRepositories Set true to exclude archived repositories */

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ExcludePrivateTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ExcludePrivateTrait/config.jelly
@@ -1,0 +1,5 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:f2="/org/jenkinsci/plugins/github_branch_source/form">
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ExcludePrivateTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ExcludePrivateTrait/config.jelly
@@ -1,5 +1,3 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials"
-         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
-         xmlns:f2="/org/jenkinsci/plugins/github_branch_source/form">
+<j:jelly xmlns:j="jelly:core">
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ExcludePrivateTrait/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ExcludePrivateTrait/help.html
@@ -1,0 +1,3 @@
+<div>
+    Exclude GitHub repositories that are private. If set, no jobs will be created for private repositories.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -66,6 +66,7 @@ TagDiscoveryTrait.authorityDisplayName=Trust origin tags
 TagDiscoveryTrait.displayName=Discover tags
 ExcludeArchivedRepositoriesTrait.displayName=Exclude archived repositories
 ExcludePublicRepositoriesTrait.displayName=Exclude public repositories
+ExcludePrivateRepositoriesTrait.displayName=Exclude private repositories
 ExcludeForkedRepositoriesTrait.displayName=Exclude repositories that are forks of another repository
 
 GitHubSCMNavigator.general=General

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -392,9 +392,9 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
 
     navigator.visitSources(
         SCMSourceObserver.filter(
-            observer, "Hello-World", "github-branch-source-plugin", "yolo-private"));
+            observer, "basic", "advanced", "yolo-private"));
 
-    assertThat(projectNames, containsInAnyOrder("Hello-World", "github-branch-source-plugin"));
+    assertThat(projectNames, containsInAnyOrder("basic", "advanced"));
   }
 
   @Test

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -254,6 +254,19 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
   }
 
   @Test
+  public void fetchOneRepo_ExcludingPrivate() throws Exception {
+    setCredentials(Collections.singletonList(credentials));
+    navigator = navigatorForRepoOwner("stephenc", credentials.getId());
+    navigator.setTraits(Collections.singletonList(new ExcludePrivateRepositoriesTrait()));
+    final Set<String> projectNames = new HashSet<>();
+    final SCMSourceObserver observer = getObserver(projectNames);
+
+    navigator.visitSources(SCMSourceObserver.filter(observer, "Hello-World"));
+
+    assertThat(projectNames, containsInAnyOrder("Hello-World"));
+  }
+
+  @Test
   public void fetchOneRepo_ExcludingForked() throws Exception {
     setCredentials(Collections.singletonList(credentials));
     navigator = navigatorForRepoOwner("stephenc", credentials.getId());
@@ -369,6 +382,19 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
             observer, "Hello-World", "github-branch-source-plugin", "yolo-private"));
 
     assertThat(projectNames, containsInAnyOrder("yolo-private"));
+  }
+
+  @Test
+  public void fetchRepos_BelongingToOrg_ExcludingPrivate() throws Exception {
+    navigator.setTraits(Collections.singletonList(new ExcludePrivateRepositoriesTrait()));
+    final Set<String> projectNames = new HashSet<>();
+    final SCMSourceObserver observer = getObserver(projectNames);
+
+    navigator.visitSources(
+        SCMSourceObserver.filter(
+            observer, "Hello-World", "github-branch-source-plugin", "yolo-private"));
+
+    assertThat(projectNames, containsInAnyOrder("Hello-World", "github-branch-source-plugin"));
   }
 
   @Test

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -261,9 +261,9 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
     final Set<String> projectNames = new HashSet<>();
     final SCMSourceObserver observer = getObserver(projectNames);
 
-    navigator.visitSources(SCMSourceObserver.filter(observer, "Hello-World"));
+    navigator.visitSources(SCMSourceObserver.filter(observer, "yolo"));
 
-    assertThat(projectNames, containsInAnyOrder("Hello-World"));
+    assertThat(projectNames, containsInAnyOrder("yolo"));
   }
 
   @Test

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -390,9 +390,7 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
     final Set<String> projectNames = new HashSet<>();
     final SCMSourceObserver observer = getObserver(projectNames);
 
-    navigator.visitSources(
-        SCMSourceObserver.filter(
-            observer, "basic", "advanced", "yolo-private"));
+    navigator.visitSources(SCMSourceObserver.filter(observer, "basic", "advanced", "yolo-private"));
 
     assertThat(projectNames, containsInAnyOrder("basic", "advanced"));
   }


### PR DESCRIPTION
# Description

This PR adds an `ExcludePrivateRepositoriesTrait`. Quick disclaimer, I'm not a Java developer and none of these changes have been tested locally. I mostly just mimicked what I saw for the `ExcludePublicRepositoriesTrait` and inverted it. My team could really use this feature. Please let me know if there's anything I need to change.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

