### PR TITLE
Revert "[JENKINS-71849] Allow `NoThrottle` to be used even on github.…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitChecker.java
@@ -100,13 +100,22 @@ public enum ApiRateLimitChecker {
     NoThrottle(Messages.ApiRateLimitChecker_NoThrottle()) {
         @Override
         public LocalChecker getChecker(@NonNull TaskListener listener, String apiUrl) {
-            return new LocalChecker(listener) {
-                @Override
-                long checkRateLimitImpl(@NonNull GHRateLimit.Record rateLimit, long count, long now)
-                        throws InterruptedException {
-                    return now;
-                }
-            };
+            if (GitHubServerConfig.GITHUB_URL.equals(apiUrl)) {
+                // If the GitHub public API is being used, this will fallback to ThrottleOnOver
+                LocalChecker checker = ThrottleOnOver.getChecker(listener, apiUrl);
+                checker.writeLog(
+                        "GitHub throttling is disabled, which is not allowed for public GitHub usage, "
+                                + "so ThrottleOnOver will be used instead. To configure a different rate limiting strategy, go to \"GitHub API usage\" under \"Configure System\" in the Jenkins settings.");
+                return checker;
+            } else {
+                return new LocalChecker(listener) {
+                    @Override
+                    long checkRateLimitImpl(@NonNull GHRateLimit.Record rateLimit, long count, long now)
+                            throws InterruptedException {
+                        return now;
+                    }
+                };
+            }
         }
     };
 

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ApiRateLimitCheckerTest.java
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 import org.jenkinsci.plugins.github.config.GitHubServerConfig;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kohsuke.github.GHRateLimit;
 import org.kohsuke.github.GitHub;
@@ -160,7 +159,6 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
         assertEquals(2, initialRequestCount);
     }
 
-    @Ignore("behavior deliberately modified")
     @Test
     public void NoCheckerConfigured() throws Exception {
         // set up scenarios
@@ -351,7 +349,6 @@ public class ApiRateLimitCheckerTest extends AbstractGitHubWireMockTest {
      *
      * @author Marc Salles Navarro
      */
-    @Ignore("behavior deliberately modified")
     @Test
     public void NoThrottleTestShouldFallbackToThrottleOnOverForGitHubDotCom() throws Exception {
         GitHubConfiguration.get().setApiRateLimitChecker(ApiRateLimitChecker.ThrottleOnOver);


### PR DESCRIPTION
…com (#653)"

This reverts commit 51d5810e9e8c15d7b4835bc6eb19fb882ffdf8e6.

# Description

Reverting #653 due to concerns of GitHub policies explained here: https://github.com/jenkinsci/github-branch-source-plugin/pull/653#issuecomment-1722715577

Issue experienced in JENKINS-71849 still exist and need continued investigation as to why `ThrottleOnOver` is not behaving as expected.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

