### PR TITLE
[JENKINS-67946][backport to 2.11.4] Support underscores in user names

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -152,7 +152,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
 
   public static final String VALID_GITHUB_REPO_NAME = "^[0-9A-Za-z._-]+$";
   public static final String VALID_GITHUB_USER_NAME =
-      "^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$";
+      "^(?=[A-Za-z0-9-_]{1,39}$)([A-Za-z0-9]((?:[A-Za-z0-9]+|-(?=[A-Za-z0-9]+))*)(_(?:[A-Za-z0-9]+))?)";
   public static final String VALID_GIT_SHA1 = "^[a-fA-F0-9]{40}$";
   public static final String GITHUB_URL = GitHubServerConfig.GITHUB_URL;
   public static final String GITHUB_COM = "github.com";

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -1024,4 +1024,44 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
     assertTrue(this.source.shouldRetrieve(mockSCMHeadObserver, null, PullRequestSCMHead.class));
     assertTrue(this.source.shouldRetrieve(mockSCMHeadObserver, null, BranchSCMHead.class));
   }
+
+  @Test
+  @Issue("JENKINS-67946")
+  public void testUserNamesWithAndWithoutUnderscores() {
+    // https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/managing-iam-for-your-enterprise/username-considerations-for-external-authentication#about-usernames-for-managed-user-accounts
+    // https://github.com/github/docs/blob/bfe96c289aee3113724495a2e498c21e2ec404e4/content/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users.md#about--data-variablesproductprodname_emus-
+    assertTrue("user_organization".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("username".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user-name".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user-name_organization".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("abcd".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("1234".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user123".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user123-org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("123-456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user123_org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user123-org456-code789".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("user123-org456_code789".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue(
+        "abcdefghijqlmnopkrstuvwxyz-123456789012".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("a".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("0".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertTrue("a-b-c-d-e-f-g".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+
+    // Valid names should contain alphanumeric characters or single hyphens, and cannot begin or end
+    // with a hyphen, and have a 39 char limit
+    assertFalse(
+        "abcdefghijqlmnopkrstuvwxyz-1234567890123".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123@org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123.org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123--org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123-".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("-user123".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123__org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123_".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("_user123".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123-_org456".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123_org456-code789".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+    assertFalse("user123_org456_code789".matches(GitHubSCMSource.VALID_GITHUB_USER_NAME));
+  }
 }


### PR DESCRIPTION
backporting https://github.com/jenkinsci/github-branch-source-plugin/pull/626 on top of `github-branch-source:2.11.4`

This draft PR is to create an incremental build.