### PR TITLE
[JENKINS-73053] Allow users with Overall/Manage permission to configure endpoints

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -182,7 +182,7 @@ public class Connector {
      */
     public static FormValidation checkScanCredentials(
             @CheckForNull Item context, String apiUri, String scanCredentialsId, @CheckForNull String repoOwner) {
-        if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+        if (context == null && !Jenkins.get().hasPermission(Jenkins.MANAGE)
                 || context != null && !context.hasPermission(Item.EXTENDED_READ)) {
             return FormValidation.ok();
         }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Endpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Endpoint.java
@@ -130,7 +130,7 @@ public class Endpoint extends AbstractDescribableImpl<Endpoint> {
         @RequirePOST
         @Restricted(NoExternalUse.class)
         public FormValidation doCheckApiUri(@QueryParameter String apiUri) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.MANAGE);
             if (Util.fixEmptyAndTrim(apiUri) == null) {
                 return FormValidation.warning("You must specify the API URL");
             }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubConfiguration.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.github_branch_source;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
@@ -231,5 +233,11 @@ public class GitHubConfiguration extends GlobalConfiguration {
             items.add(mode.getDisplayName(), mode.name());
         }
         return items;
+    }
+
+    @NonNull
+    @Override
+    public Permission getRequiredGlobalConfigPagePermission() {
+        return Jenkins.MANAGE;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1800,7 +1800,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 @QueryParameter String apiUri,
                 @QueryParameter String credentialsId) {
             if (context == null
-                    ? !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+                    ? !Jenkins.get().hasPermission(Jenkins.MANAGE)
                     : !context.hasPermission(Item.EXTENDED_READ)) {
                 return new StandardListBoxModel().includeCurrentValue(credentialsId);
             }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -2069,7 +2069,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                 @QueryParameter String apiUri,
                 @QueryParameter String credentialsId) {
             if (context == null
-                    ? !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+                    ? !Jenkins.get().hasPermission(Jenkins.MANAGE)
                     : !context.hasPermission(Item.EXTENDED_READ)) {
                 return new StandardListBoxModel().includeCurrentValue(credentialsId);
             }
@@ -2102,7 +2102,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                 @QueryParameter String repositoryUrl,
                 @QueryParameter String credentialsId,
                 @QueryParameter String repoOwner) {
-            if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+            if (context == null && !Jenkins.get().hasPermission(Jenkins.MANAGE)
                     || context != null && !context.hasPermission(Item.EXTENDED_READ)) {
                 return FormValidation.error(
                         "Unable to validate repository information"); // not supposed to be seeing this form
@@ -2249,7 +2249,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             if (credentialsId == null) {
                 return new ListBoxModel();
             }
-            if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+            if (context == null && !Jenkins.get().hasPermission(Jenkins.MANAGE)
                     || context != null && !context.hasPermission(Item.EXTENDED_READ)) {
                 return new ListBoxModel(); // not supposed to be seeing this form
             }
@@ -2297,7 +2297,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             if (repoOwner == null) {
                 return new ListBoxModel();
             }
-            if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+            if (context == null && !Jenkins.get().hasPermission(Jenkins.MANAGE)
                     || context != null && !context.hasPermission(Item.EXTENDED_READ)) {
                 return new ListBoxModel(); // not supposed to be seeing this form
             }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/SSHCheckoutTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/SSHCheckoutTrait.java
@@ -152,7 +152,7 @@ public class SSHCheckoutTrait extends SCMSourceTrait {
                 @QueryParameter String apiUri,
                 @QueryParameter String credentialsId) {
             if (context == null
-                    ? !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+                    ? !Jenkins.get().hasPermission(Jenkins.MANAGE)
                     : !context.hasPermission(Item.EXTENDED_READ)) {
                 return new StandardListBoxModel().includeCurrentValue(credentialsId);
             }
@@ -181,7 +181,7 @@ public class SSHCheckoutTrait extends SCMSourceTrait {
                 @QueryParameter String serverUrl,
                 @QueryParameter String value) {
             if (context == null
-                    ? !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+                    ? !Jenkins.get().hasPermission(Jenkins.MANAGE)
                     : !context.hasPermission(Item.EXTENDED_READ)) {
                 return FormValidation.ok();
             }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/EndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/EndpointTest.java
@@ -22,6 +22,7 @@ import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
 import org.htmlunit.WebRequest;
+import org.htmlunit.html.HtmlPage;
 import org.htmlunit.util.NameValuePair;
 import org.junit.Before;
 import org.junit.Rule;
@@ -88,6 +89,13 @@ public class EndpointTest {
                 "descriptorByName/org.jenkinsci.plugins.github_branch_source.Endpoint/checkApiUri?apiUri=" + testUrl,
                 "alice");
         assertTrue(TestRoot.get().visited);
+    }
+
+    @Test
+    @Issue("JENKINS-73053")
+    public void manageCanSetupEndpoints() throws Exception {
+        HtmlPage htmlPage = j.createWebClient().login("alice").goTo("manage/configure");
+        assertTrue(htmlPage.getVisibleText().contains("GitHub Enterprise Servers"));
     }
 
     private String appendCrumb(String url) {

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/EndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/EndpointTest.java
@@ -45,7 +45,7 @@ public class EndpointTest {
     public void setUp() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         MockAuthorizationStrategy auth = new MockAuthorizationStrategy();
-        auth.grant(Jenkins.ADMINISTER).everywhere().to("alice");
+        auth.grant(Jenkins.MANAGE).everywhere().to("alice");
         auth.grant(Jenkins.READ).everywhere().toEveryone();
         j.jenkins.setAuthorizationStrategy(auth);
         testUrl = Util.rawEncode(j.getURL().toString() + "testroot/");

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -458,7 +458,7 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
         try {
             r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
             MockAuthorizationStrategy mockStrategy = new MockAuthorizationStrategy();
-            mockStrategy.grant(Jenkins.ADMINISTER).onRoot().to("admin");
+            mockStrategy.grant(Jenkins.MANAGE).onRoot().to("admin");
             mockStrategy.grant(Item.CONFIGURE).onItems(dummy).to("bob");
             mockStrategy.grant(Item.EXTENDED_READ).onItems(dummy).to("jim");
             r.jenkins.setAuthorizationStrategy(mockStrategy);

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -739,7 +739,7 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
         try {
             r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
             MockAuthorizationStrategy mockStrategy = new MockAuthorizationStrategy();
-            mockStrategy.grant(Jenkins.ADMINISTER).onRoot().to("admin");
+            mockStrategy.grant(Jenkins.MANAGE).onRoot().to("admin");
             mockStrategy.grant(Item.CONFIGURE).onItems(dummy).to("bob");
             mockStrategy.grant(Item.EXTENDED_READ).onItems(dummy).to("jim");
             r.jenkins.setAuthorizationStrategy(mockStrategy);

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/SSHCheckoutTraitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/SSHCheckoutTraitTest.java
@@ -86,7 +86,7 @@ public class SSHCheckoutTraitTest {
         try {
             j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
             MockAuthorizationStrategy mockStrategy = new MockAuthorizationStrategy();
-            mockStrategy.grant(Jenkins.ADMINISTER).onRoot().to("admin");
+            mockStrategy.grant(Jenkins.MANAGE).onRoot().to("admin");
             mockStrategy.grant(Item.CONFIGURE).onItems(dummy).to("bob");
             mockStrategy.grant(Item.EXTENDED_READ).onItems(dummy).to("jim");
             j.jenkins.setAuthorizationStrategy(mockStrategy);


### PR DESCRIPTION
# Description

Allow users with Overall/Manage permission to configure endpoints. See [JENKINS-73053](https://issues.jenkins.io/browse/JENKINS-73053) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

