### PR TITLE
Make GitHubAppCredentials#writeReplace protected for subclasses

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -498,7 +498,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
      *   <li>The agent need not be able to contact GitHub.
      * </ul>
      */
-    private Object writeReplace() {
+    protected Object writeReplace() {
         if (
         /* XStream */ Channel.current() == null) {
             return this;


### PR DESCRIPTION
# Description

This would allow class that extends `GitHubAppCredentials` to benefit from the XStream serialization implemented in `GitHubAppCredentials`

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

@jeromepochat @jenkinsci/github-branch-source-plugin-developers 