### PR TITLE
[JENKINS-69488] do not SnapShot GitHubAppCredentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsSnapshotTaker.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsSnapshotTaker.java
@@ -1,0 +1,30 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+import com.cloudbees.plugins.credentials.CredentialsSnapshotTaker;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsSnapshotTaker;
+import hudson.Extension;
+
+/**
+ * A {@link CredentialsSnapshotTaker} for {@link GitHubAppCredentials} that is a no-op.
+ *
+ * <p>As {@code GitHubAppCredentials} tokens are time limited they need to be refreshed
+ * periodically. This is currently addressed by its use of the {@code writeReplace()} and {@code
+ * readResolve}, but as these credentials are {@link UsernamePasswordCredentials} this behaviour
+ * conflicts with the {@link UsernamePasswordCredentialsSnapshotTaker}. This SnapshotTaker restores
+ * the status quo allowing the Credentials to be replaced using the existing mechanism.
+ */
+@Extension
+public class GitHubAppCredentialsSnapshotTaker
+    extends CredentialsSnapshotTaker<GitHubAppCredentials> {
+
+  @Override
+  public GitHubAppCredentials snapshot(GitHubAppCredentials credentials) {
+    return credentials;
+  }
+
+  @Override
+  public Class<GitHubAppCredentials> type() {
+    return GitHubAppCredentials.class;
+  }
+}


### PR DESCRIPTION
The GitHubApp Credentials converts itself when serialized over remoting
to a DelegatingGitHubAppCredentials to support token refresh.

Whilst it would naively be trivial to replace this with an
implenentation in the GitHubAppCredentialsSnapshotTaker that did the
conversion, this causes issues in controller to controller propagation.

When a Snapshot is taken there may or may not be a Channel in place,
however this does not detract from the fact that it is done so
credentials can be held complete
The code could be obtaining the credentials to send to some code but may
be doing it in outside of a specific task (th a remoting channel (e.g. snapshot a credential, then
obtain a channel from a computer to execute some code).  Whilst unlikely
for this specific credential type - it is also a very generic type and
nothing would prevent code from doing this - nor would that code be
incorrect.

# Description

A brief summary describing the changes in this pull request. See 
[JENKINS-69488](https://issues.jenkins-ci.org/browse/JENKINS-69488) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

