### PR TITLE
address potential flake in GithubAppCredentialsTest

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
@@ -112,8 +112,7 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
     store.addCredentials(Domain.global(), appCredentialsNoOwner);
 
     // Add agent
-    agent = r.createOnlineSlave();
-    agent.setLabelString("my-agent");
+    agent = r.createSlave("my-agent", null);
 
     // Would use LoggerRule, but need to get agent logs as well
     LogRecorderManager mgr = r.jenkins.getLog();

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
@@ -113,6 +113,7 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
 
     // Add agent
     agent = r.createSlave("my-agent", null);
+    r.waitOnline(agent);
 
     // Would use LoggerRule, but need to get agent logs as well
     LogRecorderManager mgr = r.jenkins.getLog();


### PR DESCRIPTION
calling setLabels on an agent will not persist the node.

in older versions of Jenkins the tests would be less flaky as adding any
Node would cause all labels to be re-evaluated, so when creating a few
agents and adding labels in a loop the last one created would at least
deterministically ensure that all previous agents labels where correct.

However since 2.332 (jenkinsci/jenkins#5882)
only labels part of a node added or removed would be updated, and when
creating the agents they where created without labels, which where added
later.

This has the potential to cause tests to be flaky depending on when the periodic
trimLabels was called (or at least on other timing related things)

Additionally creating agents and waiting for them to come oneline is
slow. A job can be scheduled and the pipeline will run and then wait for the node to be
available,
so we can do other things whilst the agent is connecting.

# Description

A brief summary describing the changes in this pull request. See 
[JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

