### PR TITLE
Add "Checks" permissions to github-app docs

### DIFF
--- a/docs/github-app.adoc
+++ b/docs/github-app.adoc
@@ -46,6 +46,7 @@ The only fields you need to fill out (currently) are:
 
 Permissions this plugin uses:
 
+- Checks - Read and Write
 - Commit statuses - Read and Write
 - Contents: Read-only (to read the `Jenkinsfile` and the repository content during `git fetch`). You may need "Read & write" to update the repository such as tagging releases
 - Metadata: Read-only


### PR DESCRIPTION
# Description

the documented permissions were incomplete. To make the plugin actually work, you have to also enable Read/Write permissions on Checks.

# Submitter checklist
- ~Link to JIRA ticket in description, if appropriate.~
- ~Change is code complete and matches issue description~
- ~Automated tests have been added to exercise the changes~
- ~Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.~

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

