### PR TITLE
[JENKINS-73474] Fix GitHubAppCredentials owner inference

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -351,7 +351,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
             GitHubAppCredentials clone =
                     new GitHubAppCredentials(getScope(), getId(), getDescription(), getAppID(), getPrivateKey());
             clone.apiUri = getApiUri();
-            clone.owner = getOwner();
+            clone.owner = owner;
             return clone;
         });
     }


### PR DESCRIPTION
GitHub App installed in multiple organizations get:
```
java.lang.IllegalArgumentException: Found multiple installations for GitHub app ID ... but none match credential owner "". Set the right owner in the credential advanced options to one of: ..., ...
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.generateAppInstallationToken(GitHubAppCredentials.java:244)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.getToken(GitHubAppCredentials.java:295)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.getPassword(GitHubAppCredentials.java:324)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.CliGitAPIImpl.createPasswordFile(CliGitAPIImpl.java:2547)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:2143)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:2079)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:2070)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.CliGitAPIImpl.getRemoteSymbolicReferences(CliGitAPIImpl.java:3842)
	at PluginClassLoader for git//jenkins.plugins.git.AbstractGitSCMSource.retrieveActions(AbstractGitSCMSource.java:1176)
	at PluginClassLoader for scm-api//jenkins.scm.api.SCMSource.fetchActions(SCMSource.java:847)
	at PluginClassLoader for branch-api//jenkins.branch.MultiBranchProject.computeChildren(MultiBranchProject.java:611)
	at PluginClassLoader for cloudbees-folder//com.cloudbees.hudson.plugins.folder.computed.ComputedFolder.updateChildren(ComputedFolder.java:269)
	at PluginClassLoader for cloudbees-folder//com.cloudbees.hudson.plugins.folder.computed.FolderComputation.run(FolderComputation.java:167)
	at PluginClassLoader for branch-api//jenkins.branch.MultiBranchProject$BranchIndexing.run(MultiBranchProject.java:1057)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:447)
```

Steps to reproduce:
* install GitHub App in more than one organization
* configure GitHub App Credentials with `owner` left blank to infer value
* configure multi branch pipeline using GitHub branch source
* trigger "scan multibranch pipeline"

The regression was introduced since https://github.com/jenkinsci/github-branch-source-plugin/pull/796. The `owner` parameter is not used anymore and the credentials clone is initialized using the `owner` field read method instead of `owner` parameter value, resulting with `null` owner in the cloned credentials. While [generating the token](https://github.com/jenkinsci/github-branch-source-plugin/blob/270b36283b675915c3016624c1f594df63f1009a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java#L295-L296), there is no installation matching with empty owner, [resulting in exception](https://github.com/jenkinsci/github-branch-source-plugin/blob/270b36283b675915c3016624c1f594df63f1009a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java#L243).

This fix the credentials clone by setting the `owner` from the parameter instead of clone field `null` value.

See [JENKINS-73474](https://issues.jenkins.io/browse/JENKINS-73474) for more information.