### PR TITLE
fix flickering and improve speed in EventsTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+          <groupId>org.awaitility</groupId>
+          <artifactId>awaitility</artifactId>
+          <version>4.2.0</version>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.hamcrest</groupId>
+              <artifactId>hamcrest</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
           <groupId>io.jenkins.plugins</groupId>
           <artifactId>okhttp-api</artifactId>
         </dependency>

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/EventsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/EventsTest.java
@@ -25,6 +25,8 @@
 
 package org.jenkinsci.plugins.github_branch_source;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
@@ -34,6 +36,7 @@ import jenkins.scm.api.SCMEvents;
 import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.api.SCMSourceEvent;
 import org.apache.commons.io.IOUtils;
+import org.awaitility.Awaitility;
 import org.jenkinsci.plugins.github.extension.GHSubscriberEvent;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -55,7 +58,7 @@ public class EventsTest {
 
   @BeforeClass
   public static void setupDelay() {
-    GitHubSCMSource.setEventDelaySeconds(1);
+    GitHubSCMSource.setEventDelaySeconds(0); // fire immediately without delay
   }
 
   @Before
@@ -188,7 +191,11 @@ public class EventsTest {
   private void waitAndAssertReceived(boolean received) throws InterruptedException {
     long watermark = SCMEvents.getWatermark();
     // event will be fired by subscriber at some point
-    SCMEvents.awaitOne(watermark, 1200, TimeUnit.MILLISECONDS);
+    SCMEvents.awaitOne(watermark, received ? 20 : 200, TimeUnit.MILLISECONDS);
+
+    if (received) {
+      TestSCMEventListener.awaitUntilReceived();
+    }
 
     assertEquals(
         "Event should have " + ((!received) ? "not " : "") + "been received",
@@ -222,6 +229,13 @@ public class EventsTest {
 
     public static void setReceived(boolean received) {
       eventReceived = received;
+    }
+
+    public static void awaitUntilReceived() {
+      Awaitility.await()
+          .pollInterval(10, MILLISECONDS)
+          .atMost(1, MINUTES)
+          .until(() -> eventReceived);
     }
   }
 }


### PR DESCRIPTION
# Description

EventsTest was flickering because on high load system wait was finishing before event comes.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

