### PR TITLE
Adapt tests to the presence of `gitlab-branch-source` on the test classpath

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
@@ -69,6 +69,13 @@ public class GitHubSCMSourceTraitsTest {
     recreated.setIncludes("i*");
     recreated.setExcludes("production");
     recreated.setScanCredentialsId("foo");
+    String trust;
+    if (r.jenkins.getPlugin("gitlab-branch-source") != null) {
+      trust =
+          "org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission";
+    } else {
+      trust = "TrustPermission";
+    }
     assertThat(
         DescribableModel.uninstantiate2_(recreated).toString(),
         is(
@@ -82,7 +89,9 @@ public class GitHubSCMSourceTraitsTest {
                 + "@gitHubPullRequestDiscovery$OriginPullRequestDiscoveryTrait(strategyId=1), "
                 + "@gitHubForkDiscovery$ForkPullRequestDiscoveryTrait("
                 + "strategyId=2,"
-                + "trust=@gitHubTrustPermissions$TrustPermission()), "
+                + "trust=@gitHubTrustPermissions$"
+                + trust
+                + "()), "
                 + "@headWildcardFilter$WildcardSCMHeadFilterTrait(excludes=production,includes=i*)])"));
   }
 

--- a/src/test/resources/org/jenkinsci/plugins/github_branch_source/configuration-as-code.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/github_branch_source/configuration-as-code.yaml
@@ -17,4 +17,4 @@ unclassified:
                       strategyId: 2
                   - gitHubForkDiscovery:
                       strategyId: 3
-                      trust: "trustPermission"
+                      trust: "gitHubTrustPermissions"


### PR DESCRIPTION
Without this PR, `mvn clean verify -Dtest=InjectedTest,org.jenkinsci.plugins.github_branch_source.GitHubBranchSourcesJCasCCompatibilityTest,org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceTraitsTest` passes without `gitlab-branch-source` on the test classpath but fails with it.

With this PR, it passes both with and without `gitlab-branch-source` on the classpath.

Therefore, this PR is needed to add `gitlab-branch-source` to `jenkinsci/bom`.