### PR TITLE
[JENKINS-73388] Allow alternative implementation for GitHub App credentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -306,8 +306,8 @@ public class Connector {
                             githubDomainRequirements(apiUri)),
                     CredentialsMatchers.allOf(
                             CredentialsMatchers.withId(scanCredentialsId), githubScanCredentialsMatcher()));
-            if (c instanceof GitHubAppCredentials && repoOwner != null) {
-                return ((GitHubAppCredentials) c).withOwner(repoOwner);
+            if (c instanceof GitHubAppAuthentication && repoOwner != null) {
+                return ((GitHubAppAuthentication) c).getCredentials().withOwner(repoOwner);
             } else {
                 return c;
             }
@@ -365,9 +365,9 @@ public class Connector {
             hash = "anonymous";
             authHash = "anonymous";
             gitHubAppCredentials = null;
-        } else if (credentials instanceof GitHubAppCredentials) {
+        } else if (credentials instanceof GitHubAppAuthentication) {
             password = null;
-            gitHubAppCredentials = (GitHubAppCredentials) credentials;
+            gitHubAppCredentials = ((GitHubAppAuthentication) credentials).getCredentials();
             hash = Util.getDigestOf(gitHubAppCredentials.getAppID()
                     + gitHubAppCredentials.getOwner()
                     + gitHubAppCredentials.getPrivateKey().getPlainText()
@@ -411,7 +411,7 @@ public class Connector {
                     gb.withAuthorizationProvider(
                             ImmutableAuthorizationProvider.fromLoginAndPassword(username, password));
                 }
-                return new GitHubConnection(gb.build(), cache, credentials instanceof GitHubAppCredentials);
+                return new GitHubConnection(gb.build(), cache, credentials instanceof GitHubAppAuthentication);
             } catch (IOException e) {
                 throw new RuntimeException(e.getMessage(), e);
             }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -213,7 +213,7 @@ public class Connector {
                     GitHub connector = Connector.connect(apiUri, credentials);
                     try {
                         try {
-                            boolean githubAppAuthentication = credentials instanceof GitHubAppCredentials;
+                            boolean githubAppAuthentication = credentials instanceof GitHubAppAuthentication;
                             if (githubAppAuthentication) {
                                 int remaining = connector.getRateLimit().getRemaining();
                                 return FormValidation.ok("GHApp verified, remaining rate limit: %d", remaining);

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppAuthentication.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppAuthentication.java
@@ -1,6 +1,9 @@
 package org.jenkinsci.plugins.github_branch_source;
 
 /**
- * GitHub App authentication marker interface.
+ * GitHub App credentials supplier.
  */
-public interface GitHubAppAuthentication {}
+public interface GitHubAppAuthentication {
+
+    GitHubAppCredentials getCredentials();
+}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppAuthentication.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppAuthentication.java
@@ -1,0 +1,6 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+/**
+ * GitHub App authentication marker interface.
+ */
+public interface GitHubAppAuthentication {}

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -149,6 +149,11 @@ public class GitHubAppCredentials extends BaseStandardCredentials
         return new CredentialsTokenProvider(this);
     }
 
+    @Override
+    public GitHubAppCredentials getCredentials() {
+        return this;
+    }
+
     private static AuthorizationProvider createJwtProvider(String appId, String appPrivateKey) {
         try {
             return new JWTTokenProvider(appId, appPrivateKey);

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -53,7 +53,8 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 
 @SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "XStream")
-public class GitHubAppCredentials extends BaseStandardCredentials implements StandardUsernamePasswordCredentials {
+public class GitHubAppCredentials extends BaseStandardCredentials
+        implements StandardUsernamePasswordCredentials, GitHubAppAuthentication {
 
     private static final Logger LOGGER = Logger.getLogger(GitHubAppCredentials.class.getName());
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -992,7 +992,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 SourceFactory sourceFactory = new SourceFactory(request);
                 WitnessImpl witness = new WitnessImpl(listener);
 
-                boolean githubAppAuthentication = credentials instanceof GitHubAppCredentials;
+                boolean githubAppAuthentication = credentials instanceof GitHubAppAuthentication;
                 if (github.isAnonymous()) {
                     listener.getLogger()
                             .format(
@@ -1297,7 +1297,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                 SourceFactory sourceFactory = new SourceFactory(request);
                 WitnessImpl witness = new WitnessImpl(listener);
 
-                boolean githubAppAuthentication = credentials instanceof GitHubAppCredentials;
+                boolean githubAppAuthentication = credentials instanceof GitHubAppAuthentication;
                 if (github.isAnonymous()) {
                     listener.getLogger()
                             .format(


### PR DESCRIPTION
The current `Connector` supports GitHub App credentials with [class inheritance constraint on credentials implementation](https://github.com/jenkinsci/github-branch-source-plugin/blob/5b0c0cea18c351352f2d33ad2491d148bb38a447/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java#L216).

This PR introduces an interface to support GitHub App credentials alternative implementations that cannot extends [`GitHubAppCredentials`](https://github.com/jenkinsci/github-branch-source-plugin/blob/master/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java).

See [JENKINS-73388](https://issues.jenkins-ci.org/browse/JENKINS-73388) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

