### PR TITLE
[JENKINS-68633] Ignore Credentials Dropdown field validation when con…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -2130,8 +2130,17 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         @CheckForNull @AncestorInPath Item context,
         @QueryParameter String apiUri,
         @QueryParameter String repoOwner,
-        @QueryParameter String value) {
-      return Connector.checkScanCredentials(context, apiUri, value, repoOwner);
+        @QueryParameter String value,
+        @QueryParameter boolean configuredByUrl) {
+
+      if (!configuredByUrl) {
+        return Connector.checkScanCredentials(context, apiUri, value, repoOwner);
+      } else if (value.isEmpty()) {
+          return FormValidation.warning("Credentials are recommended");
+      } else {
+        // Using the URL-based configuration, that has its own "Validate" button
+        return FormValidation.ok();
+      }
     }
 
     @RequirePOST
@@ -2200,8 +2209,9 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
         @CheckForNull @AncestorInPath Item context,
         @QueryParameter String apiUri,
         @QueryParameter String scanCredentialsId,
-        @QueryParameter String repoOwner) {
-      return doCheckCredentialsId(context, apiUri, scanCredentialsId, repoOwner);
+        @QueryParameter String repoOwner,
+        @QueryParameter boolean configuredByUrl) {
+      return doCheckCredentialsId(context, apiUri, scanCredentialsId, repoOwner, configuredByUrl);
     }
 
     @Restricted(NoExternalUse.class)

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource/config-detail.jelly
@@ -17,7 +17,7 @@
       <f:entry title="${%Repository HTTPS URL}" field="repositoryUrl">
         <f:textbox/>
       </f:entry>
-      <f:validateButton method="validateRepositoryUrlAndCredentials" title="${%Validate}" with="repositoryUrl,credentialsId,repoOwner"/>
+      <f:validateButton method="validateRepositoryUrlAndCredentials" title="${%Validate}" with="repositoryUrl,credentialsId"/>
     </f:nested>
   </f:radioBlock>
   <f:radioBlock name="configuredByUrlRadio" value="false" checked="false" title="${%Repository Scan - Deprecated Visualization}" inline="true">

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -59,6 +59,7 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.SecurityRealm;
+import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.LogTaskListener;
 import java.io.File;
@@ -72,6 +73,7 @@ import jenkins.plugins.git.GitSCMSource;
 import jenkins.scm.api.*;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Before;
@@ -874,6 +876,24 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
   }
 
   @Test
+  @Issue("JENKINS-68633")
+  public void doCheckCredentialsId() {
+    GitHubSCMSource.DescriptorImpl descriptor = (GitHubSCMSource.DescriptorImpl) source.getDescriptor();
+
+    // If no credentials are supplied, display the warning
+    FormValidation test = descriptor.doCheckCredentialsId(null, "", "", "", true);
+    assertThat(test.kind, is(FormValidation.Kind.WARNING));
+    assertThat(test.getMessage(), is("Credentials are recommended"));
+    test = descriptor.doCheckCredentialsId(null, "", "", "", false);
+    assertThat(test.kind, is(FormValidation.Kind.WARNING));
+    assertThat(test.getMessage(), is("Credentials are recommended"));
+
+    // If configureByUrl and credentials provided, always return OK
+    test = descriptor.doCheckCredentialsId(null, "", "", "test", true);
+    assertThat(test.kind, is(FormValidation.Kind.OK));
+  }
+
+    @Test
   @Issue("JENKINS-65071")
   public void testCheckIncludesBranchSCMHeadType() throws Exception {
     SCMHeadObserver mockSCMHeadObserver = Mockito.mock(SCMHeadObserver.class);


### PR DESCRIPTION
…figured by HTTPS URL

# Description

Ignore FormValidation when "Repository HTTPS URL" as there is a Validate button for it. See [JENKINS-68633](https://issues.jenkins.io/browse/JENKINS-68633) for further information. 

Note: The other things I was thinking about is to consolidate the 2 following checks and just use one:

* [GitHubSCMSource.DescriptorImpl#doValidateRepositoryUrlAndCredentials](https://github.com/jenkinsci/github-branch-source-plugin/blob/github-branch-source-2.11.5/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java#L2136-L2193)
* [Connector#checkScanCredentials]()https://github.com/jenkinsci/github-branch-source-plugin/blob/github-branch-source-2.11.5/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java#L161-L233)

I am not sure why there are 2. The `Connector#checkScanCredentials` seems to provide more info when using GitHub App and seems like a better choice. @jenkinsci/github-branch-source-plugin-developers  WDYT ?

# Submitter checklist

- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist

- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes

- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

@jenkinsci/github-branch-source-plugin-developers 