### PR TITLE
bump github-api to support new teams api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
         <java.level>8</java.level>
         <jenkins.version>2.323</jenkins.version>
         <useBeta>true</useBeta>
+        <!-- TODO remove jth override when we bump the parent version -->
+        <jenkins-test-harness.version>1706.v5257fc59612a_</jenkins-test-harness.version>
     </properties>
 
     <scm>
@@ -127,11 +129,6 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>3.11</version>
             </dependency>
-          <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness</artifactId>
-            <version>1706.v5257fc59612a_</version>
-          </dependency>
         </dependencies>
     </dependencyManagement>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.122</version>
+            <version>1.303-400.v35c2d8258028</version>
         </dependency>
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
@@ -118,7 +118,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.289.x</artifactId>
-                <version>1090.v0a_33df40457a_</version>
+                <version>1280.vd669827e38cd</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -127,6 +127,11 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>3.11</version>
             </dependency>
+          <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-test-harness</artifactId>
+            <version>1706.v5257fc59612a_</version>
+          </dependency>
         </dependencies>
     </dependencyManagement>
     <build>

--- a/src/test/resources/api/__files/body-(root)-XwEI7.json
+++ b/src/test/resources/api/__files/body-(root)-XwEI7.json
@@ -24,7 +24,6 @@
   "current_user_repositories_url": "https://api.github.com/user/repos{?type,page,per_page,sort}",
   "starred_url": "https://api.github.com/user/starred{/owner}{/repo}",
   "starred_gists_url": "https://api.github.com/gists/starred",
-  "team_url": "https://api.github.com/teams",
   "user_url": "https://api.github.com/users/{user}",
   "user_organizations_url": "https://api.github.com/user/orgs",
   "user_repositories_url": "https://api.github.com/users/{user}/repos{?type,page,per_page,sort}",

--- a/src/test/resources/api/__files/body-orgs-cloudbeers-teams-justice-league-AHFpl.json
+++ b/src/test/resources/api/__files/body-orgs-cloudbeers-teams-justice-league-AHFpl.json
@@ -1,13 +1,13 @@
 {
         "id": 1,
         "node_id": "MDQ6VGVhbTE=",
-        "url": "https://api.github.com/teams/1",
+        "url": "https://api.github.com/organizations/4181899/team/1/",
         "name": "Justice League",
         "slug": "justice-league",
         "description": "A great team.",
         "privacy": "closed",
         "permission": "admin",
-        "members_url": "https://api.github.com/teams/1/members{/member}",
-        "repositories_url": "https://api.github.com/teams/1/repos",
+        "members_url": "https://api.github.com/organizations/4181899/team/1/members{/member}",
+        "repositories_url": "https://api.github.com/organizations/4181899/teams/1/repos",
         "parent": null
 }

--- a/src/test/resources/api/mappings/mapping-body-orgs-cloudbeers-teams-repo-gOYDg.json
+++ b/src/test/resources/api/mappings/mapping-body-orgs-cloudbeers-teams-repo-gOYDg.json
@@ -1,6 +1,6 @@
 {
   "request" : {
-    "url" : "/teams/1/repos?per_page=100",
+    "url" : "/organizations/4181899/team/1/repos?per_page=100",
     "method" : "GET"
   },
   "response" : {

--- a/src/test/resources/api/mappings/mapping-contents-fu-nMBRw.json
+++ b/src/test/resources/api/mappings/mapping-contents-fu-nMBRw.json
@@ -6,13 +6,13 @@
     "method" : "GET"
   },
   "response" : {
-    "status" : 301,
+    "status" : 200,
     "bodyFileName" : "body-contents-fu-nMBRw.json",
     "headers" : {
       "Date" : "Wed, 24 Apr 2019 07:12:07 GMT",
       "Content-Type" : "application/json; charset=utf-8",
       "Server" : "GitHub.com",
-      "Status" : "301 Moved Permanently",
+      "Status" : "200 OK",
       "X-RateLimit-Limit" : "60",
       "X-RateLimit-Remaining" : "59",
       "X-RateLimit-Reset" : "1556093527",


### PR DESCRIPTION
# Description

Teams api has been deprecated (see: https://github.blog/changelog/2022-02-22-sunset-notice-deprecated-teams-api-endpoints/). Org scans via team name no longer work. Fix was done in https://github.com/hub4j/github-api/issues/1386
Propagating the fix through to this plugin.
See also https://github.com/jenkinsci/github-api-plugin/pull/133

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

