### PR TITLE
More concise suggestion for `GitHubAppCredentials.privateKey`

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials/help-privateKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials/help-privateKey.html
@@ -2,5 +2,5 @@
     Private key for authenticating to GitHub with, it must be in PKCS#8 format, GitHub will give it to you in PKCS#1.
 </p>
 <p>
-    You can convert it with <code>openssl pkcs8 -topk8 -inform PEM -outform PEM -in current-key.pem -out new-key.pem -nocrypt</code>
+    You can convert it with: <code>openssl pkcs8 -topk8 -nocrypt -in downloaded-key.pem</code>
 </p>


### PR DESCRIPTION
Omitting the `-out` parameter since the form is prompting you to paste in text, not upload a file, so may as well just print to stdout.

Omitting `-inform` / `-outform` since they seem to be inferred.

Moving `-in` to the end to make it more convenient to paste this example and then just delete the example filename and replace with the real value.