### PR TITLE
[JENKINS-73791] Prevent PR 404 on details to break Branches scan

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1053,6 +1053,19 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                         }
                     });
 
+                    if (request.isFetchPRs()) {
+                        // JENKINS-56996 / JENKINS-73791
+                        // PRs are one the most error prone areas for scans
+                        // Branches and tags are contained only the current repo, PRs go across forks
+                        // FileNotFoundException can occur in a number of situations
+                        // When this happens, it is not ideal behavior but it is better to let the PR be
+                        // orphaned
+                        // and the orphan strategy control the result than for this error to stop scanning
+                        // (For Org scanning this is particularly important.)
+                        // If some more general IO exception is thrown, we will still fail.
+                        validatePullRequests(request);
+                    }
+
                     if (request.isFetchBranches()
                             && !request.isComplete()
                             && this.shouldRetrieve(observer, event, BranchSCMHead.class)) {
@@ -1067,6 +1080,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                                             HyperlinkNote.encodeTo(
                                                     resolvedRepositoryUrl + "/tree/" + branchName, branchName));
                             BranchSCMHead head = new BranchSCMHead(branchName);
+
                             if (request.process(
                                     head,
                                     new SCMRevisionImpl(head, branch.getSHA1()),
@@ -1081,8 +1095,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                                         }
                                     },
                                     new CriteriaWitness(listener))) {
-                                listener.getLogger()
-                                        .format("%n  %d branches were processed (query completed)%n", count);
                                 break;
                             }
                         }
@@ -1095,18 +1107,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                         int count = 0;
                         int errorCount = 0;
                         Map<Boolean, Set<ChangeRequestCheckoutStrategy>> strategies = request.getPRStrategies();
-
-                        // JENKINS-56996
-                        // PRs are one the most error prone areas for scans
-                        // Branches and tags are contained only the current repo, PRs go across forks
-                        // FileNotFoundException can occur in a number of situations
-                        // When this happens, it is not ideal behavior but it is better to let the PR be
-                        // orphaned
-                        // and the orphan strategy control the result than for this error to stop scanning
-                        // (For Org scanning this is particularly important.)
-                        // If some more general IO exception is thrown, we will still fail.
-
-                        validatePullRequests(request);
                         for (final GHPullRequest pr : request.getPullRequests()) {
                             int number = pr.getNumber();
                             try {

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSourceTest.java
@@ -375,6 +375,11 @@ public class GitHubSCMSourceTest extends GitSCMSourceBase {
 
     @Test
     public void fetchSmokes_badUser() throws Exception {
+        source.setTraits(Arrays.asList(
+                new BranchDiscoveryTrait(true, false),
+                new ForkPullRequestDiscoveryTrait(
+                        EnumSet.of(ChangeRequestCheckoutStrategy.MERGE),
+                        new ForkPullRequestDiscoveryTrait.TrustContributors())));
         // make it so PR-2 returns a file not found for user
         githubApi.stubFor(get(urlMatching("(/api/v3)?/repos/cloudbeers/yolo/pulls/2"))
                 .inScenario("Pull Request Merge Hash")


### PR DESCRIPTION
# Description

[JENKINS-73791](https://issues.jenkins.io/browse/JENKINS-73791): The retrieval of branches can fail the entire Branch Scanning if a `BranchDiscoveryTrait` strategy that involves checking on PRs is used while some PR parts cannot be retrieved with a 404 `FileNotFoundException`.

This is an extension of [JENKINS-56996](https://issues.jenkins.io/browse/JENKINS-56996) / https://github.com/jenkinsci/github-branch-source-plugin/pull/224.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

@jenkinsci/github-branch-source-plugin-developers 