### PR TITLE
[JENKINS-73388] Allow alternative implementation for GitHub App credentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -359,7 +359,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
     @NonNull
     @Override
     public Credentials forRun(Run<?, ?> context) {
-        if (owner != null) {
+        if (getOwner() != null) {
             return this;
         }
         Job<?, ?> job = context.getParent();

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -191,7 +191,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
         private final GitHubAppCredentials credentials;
 
         CredentialsTokenProvider(GitHubAppCredentials credentials) {
-            super(credentials.appID, credentials.privateKey.getPlainText());
+            super(credentials.getAppID(), credentials.getPrivateKey().getPlainText());
             this.credentials = credentials;
         }
 
@@ -284,17 +284,17 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
 
     @NonNull
     String actualApiUri() {
-        return Util.fixEmpty(apiUri) == null ? "https://api.github.com" : apiUri;
+        return Util.fixEmpty(getApiUri()) == null ? "https://api.github.com" : getApiUri();
     }
 
     private AppInstallationToken getToken(GitHub gitHub) {
         synchronized (this) {
             try {
                 if (cachedToken == null || cachedToken.isStale()) {
-                    LOGGER.log(Level.FINE, "Generating App Installation Token for app ID {0}", appID);
+                    LOGGER.log(Level.FINE, "Generating App Installation Token for app ID {0}", getAppID());
                     cachedToken = generateAppInstallationToken(
-                            gitHub, appID, privateKey.getPlainText(), actualApiUri(), owner);
-                    LOGGER.log(Level.FINER, "Retrieved GitHub App Installation Token for app ID {0}", appID);
+                            gitHub, getAppID(), getPrivateKey().getPlainText(), actualApiUri(), getOwner());
+                    LOGGER.log(Level.FINER, "Retrieved GitHub App Installation Token for app ID {0}", getAppID());
                 }
             } catch (Exception e) {
                 if (cachedToken != null && !cachedToken.isExpired()) {
@@ -304,14 +304,14 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
                     LOGGER.log(
                             Level.WARNING,
                             "Failed to generate new GitHub App Installation Token for app ID "
-                                    + appID
+                                    + getAppID()
                                     + ": cached token is stale but has not expired",
                             e);
                 } else {
                     throw e;
                 }
             }
-            LOGGER.log(Level.FINEST, "Returned GitHub App Installation Token for app ID {0}", appID);
+            LOGGER.log(Level.FINEST, "Returned GitHub App Installation Token for app ID {0}", getAppID());
 
             return cachedToken;
         }
@@ -328,7 +328,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
     @NonNull
     @Override
     public String getUsername() {
-        return appID;
+        return getAppID();
     }
 
     @Override
@@ -338,9 +338,9 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
 
     @NonNull
     public synchronized GitHubAppCredentials withOwner(@NonNull String owner) {
-        if (this.owner != null) {
-            if (!owner.equals(this.owner)) {
-                throw new IllegalArgumentException("Owner mismatch: " + this.owner + " vs. " + owner);
+        if (this.getOwner() != null) {
+            if (!owner.equals(this.getOwner())) {
+                throw new IllegalArgumentException("Owner mismatch: " + this.getOwner() + " vs. " + owner);
             }
             return this;
         }
@@ -349,9 +349,9 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
         }
         return byOwner.computeIfAbsent(owner, k -> {
             GitHubAppCredentials clone =
-                    new GitHubAppCredentials(getScope(), getId(), getDescription(), appID, privateKey);
-            clone.apiUri = apiUri;
-            clone.owner = owner;
+                    new GitHubAppCredentials(getScope(), getId(), getDescription(), getAppID(), getPrivateKey());
+            clone.apiUri = getApiUri();
+            clone.owner = getOwner();
             return clone;
         });
     }
@@ -523,12 +523,12 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
         DelegatingGitHubAppCredentials(GitHubAppCredentials onMaster) {
             super(onMaster.getScope(), onMaster.getId(), onMaster.getDescription());
             JenkinsJVM.checkJenkinsJVM();
-            appID = onMaster.appID;
+            appID = onMaster.getAppID();
             JSONObject j = new JSONObject();
             j.put("appID", appID);
-            j.put("privateKey", onMaster.privateKey.getPlainText());
+            j.put("privateKey", onMaster.getPrivateKey().getPlainText());
             j.put("apiUri", onMaster.actualApiUri());
-            j.put("owner", onMaster.owner);
+            j.put("owner", onMaster.getOwner());
             tokenRefreshData = Secret.fromString(j.toString()).getEncryptedValue();
 
             // Check token is valid before sending it to the agent.
@@ -541,7 +541,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
                 LOGGER.log(
                         Level.FINEST,
                         "Checking App Installation Token for app ID {0} before sending to agent",
-                        onMaster.appID);
+                        onMaster.getAppID());
                 onMaster.getPassword();
             } catch (Exception e) {
                 LOGGER.log(


### PR DESCRIPTION
This encapsulate fields making possible to extend `GitHubAppCredentials` to retrieve properties from an alternative storage instead of field values.

Pseudo code:
```java
class AlternativeGitHubAppCredentials extends GitHubAppCredentials {

    @Override
    public getAppID() {
        return retrieveFromExternalSystem("appId");
    }

    @Override
    public getPrivateKey() {
        return retrieveFromExternalSystem("privateKey");
    }
}
```

See [JENKINS-73388](https://issues.jenkins-ci.org/browse/JENKINS-73388) for further information.