### PR TITLE
Fix naming of unstable status

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/Messages.properties
@@ -13,7 +13,7 @@ ForkPullRequestDiscoveryTrait.nobodyDisplayName=Nobody
 GitHubBranchFilter.DisplayName=GitHub Branch Jobs Only
 
 GitHubBuildStatusNotification.CommitStatus.Good=This commit looks good
-GitHubBuildStatusNotification.CommitStatus.Unstable=This commit has test failures
+GitHubBuildStatusNotification.CommitStatus.Unstable=This commit has failing tests or missing quality gates
 GitHubBuildStatusNotification.CommitStatus.Failure=This commit cannot be built
 GitHubBuildStatusNotification.CommitStatus.Aborted=The build of this commit was aborted
 GitHubBuildStatusNotification.CommitStatus.Other=Something is wrong with the build of this commit


### PR DESCRIPTION
Unstable build can have several reasons:
- failing tests
- uncovered lines
- SpotBugs warnings

![status](https://github.com/jenkinsci/github-branch-source-plugin/assets/503338/ce6c1ef4-4934-420e-9b30-feb77b74a077)

See bug report at https://github.com/jenkinsci/warnings-ng-plugin/pull/1649#issuecomment-1895154647


