### PR TITLE
PCT compatibility with `cloudbees-bitbucket-branch-source`

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.67</version>
+    <version>4.72</version>
     <relativePath />
   </parent>
 
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
-        <version>2163.v2d916d90c305</version>
+        <version>2378.v3e03930028f2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -66,8 +66,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>okhttp-api</artifactId>
-      <!--Remove once this version is in the bom-->
-      <version>4.10.0-136.v1d8ce1b_1db_72</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTraitsTest.java
@@ -75,6 +75,15 @@ public class GitHubSCMSourceTraitsTest {
         } else {
             trust = "TrustPermission";
         }
+        String originTrait;
+        String forkTrait;
+        if (r.jenkins.getPlugin("cloudbees-bitbucket-branch-source") != null) {
+            originTrait = "org.jenkinsci.plugins.github_branch_source.OriginPullRequestDiscoveryTrait";
+            forkTrait = "org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait";
+        } else {
+            originTrait = "OriginPullRequestDiscoveryTrait";
+            forkTrait = "ForkPullRequestDiscoveryTrait";
+        }
         assertThat(
                 DescribableModel.uninstantiate2_(recreated).toString(),
                 is("@github("
@@ -84,8 +93,8 @@ public class GitHubSCMSourceTraitsTest {
                         + "repository=repo,"
                         + "traits=["
                         + "@gitHubBranchDiscovery$org.jenkinsci.plugins.github_branch_source.BranchDiscoveryTrait(strategyId=1), "
-                        + "@gitHubPullRequestDiscovery$OriginPullRequestDiscoveryTrait(strategyId=1), "
-                        + "@gitHubForkDiscovery$ForkPullRequestDiscoveryTrait("
+                        + "@gitHubPullRequestDiscovery$" + originTrait + "(strategyId=1), "
+                        + "@gitHubForkDiscovery$" + forkTrait + "("
                         + "strategyId=2,"
                         + "trust=@gitHubTrustPermissions$"
                         + trust


### PR DESCRIPTION
Allow this test to pass when `cloudbees-bitbucket-branch-source` is on the test classpath