### PR TITLE
Fix GH icon for app credentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -660,7 +660,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
         /** {@inheritDoc} */
         @Override
         public String getIconClassName() {
-            return "icon-github-logo";
+            return "symbol-logo-github plugin-ionicons-api";
         }
 
         @SuppressWarnings("unused") // jelly


### PR DESCRIPTION
The change proposed fixes a left over from https://github.com/jenkinsci/github-branch-source-plugin/pull/706

Before:
![Screenshot 2024-03-31 at 23 40 25](https://github.com/jenkinsci/github-branch-source-plugin/assets/13383509/a1103689-a90e-4131-b893-d97273ef26c2)

After:
![Screenshot 2024-03-31 at 23 40 18](https://github.com/jenkinsci/github-branch-source-plugin/assets/13383509/848b7599-82bc-408b-95db-ed4287ca4c82)