### PR TITLE
[JENKINS-70163] Do not cache resolved proxy address in Connector clients

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -91,7 +91,7 @@ import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.RateLimitHandler;
 import org.kohsuke.github.authorization.ImmutableAuthorizationProvider;
-import org.kohsuke.github.extras.okhttp3.OkHttpConnector;
+import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector;
 
 /** Utilities that could perhaps be moved into {@code github-api}. */
 @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE") // https://github.com/spotbugs/spotbugs/issues/1539
@@ -484,7 +484,7 @@ public class Connector {
     if (cache != null) {
       clientBuilder.cache(cache);
     }
-    gb.withConnector(new OkHttpConnector(clientBuilder.build()));
+    gb.withConnector(new OkHttpGitHubConnector(clientBuilder.build()));
     return gb;
   }
 


### PR DESCRIPTION
# Description

[JENKINS-70163](https://issues.jenkins.io/browse/JENKINS-70163) and see https://github.com/square/okhttp/issues/7698.

The `ProxySelector` set by the `JenkinsOkHttpClient` builder keeps record of the proxy resolved address in the `InetSocketAddress`. If changes occur in the network, so that the proxy host does not change but the resolved IPs do, the old address are still in use.

Proposed a change upstream at https://github.com/jenkinsci/okhttp-api-plugin/pull/159. 
In the meantime, I propose to create a ProxySelector here in the `Connector` until `okhttp-api-plugin` is released.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

