### PR TITLE
.editorconfig: fix *.java indentation…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.java]
+ij_continuation_indent_size = 8
+indent_size = 4


### PR DESCRIPTION
…by IntelliJ IDEA editorconfig plugin auto-formatting support

# Description

A small fix for IDEA "Reformat Code" and run-time editing to produce same indentation markup as `mvn spotless:apply`.

A large library of `ij_*` rules can be seen at e.g. https://android.googlesource.com/platform/tools/adt/idea/+/10c06f3d04c92db012597d0fe26f9b3337f76d9a/.editorconfig or https://codeberg.org/PGPainless/pgpainless/src/branch/main/.editorconfig