### PR TITLE
[JENKINS-60874] Configuring ForkPullRequestDiscoveryTrait using Job DSL

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait2Test.java
@@ -28,9 +28,6 @@ import static org.junit.Assert.*;
 import java.util.Collections;
 import java.util.List;
 import jenkins.branch.BranchSource;
-import jenkins.scm.api.SCMRevision;
-import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
-import jenkins.scm.api.trait.SCMHeadAuthority;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Ignore;
@@ -69,8 +66,7 @@ public class ForkPullRequestDiscoveryTrait2Test {
 
     private void assertRoundTrip(
             WorkflowMultiBranchProject p,
-            SCMHeadAuthority<? super GitHubSCMSourceRequest, ? extends ChangeRequestSCMHead2, ? extends SCMRevision>
-                    trust,
+            ForkPullRequestDiscoveryTrait.GitHubForkTrustPolicy trust,
             boolean configuredByUrl)
             throws Exception {
 


### PR DESCRIPTION
# Description

[JENKINS-26535](https://issues.jenkins-ci.org/browse/JENKINS-26535) describes an issue where wildcards in generics aren't handled well and result in the inability to configure classes that use wildcards in Job DSL, such as the SCMHeadAuthority class used for the forked PR trust policy. To work around this issue, create a new abstract class named GitHubForkTrustPolicy which extends the necessary SCMHeadAuthority superclass with its proper generics and use it in the constructor instead. Update all the trust policies to extend from this abstract class so they can be used.

Example use:
```groovy
branchSources {
    branchSource {
        source {
            github {
                // snipped standard repository fields

                traits {
                    gitHubBranchDiscovery {
                        strategyId 1
                    }
                    gitHubPullRequestDiscovery {
                        strategyId 1
                    }
                    gitHubForkDiscovery {
                        strategyId 1
                        trust {
                            gitHubTrustPermissions()
                        }
                    }
                }
            }
        }
    }
}
```

Fixes [JENKINS-60874](https://issues.jenkins-ci.org/browse/JENKINS-60874). 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] ~Link to jenkins.io PR, or an explanation for why no doc changes are needed~
This will be discovered and exposed through the Job DSL API viewer.

# Users/aliases to notify
