### PR TITLE
[JENKINS-67946] Support underscores in user names (GitHub Enterprise Managed User accounts)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -151,7 +151,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
 
   public static final String VALID_GITHUB_REPO_NAME = "^[0-9A-Za-z._-]+$";
   public static final String VALID_GITHUB_USER_NAME =
-      "^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$";
+      "^[A-Za-z0-9](?:[A-Za-z0-9_]|-(?=[A-Za-z0-9])){0,38}$";
   public static final String VALID_GIT_SHA1 = "^[a-fA-F0-9]{40}$";
   public static final String GITHUB_URL = GitHubServerConfig.GITHUB_URL;
   public static final String GITHUB_COM = "github.com";

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -151,7 +151,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
 
   public static final String VALID_GITHUB_REPO_NAME = "^[0-9A-Za-z._-]+$";
   public static final String VALID_GITHUB_USER_NAME =
-      "^[A-Za-z0-9](?:[A-Za-z0-9_]|-(?=[A-Za-z0-9])){0,38}$";
+      "^(?=[A-Za-z0-9-_]{1,39}$)([A-Za-z0-9]((?:[A-Za-z0-9]+|-(?=[A-Za-z0-9]+))*)(_(?:[A-Za-z0-9]+))?)";
   public static final String VALID_GIT_SHA1 = "^[a-fA-F0-9]{40}$";
   public static final String GITHUB_URL = GitHubServerConfig.GITHUB_URL;
   public static final String GITHUB_COM = "github.com";

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -1044,4 +1044,20 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
     assertTrue(this.source.shouldRetrieve(mockSCMHeadObserver, null, PullRequestSCMHead.class));
     assertTrue(this.source.shouldRetrieve(mockSCMHeadObserver, null, BranchSCMHead.class));
   }
+
+  @Test
+  @Issue("JENKINS-67946")
+  public void testUserNamesWithAndWithoutUnderscores() throws Exception {
+    // https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/managing-iam-for-your-enterprise/username-considerations-for-external-authentication#about-usernames-for-managed-user-accounts
+    // https://github.com/github/docs/blob/bfe96c289aee3113724495a2e498c21e2ec404e4/content/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users.md#about--data-variablesproductprodname_emus-
+    String repoOwnerWithUnderscore = "user_organization";
+    String repoOwnerNoUnderscore = "username";
+    String repoOwnerHyphen = "user-name";
+    String repoOwnerHyphenUnderscore = "user-name_organization";
+    assertTrue(repoOwnerWithUnderscore.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue(repoOwnerNoUnderscore.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue(repoOwnerHyphen.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue(repoOwnerHyphenUnderscore.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+  }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -1047,7 +1047,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
 
   @Test
   @Issue("JENKINS-67946")
-  public void testUserNamesWithAndWithoutUnderscores() throws Exception {
+  public void testUserNamesWithAndWithoutUnderscores() {
     // https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/managing-iam-for-your-enterprise/username-considerations-for-external-authentication#about-usernames-for-managed-user-accounts
     // https://github.com/github/docs/blob/bfe96c289aee3113724495a2e498c21e2ec404e4/content/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users.md#about--data-variablesproductprodname_emus-
     String repoOwnerWithUnderscore = "user_organization";
@@ -1059,5 +1059,4 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
     assertTrue(repoOwnerHyphen.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertTrue(repoOwnerHyphenUnderscore.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
   }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -1064,6 +1064,9 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
     assertTrue("user123-org456_code789".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertTrue(
         "abcdefghijqlmnopkrstuvwxyz-123456789012".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("a".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("0".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("a-b-c-d-e-f-g".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
 
     // Valid names should contain alphanumeric characters or single hyphens, and cannot begin or end
     // with a hyphen, and have a 39 char limit

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -1057,6 +1057,27 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
     assertTrue(repoOwnerWithUnderscore.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertTrue(repoOwnerNoUnderscore.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertTrue(repoOwnerHyphen.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
-    assertTrue(repoOwnerHyphenUnderscore.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("abcd".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("1234".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user123".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user123-org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("123-456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user123_org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user123-org456-code789".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user123-org456_code789".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("abcdefghijqlmnopkrstuvwxyz-123456789012".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+
+    assertFalse("abcdefghijqlmnopkrstuvwxyz-1234567890123".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123@org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123.org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123--org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123-".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("-user123".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123__org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123_".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("_user123".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123-_org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123_org456-code789".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123_org456_code789".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -1050,13 +1050,10 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
   public void testUserNamesWithAndWithoutUnderscores() {
     // https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/managing-iam-for-your-enterprise/username-considerations-for-external-authentication#about-usernames-for-managed-user-accounts
     // https://github.com/github/docs/blob/bfe96c289aee3113724495a2e498c21e2ec404e4/content/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users.md#about--data-variablesproductprodname_emus-
-    String repoOwnerWithUnderscore = "user_organization";
-    String repoOwnerNoUnderscore = "username";
-    String repoOwnerHyphen = "user-name";
-    String repoOwnerHyphenUnderscore = "user-name_organization";
-    assertTrue(repoOwnerWithUnderscore.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
-    assertTrue(repoOwnerNoUnderscore.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
-    assertTrue(repoOwnerHyphen.matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user_organization".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("username".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user-name".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user-name_organization".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertTrue("abcd".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertTrue("1234".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertTrue("user123".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
@@ -1065,9 +1062,13 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
     assertTrue("user123_org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertTrue("user123-org456-code789".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertTrue("user123-org456_code789".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
-    assertTrue("abcdefghijqlmnopkrstuvwxyz-123456789012".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue(
+        "abcdefghijqlmnopkrstuvwxyz-123456789012".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
 
-    assertFalse("abcdefghijqlmnopkrstuvwxyz-1234567890123".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    // Valid names should contain alphanumeric characters or single hyphens, and cannot begin or end
+    // with a hyphen, and have a 39 char limit
+    assertFalse(
+        "abcdefghijqlmnopkrstuvwxyz-1234567890123".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertFalse("user123@org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertFalse("user123.org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
     assertFalse("user123--org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));


### PR DESCRIPTION
# Description

When using [GitHub EMU](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) (Enterprise Managed User) accounts, the username contains an underscore, which prevents PR builds from forked repos.

We have a CloudBees client impacted by this issue, and I saw the previous PR was held up due to lack of regression testcases, so this PR takes the regex fix from https://github.com/jenkinsci/github-branch-source-plugin/pull/421 and adds a testcase to catch regressions for this fix, with the hopes this will allow the fix to be merged.

The format of GitHub EMU accounts is documented at:
https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/managing-iam-for-your-enterprise/username-considerations-for-external-authentication#about-usernames-for-managed-user-accounts

See [JENKINS-67946](https://issues.jenkins-ci.org/browse/JENKINS-67946) for further information.

To manually test this fix, it requires a GitHub Enterprise Managed User account, then create a Multibranch Pipeline job pointing to a GitHub Organization repo, fork that repo to your GitHub EMU account (which has an underscore in the username), create a feature branch and a commit, and open a PR against your organization account. 

Before this fix, the Webhook payload would reach Jenkins and if you enable custom loggers for `org.jenkinsci.plugins.github.webhook` it would be logged at https://github.com/jenkinsci/github-plugin/blob/b1482bd800a49fb2519d4d5525dd8e22f1870d1c/src/main/java/org/jenkinsci/plugins/github/webhook/GHEventPayload.java#L76 , but you would never see the PR get processed in the job's `indexing/events.log`.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [x] Link to jenkins.io PR, or an explanation for why no doc changes are needed

No documentation changes should be needed, but the plugin release notes could have an entry such as:

> [JENKINS-67946] Support underscores in user names (GitHub Enterprise Managed User accounts)

# Users/aliases to notify

