### PR TITLE
[JENKINS-72030] Add checkbox to enable/disable Avatar retrieval

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -128,6 +128,12 @@ public class GitHubSCMNavigator extends SCMNavigator {
     @CheckForNull
     private String credentialsId;
     /** The behavioural traits to apply. */
+
+    /**
+     * Whether to enable the retrieval of the Organization avatar. If false, then the default GitHub logo will be used.
+     */
+    private boolean enableAvatar;
+
     @NonNull
     private List<SCMTrait<? extends SCMTrait<?>>> traits;
 
@@ -221,6 +227,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
     public GitHubSCMNavigator(String repoOwner) {
         this.repoOwner = StringUtils.defaultString(repoOwner);
         this.traits = new ArrayList<>();
+        this.enableAvatar = false;
     }
 
     /**
@@ -300,6 +307,25 @@ public class GitHubSCMNavigator extends SCMNavigator {
     @DataBoundSetter
     public void setCredentialsId(@CheckForNull String credentialsId) {
         this.credentialsId = Util.fixEmpty(credentialsId);
+    }
+
+    /**
+     * Return if the avatar retrieval is enabled.
+     *
+     * @return true is enabled, false otherwise
+     */
+    public boolean isEnableAvatar() {
+        return enableAvatar;
+    }
+
+    /**
+     * Enable retrieval of the organization avatar.
+     *
+     * @param enableAvatar true to enable, false to disable
+     */
+    @DataBoundSetter
+    public void setEnableAvatar(boolean enableAvatar) {
+        this.enableAvatar = enableAvatar;
     }
 
     /**
@@ -1531,7 +1557,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 Connector.lookupScanCredentials((Item) owner, getApiUri(), credentialsId, repoOwner);
         GitHub hub = Connector.connect(getApiUri(), credentials);
         Connector.configureLocalRateLimitChecker(listener, hub);
-        boolean privateMode = determinePrivateMode(apiUri);
+        boolean privateMode = !enableAvatar || determinePrivateMode(apiUri);
         try {
             GHUser u = hub.getUser(getRepoOwner());
             String objectUrl = u.getHtmlUrl() == null ? null : u.getHtmlUrl().toExternalForm();

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -132,7 +132,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
     /**
      * Whether to enable the retrieval of the Organization avatar. If false, then the default GitHub logo will be used.
      */
-    private boolean enableAvatar;
+    private Boolean enableAvatar;
 
     @NonNull
     private List<SCMTrait<? extends SCMTrait<?>>> traits;
@@ -227,7 +227,6 @@ public class GitHubSCMNavigator extends SCMNavigator {
     public GitHubSCMNavigator(String repoOwner) {
         this.repoOwner = StringUtils.defaultString(repoOwner);
         this.traits = new ArrayList<>();
-        this.enableAvatar = false;
     }
 
     /**
@@ -314,7 +313,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
      *
      * @return true is enabled, false otherwise
      */
-    public boolean isEnableAvatar() {
+    @CheckForNull
+    public Boolean getEnableAvatar() {
         return enableAvatar;
     }
 
@@ -324,7 +324,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
      * @param enableAvatar true to enable, false to disable
      */
     @DataBoundSetter
-    public void setEnableAvatar(boolean enableAvatar) {
+    public void setEnableAvatar(Boolean enableAvatar) {
         this.enableAvatar = enableAvatar;
     }
 
@@ -390,6 +390,9 @@ public class GitHubSCMNavigator extends SCMNavigator {
     private Object readResolve() {
         if (scanCredentialsId != null) {
             credentialsId = scanCredentialsId;
+        }
+        if (enableAvatar == null) {
+            enableAvatar = Boolean.TRUE;
         }
         if (traits == null) {
             boolean buildOriginBranch = this.buildOriginBranch == null || this.buildOriginBranch;
@@ -1557,7 +1560,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 Connector.lookupScanCredentials((Item) owner, getApiUri(), credentialsId, repoOwner);
         GitHub hub = Connector.connect(getApiUri(), credentials);
         Connector.configureLocalRateLimitChecker(listener, hub);
-        boolean privateMode = !enableAvatar || determinePrivateMode(apiUri);
+        boolean privateMode = !Boolean.TRUE.equals(enableAvatar) || determinePrivateMode(apiUri);
         try {
             GHUser u = hub.getUser(getRepoOwner());
             String objectUrl = u.getHtmlUrl() == null ? null : u.getHtmlUrl().toExternalForm();

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1561,7 +1561,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 Connector.lookupScanCredentials((Item) owner, getApiUri(), credentialsId, repoOwner);
         GitHub hub = Connector.connect(getApiUri(), credentials);
         Connector.configureLocalRateLimitChecker(listener, hub);
-        boolean privateMode = !Boolean.TRUE.equals(enableAvatar) || determinePrivateMode(apiUri);
+        boolean privateMode = !getEnableAvatar() || determinePrivateMode(apiUri);
         try {
             GHUser u = hub.getUser(getRepoOwner());
             String objectUrl = u.getHtmlUrl() == null ? null : u.getHtmlUrl().toExternalForm();

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -315,7 +315,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
      */
     @NonNull
     @SuppressWarnings("unused") // stapler
-    public boolean getEnableAvatar() {
+    public boolean isEnableAvatar() {
         return Boolean.TRUE.equals(enableAvatar);
     }
 
@@ -1561,7 +1561,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 Connector.lookupScanCredentials((Item) owner, getApiUri(), credentialsId, repoOwner);
         GitHub hub = Connector.connect(getApiUri(), credentials);
         Connector.configureLocalRateLimitChecker(listener, hub);
-        boolean privateMode = !getEnableAvatar() || determinePrivateMode(apiUri);
+        boolean privateMode = !isEnableAvatar() || determinePrivateMode(apiUri);
         try {
             GHUser u = hub.getUser(getRepoOwner());
             String objectUrl = u.getHtmlUrl() == null ? null : u.getHtmlUrl().toExternalForm();

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -313,9 +313,10 @@ public class GitHubSCMNavigator extends SCMNavigator {
      *
      * @return true is enabled, false otherwise
      */
-    @CheckForNull
-    public Boolean getEnableAvatar() {
-        return enableAvatar;
+    @NonNull
+    @SuppressWarnings("unused") // stapler
+    public boolean getEnableAvatar() {
+        return Boolean.TRUE.equals(enableAvatar);
     }
 
     /**
@@ -324,7 +325,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
      * @param enableAvatar true to enable, false to disable
      */
     @DataBoundSetter
-    public void setEnableAvatar(Boolean enableAvatar) {
+    public void setEnableAvatar(boolean enableAvatar) {
         this.enableAvatar = enableAvatar;
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/config.jelly
@@ -19,6 +19,9 @@
   <f:entry title="${%Owner}" field="repoOwner">
     <f:textbox/>
   </f:entry>
+  <f:entry title="${%Enable Avatar}" field="enableAvatar">
+    <f:checkbox default="false"/>
+  </f:entry>
   <f:entry title="${%Behaviours}">
     <scm:traits field="traits"/>
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/config.jelly
@@ -20,7 +20,7 @@
     <f:textbox/>
   </f:entry>
   <f:entry title="${%Enable Avatar}" field="enableAvatar">
-    <f:checkbox default="false"/>
+    <f:checkbox/>
   </f:entry>
   <f:entry title="${%Behaviours}">
     <scm:traits field="traits"/>

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/help-enableAvatar.html
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator/help-enableAvatar.html
@@ -1,0 +1,4 @@
+<div>
+    <p>Whether to use the <strong>GitHub Organization</strong> or <strong>GitHub User Account</strong> avatar as icon (only possible if private mode is disabled).</p>
+    <p>Note: this consumes an anonymous call to check if private mode is enabled. Although the result of this check is cached for some time (20 hours by default), this can block operations in some environments. See <a href="https://issues.jenkins.io/browse/JENKINS-72030">JENKINS-72030</a></p>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -437,8 +437,8 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
     }
 
     @Test
-    public void fetchActionsWithoutAvatar() throws Exception {
-        navigator.setEnableAvatar(false);
+    public void fetchActionsWithAvatar() throws Exception {
+        navigator.setEnableAvatar(true);
         assertThat(
                 navigator.fetchActions(Mockito.mock(SCMNavigatorOwner.class), null, null),
                 Matchers.containsInAnyOrder(

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -432,6 +432,18 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
                 Matchers.containsInAnyOrder(
                         Matchers.is(
                                 new ObjectMetadataAction("CloudBeers, Inc.", null, "https://github.com/cloudbeers")),
+                        Matchers.is(new GitHubOrgMetadataAction((String) null)),
+                        Matchers.is(new GitHubLink("icon-github-logo", "https://github.com/cloudbeers"))));
+    }
+
+    @Test
+    public void fetchActionsWithAvatar() throws Exception {
+        navigator.setEnableAvatar(true);
+        assertThat(
+                navigator.fetchActions(Mockito.mock(SCMNavigatorOwner.class), null, null),
+                Matchers.containsInAnyOrder(
+                        Matchers.is(
+                                new ObjectMetadataAction("CloudBeers, Inc.", null, "https://github.com/cloudbeers")),
                         Matchers.is(new GitHubOrgMetadataAction("https://avatars.githubusercontent.com/u/4181899?v=3")),
                         Matchers.is(new GitHubLink("icon-github-logo", "https://github.com/cloudbeers"))));
     }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -437,8 +437,8 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
     }
 
     @Test
-    public void fetchActionsWithAvatar() throws Exception {
-        navigator.setEnableAvatar(true);
+    public void fetchActionsWithoutAvatar() throws Exception {
+        navigator.setEnableAvatar(false);
         assertThat(
                 navigator.fetchActions(Mockito.mock(SCMNavigatorOwner.class), null, null),
                 Matchers.containsInAnyOrder(


### PR DESCRIPTION
# Description

Proposing a field configuration to enable / disable the Avatar action fetch that can be causing issues because of the anonymous call. Even with recent addition of a cache, this can still be a problem.
See [JENKINS-72030](https://issues.jenkins.io/browse/JENKINS-72030) for further information. 

I thought it would be a better to disable it by default after seeing recent discussions in https://github.com/jenkinsci/github-branch-source-plugin/pull/653#issuecomment-1722715577.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

@jglick @bitwiseman @rsandell 