### PR TITLE
Do not enforce GitHub app to comes from the same org as the repo org. The GH app can come from another org as log as it is installed in the org with the target git repo there is no security issue

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -326,9 +326,6 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
     @NonNull
     public synchronized GitHubAppCredentials withOwner(@NonNull String owner) {
         if (this.owner != null) {
-            if (!owner.equals(this.owner)) {
-                throw new IllegalArgumentException("Owner mismatch: " + this.owner + " vs. " + owner);
-            }
             return this;
         }
         if (byOwner == null) {


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

# Description

A brief summary describing the changes in this pull request. See 
[JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

