### PR TITLE
Change default PR build strategy from merge to head

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -2522,9 +2522,9 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
     public List<SCMSourceTrait> getTraitsDefaults() {
       return Arrays.asList( // TODO finalize
           new BranchDiscoveryTrait(true, false),
-          new OriginPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)),
+          new OriginPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD)),
           new ForkPullRequestDiscoveryTrait(
-              EnumSet.of(ChangeRequestCheckoutStrategy.MERGE),
+              EnumSet.of(ChangeRequestCheckoutStrategy.HEAD),
               new ForkPullRequestDiscoveryTrait.TrustPermission()));
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-strategyId.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait/help-strategyId.html
@@ -4,6 +4,7 @@
         <dt>Merging the pull request with the current target branch revision</dt>
         <dd>Discover each pull request once with the discovered revision corresponding to the result of merging with the
             current revision of the target branch.
+            Note that pushes to the target branch will result in new pull request builds.
         </dd>
         <dt>The current pull request revision</dt>
         <dd>Discover each pull request once with the discovered revision corresponding to the pull request head revision

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait/help-strategyId.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait/help-strategyId.html
@@ -4,6 +4,7 @@
         <dt>Merging the pull request with the current target branch revision</dt>
         <dd>Discover each pull request once with the discovered revision corresponding to the result of merging with the
             current revision of the target branch.
+            Note that pushes to the target branch will result in new pull request builds.
         </dd>
         <dt>The current pull request revision</dt>
         <dd>Discover each pull request once with the discovered revision corresponding to the pull request head revision


### PR DESCRIPTION
When multibranch was first written, using PR merge build strategy seemed like a neat way to ensure that trunk was never broken. But this strategy comes with downsides:

* It can be expensive: as the number of open PRs grow, the time spent testing them can grow _quadratically_ rather than linearly: every time one is merged, all the remaining ones are rebuilt.
* It violates the principle of least surprise: `gh pr checkout 123 && make` can produce different results than CI.
* This plugin as well as `github-checks` submit a commit status or check but then need to account for the fact that the built commit might be an ephemeral merge commit and the submission actually needs to use the first parent—though it might not, even in merge strategy, if the PR head is already up to date.
  * You can then have a PR which is initially green but then goes red without being touched, or vice-versa; this is in some sense the point of the strategy to begin with, but GitHub retains no historical record of why a status/check was overwritten for a given PR branch commit. (You _can_ create a permalink to a particular check run, even if outdated—but after it is superseded for that commit, you cannot readily look it up if you did not remember to save the permalink before.) The same issue of course applies to using **Replay** (Jenkins) or **Re-run** (Checks tab) but at least that scenario involves a deliberate gesture.

In practice, it is not very common that two pull requests are filed which individually pass CI, fail CI in combination, and yet have no textual merge conflicts (edits within ~3 lines of one another). It can certainly happen (https://github.com/jenkinsci/script-security-plugin/pull/468 is an example) but not very often, and it is even less common that the failure is so weird that is difficult to fix trunk retroactively.

Furthermore, since this feature was conceived, GitHub itself has evolved to include branch protections such as the rule that a PR must be up to date before merging (which Dependabot will automatically honor by rebasing); as well as the introduction of a merge queue feature that supersedes this Jenkins trick.

This patch simply changes the default for multibranch projects or organization folders newly created via the GUI, to the simpler and more comprehensible head mode: build whatever was last pushed to the PR branch. Example result in `config.xml`:

```xml
<traits>
  <org.jenkinsci.plugins.github__branch__source.BranchDiscoveryTrait>
    <strategyId>1</strategyId>
  </org.jenkinsci.plugins.github__branch__source.BranchDiscoveryTrait>
  <org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait>
    <strategyId>2</strategyId>
  </org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait>
  <org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait>
    <strategyId>2</strategyId>
    <trust class="org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission"/>
  </org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait>
</traits>
```

For what I suppose are historical reasons, `strategyId` is an `int` rather than a more legible `enum`: https://github.com/jenkinsci/github-branch-source-plugin/blob/3a7603564d04ec5b89e9b24e05858a587d863ba2/src/main/java/org/jenkinsci/plugins/github_branch_source/OriginPullRequestDiscoveryTrait.java#L57-L67
