### PR TITLE
:new: Add mixed category to group branches and pull requests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchesAndChangeRequestsCategory.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchesAndChangeRequestsCategory.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.github_branch_source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMSource;
+import org.jvnet.localizer.Localizable;
+
+import static org.jenkinsci.plugins.github_branch_source.Messages._GitHubSCMSource_BranchesAndChangeRequestsCategory;
+
+/**
+ * Standard category for {@link SCMHead} instances that includes all {@link SCMHead}s.
+ *
+ * @since 2.0
+ */
+public final class BranchesAndChangeRequestsCategory extends SCMHeadCategory {
+  /**
+   * The {@link BranchesAndChangeRequestsCategory} singleton with the default naming.
+   */
+  public static final BranchesAndChangeRequestsCategory DEFAULT = new BranchesAndChangeRequestsCategory();
+
+  /**
+   * Constructs a {@link BranchesAndChangeRequestsCategory} using the default naming.
+   */
+  private BranchesAndChangeRequestsCategory() {
+    super("all", _GitHubSCMSource_BranchesAndChangeRequestsCategory());
+  }
+
+  /**
+   * Constructs a {@link BranchesAndChangeRequestsCategory} with customized naming. Use this constructor when the generic
+   * naming is not appropriate terminology for the specific {@link SCMSource}'s naming of change requests.
+   *
+   * @param displayName
+   *   the display name for change requests.
+   */
+  @SuppressFBWarnings("NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION")
+  public BranchesAndChangeRequestsCategory(@NonNull Localizable displayName) {
+    super("all", displayName);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isMatch(@NonNull SCMHead instance) {
+    return true;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchesAndChangeRequestsCategory.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchesAndChangeRequestsCategory.java
@@ -24,6 +24,8 @@
 
 package org.jenkinsci.plugins.github_branch_source;
 
+import static org.jenkinsci.plugins.github_branch_source.Messages._GitHubSCMSource_BranchesAndChangeRequestsCategory;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.scm.api.SCMHead;
@@ -31,43 +33,41 @@ import jenkins.scm.api.SCMHeadCategory;
 import jenkins.scm.api.SCMSource;
 import org.jvnet.localizer.Localizable;
 
-import static org.jenkinsci.plugins.github_branch_source.Messages._GitHubSCMSource_BranchesAndChangeRequestsCategory;
-
 /**
  * Standard category for {@link SCMHead} instances that includes all {@link SCMHead}s.
  *
  * @since 2.0
  */
 public final class BranchesAndChangeRequestsCategory extends SCMHeadCategory {
-  /**
-   * The {@link BranchesAndChangeRequestsCategory} singleton with the default naming.
-   */
-  public static final BranchesAndChangeRequestsCategory DEFAULT = new BranchesAndChangeRequestsCategory();
+    /**
+     * The {@link BranchesAndChangeRequestsCategory} singleton with the default naming.
+     */
+    public static final BranchesAndChangeRequestsCategory DEFAULT = new BranchesAndChangeRequestsCategory();
 
-  /**
-   * Constructs a {@link BranchesAndChangeRequestsCategory} using the default naming.
-   */
-  private BranchesAndChangeRequestsCategory() {
-    super("all", _GitHubSCMSource_BranchesAndChangeRequestsCategory());
-  }
+    /**
+     * Constructs a {@link BranchesAndChangeRequestsCategory} using the default naming.
+     */
+    private BranchesAndChangeRequestsCategory() {
+        super("all", _GitHubSCMSource_BranchesAndChangeRequestsCategory());
+    }
 
-  /**
-   * Constructs a {@link BranchesAndChangeRequestsCategory} with customized naming. Use this constructor when the generic
-   * naming is not appropriate terminology for the specific {@link SCMSource}'s naming of change requests.
-   *
-   * @param displayName
-   *   the display name for change requests.
-   */
-  @SuppressFBWarnings("NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION")
-  public BranchesAndChangeRequestsCategory(@NonNull Localizable displayName) {
-    super("all", displayName);
-  }
+    /**
+     * Constructs a {@link BranchesAndChangeRequestsCategory} with customized naming. Use this constructor when the generic
+     * naming is not appropriate terminology for the specific {@link SCMSource}'s naming of change requests.
+     *
+     * @param displayName
+     *   the display name for change requests.
+     */
+    @SuppressFBWarnings("NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION")
+    public BranchesAndChangeRequestsCategory(@NonNull Localizable displayName) {
+        super("all", displayName);
+    }
 
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public boolean isMatch(@NonNull SCMHead instance) {
-    return true;
-  }
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isMatch(@NonNull SCMHead instance) {
+        return true;
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchesAndChangeRequestsDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchesAndChangeRequestsDiscoveryTrait.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.github_branch_source;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.github_branch_source.BranchDiscoveryTrait.BranchSCMHeadAuthority;
+import org.jenkinsci.plugins.github_branch_source.OriginPullRequestDiscoveryTrait.OriginChangeRequestSCMHeadAuthority;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.EnumSet;
+
+/**
+ * A {@link Discovery} trait for GitHub that will discover branches on the repository.
+ *
+ * @since 2.2.0
+ */
+public class BranchesAndChangeRequestsDiscoveryTrait extends SCMSourceTrait {
+    /**
+     * Constructor for stapler.
+     */
+    @DataBoundConstructor
+    public BranchesAndChangeRequestsDiscoveryTrait() {}
+
+    /** {@inheritDoc} */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        GitHubSCMSourceContext ctx = (GitHubSCMSourceContext) context;
+        ctx.wantBranches(true);
+        ctx.withFilter(new BranchDiscoveryTrait.ExcludeOriginPRBranchesSCMHeadFilter());
+        ctx.withAuthority(new BranchSCMHeadAuthority());
+
+        ctx.wantOriginPRs(true);
+        ctx.wantForkPRs(false); // TODO: make optional?
+        ctx.withAuthority(new OriginChangeRequestSCMHeadAuthority());
+        ctx.withOriginPRStrategies(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean includeCategory(@NonNull SCMHeadCategory category) {
+        return category instanceof BranchesAndChangeRequestsCategory;
+    }
+
+    /** Our descriptor. */
+    @Symbol("gitHubBranchesAndChangeRequestsDiscovery")
+    @Extension
+    @Discovery
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /** {@inheritDoc} */
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.BranchesAndChangeRequestsDiscoveryTrait_displayName();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Class<? extends SCMSourceContext<?, ?>> getContextClass() {
+            return GitHubSCMSourceContext.class;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return GitHubSCMSource.class;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchesAndChangeRequestsDiscoveryTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/BranchesAndChangeRequestsDiscoveryTrait.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.github_branch_source;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import java.util.EnumSet;
 import jenkins.scm.api.SCMHeadCategory;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
@@ -36,8 +37,6 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.github_branch_source.BranchDiscoveryTrait.BranchSCMHeadAuthority;
 import org.jenkinsci.plugins.github_branch_source.OriginPullRequestDiscoveryTrait.OriginChangeRequestSCMHeadAuthority;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import java.util.EnumSet;
 
 /**
  * A {@link Discovery} trait for GitHub that will discover branches on the repository.

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -2466,7 +2466,8 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             return new SCMHeadCategory[] {
                 new UncategorizedSCMHeadCategory(Messages._GitHubSCMSource_UncategorizedCategory()),
                 new ChangeRequestSCMHeadCategory(Messages._GitHubSCMSource_ChangeRequestCategory()),
-                new TagSCMHeadCategory(Messages._GitHubSCMSource_TagCategory())
+                new TagSCMHeadCategory(Messages._GitHubSCMSource_TagCategory()),
+                new BranchesAndChangeRequestsCategory(Messages._GitHubSCMSource_BranchesAndChangeRequestsCategory())
             };
         }
     }

--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -1,6 +1,9 @@
 BranchSCMHead.Pronoun=Branch
 GitHubTagSCMHead.Pronoun=Tag
 
+BranchesAndChangeRequestsDiscoveryTrait.displayName=Discover branches & pull requests
+BranchesAndChangeRequestsDiscoveryTrait.DisplayName=GitHub Branch & Pull Requests Jobs
+
 ForkPullRequestDiscoveryTrait.contributorsDisplayName=Collaborators
 ForkPullRequestDiscoveryTrait.permissionsDisplayName=From users with Admin or Write permission
 ForkPullRequestDiscoveryTrait.displayName=Discover pull requests from forks
@@ -38,6 +41,7 @@ GitHubSCMNavigator.Description=Scans a GitHub organization (or user account) for
 GitHubSCMNavigator.Pronoun=Organization
 GitHubSCMNavigator.UncategorizedCategory=Repositories
 
+GitHubSCMSource.BranchesAndChangeRequestsCategory=Branches & Pull Requests
 GitHubSCMSource.ChangeRequestCategory=Pull Requests
 GitHubSCMSource.TagCategory=Tags
 GitHubSCMSource.DisplayName=GitHub


### PR DESCRIPTION
# Description

Most repositories I've worked with professionally had a unique set of requirements that are currently not addressed well by this plugin. We wanted to have:

* Build branches, except for PoCs/investigation branches
* Specific behavior for PR builds, ex: Sonar integration to check new code only
* A single view with all of those jobs

We address almost all of this except for the last part.

* We use the branch discovery trait with regex filters and branch naming convention for `#1`
* We use the pull request (from origin) discovery trait with draft PR filter for `#2`
* BUT: we have an issue with jobs "jumping" from the 'Branches' view to the 'Pull Requests' view when we open the PR which is pretty confusing. It also means that people searching for the builds related to a feature can't 'ctrl-f' in a single location.

I think that finding a way to group the branch & PR jobs would be beneficial for lots of users.

See [JENKINS-72490](https://issues.jenkins-ci.org/browse/JENKINS-72490). 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description - there are still discussions to be had on the use-case and implementation
- [ ] Automated tests have been added to exercise the changes - there are still discussions to be had on the use-case and implementation
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [x] Run the changes and verify that the change matches the issue description
- [x] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given - there are still discussions to be had on the use-case and implementation

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed - there are still discussions to be had on the use-case and implementation

# Users/aliases to notify

@quilicicf

# How to test

I created [a public repository](https://github.com/quilicicf/TestPrAndBranchDiscoveryTrait) to help test the changes.

To test: 

* Pull the branch
* Run the local Jenkins instance with `mvn hpi:run`
* Open the test instance: http://localhost:8080/jenkins
* Create a multi-branch pipeline job on the test repository (see link above) with the new discovery trait `Discover branches & pull requests` 
    > You will probably have to [create a GitHub personal access token](https://docs.github.com/en/enterprise-server@3.9/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token) with content read access to the repository in question to avoid the tiny rate limits of anonymous users on the GitHub REST API. Create a Jenkins credential (`usernamePassword`) with your login/PAT and use it in the configuration of the branch source in the job.

The test repository is setup so you can see two jobs, one for the `master` branch, one for `PR-1`.

The Jenkinsfile in the repository displays the global environment variables that are present only for PRs, you can validate that they are `null` on `master` and have values on the PR.

# What it looks like

![example_on_test_repository](https://github.com/jenkinsci/github-branch-source-plugin/assets/5594303/8b5e308c-b337-4c1c-85c2-072e4656fe6a)

> Note: I haven't made the view uncategorized so the `Branches` view still shows up and is displayed by default which is bad but I'm not sure making it uncategorized is the right way to do this. 