### PR TITLE
Revert "Do not enforce GitHub app to comes from the same org as the repo org. The GH app can come from another org as log as it is installed in the org with the target git repo there is no security issue"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -326,6 +326,9 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
     @NonNull
     public synchronized GitHubAppCredentials withOwner(@NonNull String owner) {
         if (this.owner != null) {
+            if (!owner.equals(this.owner)) {
+                throw new IllegalArgumentException("Owner mismatch: " + this.owner + " vs. " + owner);
+            }
             return this;
         }
         if (byOwner == null) {


### PR DESCRIPTION
Reverts jenkinsci/github-branch-source-plugin#744

The owner is intended to restrict the credential to the specified org.  If the user wishes to use an app credential in multiple orgs they can remove the owner.

there was no details / ticket with information in the original and I concur with @jglick that the change is incorrect.