### PR TITLE
Handle various errors from `doValidateRepositoryUrlAndCredentials`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -2155,7 +2155,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                 } finally {
                     Connector.release(github);
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 return FormValidation.error(e, "Error validating repository information. " + sb.toString());
             }
             return FormValidation.ok(sb.toString());


### PR DESCRIPTION
I got an Angry Jenkins while trying to validate a connection to a GitHub Enterprise server behind a VPN. System log said:

```
java.net.SocketTimeoutException: Connect timed out
	at java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:551)
	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:602)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
	at java.base/java.net.Socket.connect(Socket.java:633)
	at PluginClassLoader for okhttp-api//okhttp3.internal.platform.Platform.connectSocket(Platform.kt:128)
	at PluginClassLoader for okhttp-api//okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.kt:295)
	at PluginClassLoader for okhttp-api//okhttp3.internal.connection.RealConnection.connect(RealConnection.kt:207)
	at PluginClassLoader for okhttp-api//okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.kt:226)
	at PluginClassLoader for okhttp-api//okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.kt:106)
	at PluginClassLoader for okhttp-api//okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.kt:74)
	at PluginClassLoader for okhttp-api//okhttp3.internal.connection.RealCall.initExchange$okhttp(RealCall.kt:255)
	at PluginClassLoader for okhttp-api//okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:32)
	at PluginClassLoader for okhttp-api//okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at PluginClassLoader for okhttp-api//okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
	at PluginClassLoader for okhttp-api//okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at PluginClassLoader for okhttp-api//okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
	at PluginClassLoader for okhttp-api//okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at PluginClassLoader for okhttp-api//okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
	at PluginClassLoader for okhttp-api//okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at PluginClassLoader for github-api//org.kohsuke.github.extras.okhttp3.ObsoleteUrlFactory$UnexpectedException.lambda$static$0(ObsoleteUrlFactory.java:1364)
	at PluginClassLoader for okhttp-api//okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at PluginClassLoader for okhttp-api//okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
	at PluginClassLoader for okhttp-api//okhttp3.internal.connection.RealCall.execute(RealCall.kt:154)
	at PluginClassLoader for github-api//org.kohsuke.github.extras.okhttp3.ObsoleteUrlFactory$OkHttpURLConnection.getResponse(ObsoleteUrlFactory.java:670)
	at PluginClassLoader for github-api//org.kohsuke.github.extras.okhttp3.ObsoleteUrlFactory$OkHttpURLConnection.getResponseCode(ObsoleteUrlFactory.java:701)
	at PluginClassLoader for github-api//org.kohsuke.github.extras.okhttp3.ObsoleteUrlFactory$DelegatingHttpsURLConnection.getResponseCode(ObsoleteUrlFactory.java:1063)
	at PluginClassLoader for github-api//org.kohsuke.github.internal.GitHubConnectorHttpConnectorAdapter.send(GitHubConnectorHttpConnectorAdapter.java:87)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:461)
Caused: org.kohsuke.github.HttpException: Server returned HTTP response code: -1, message: 'null' for URL: https://github.example.com/api/v3/app
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.interpretApiError(GitHubClient.java:743)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:478)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:427)
	at PluginClassLoader for github-api//org.kohsuke.github.Requester.fetch(Requester.java:85)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHub.getApp(GitHub.java:1189)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.generateAppInstallationToken(GitHubAppCredentials.java:218)
Caused: java.lang.IllegalArgumentException: Couldn't authenticate with GitHub app ID 1234
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.generateAppInstallationToken(GitHubAppCredentials.java:220)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.getToken(GitHubAppCredentials.java:295)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials$CredentialsTokenProvider.getEncodedAuthorization(GitHubAppCredentials.java:199)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.prepareConnectorRequest(GitHubClient.java:616)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:455)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.fetch(GitHubClient.java:159)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.checkApiUrlValidity(GitHubClient.java:390)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHub.checkApiUrlValidity(GitHub.java:1321)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.ApiRateLimitChecker.verifyConnection(ApiRateLimitChecker.java:194)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.Connector$GitHubConnection.verifyConnection(Connector.java:722)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.Connector.connect(Connector.java:419)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubSCMSource$DescriptorImpl.doValidateRepositoryUrlAndCredentials(GitHubSCMSource.java:2143)
```

Maybe `generateAppInstallationToken` should be allowed to throw `IOException`, but anyway it seems that if `Connector.connect` fails for any reason, that is presumably something you want displayed in the output of the validation button, not sent to the system log.
