### PR TITLE
Ensure that GitHubAppCredentials creates tokens for the proper app installation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -325,7 +325,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
 
     @NonNull
     public synchronized GitHubAppCredentials withOwner(@NonNull String owner) {
-        if (this.owner != null) {
+        if (this.owner != null && this.owner.equals(owner)) {
             return this;
         }
         if (byOwner == null) {


### PR DESCRIPTION
# Description

This PR improves the fix merged in https://github.com/jenkinsci/github-branch-source-plugin/pull/744 by ensuring that GitHubAppCredentials#withOwner() always returns a proper GitHubAppCredentials instance with the requested owner set, as otherwise tokens issued for different installations might be used to access resources of a GitHub organization.

Further information can be found in the discussion of PR #744.

A brief summary describing the changes in this pull request. See 
[JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX) for further information. 

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

