### PR TITLE
deflake GithubAppCredentialsAppInstallationTokenTest

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
@@ -290,7 +290,7 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
 
             // We want to demonstrate successful caching without waiting for the default 1 minute
             // Must set this to a large enough number to avoid flaky test
-            GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = 5;
+            GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = 10;
 
             // Ensure we are working from sufficiently clean cache state
             Thread.sleep(Duration.ofSeconds(GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS + 2)
@@ -362,7 +362,7 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
 
             // We want to demonstrate successful caching without waiting for a the default 1 minute
             // Must set this to a large enough number to avoid flaky test
-            GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = 5;
+            GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = 10;
 
             // Ensure we are working from sufficiently clean cache state
             Thread.sleep(Duration.ofSeconds(GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS + 2)
@@ -479,7 +479,7 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
 
             // We want to demonstrate successful caching without waiting for the default 1 minute
             // Must set this to a large enough number to avoid flaky test
-            GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = 5;
+            GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = 10;
 
             // Ensure we are working from sufficiently clean cache state
             Thread.sleep(Duration.ofSeconds(GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS + 2)


### PR DESCRIPTION
In CI have have seen flakes from `GithubAppCredentialsAppInstallationTokenTest.` 

inspecting the logs shows the flakes are occurring as the CI system is too slow and has just passed the 5 seconds configured for the cache timeout when it was not expecting it to.

Increase the timeout to 10 seconds to reduce the flakes (which will unfortunately increate the test time slightly of these tests)

# Description

A brief summary describing the changes in this pull request. See 
[JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

