### PR TITLE
[JENKINS-75471] Gracefully skip repository if its processing fails in Organization scan

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1083,7 +1083,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                                                             "%d repositories were processed (query completed)",
                                                             witness.getCount())));
                                 }
-                            } catch (Exception e) {
+                            } catch (IOException e) {
                                 listener.getLogger()
                                         .println(GitHubConsoleNote.create(
                                                 System.currentTimeMillis(),
@@ -1176,7 +1176,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
                                                         "%d repositories were processed (query completed)",
                                                         witness.getCount())));
                             }
-                        } catch (Exception e) {
+                        } catch (IOException e) {
                             listener.getLogger()
                                     .println(GitHubConsoleNote.create(
                                             System.currentTimeMillis(),

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -47,6 +47,7 @@ import hudson.security.AuthorizationStrategy;
 import hudson.security.SecurityRealm;
 import hudson.util.ListBoxModel;
 import hudson.util.LogTaskListener;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -458,6 +459,42 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
         navigator.visitSources(SCMSourceObserver.filter(observer, "yolo", "rando-unknown"));
 
         assertEquals(projectNames, Collections.singleton("yolo"));
+    }
+
+    @Test
+    public void fetchBadRepo() throws Exception {
+        final Set<String> projectNames = new HashSet<>();
+        final SCMSourceObserver observer = new SCMSourceObserver() {
+            @NonNull
+            @Override
+            public SCMSourceOwner getContext() {
+                return scmSourceOwner;
+            }
+
+            @NonNull
+            @Override
+            public TaskListener getListener() {
+                return new LogTaskListener(Logger.getAnonymousLogger(), Level.INFO);
+            }
+
+            @NonNull
+            @Override
+            public ProjectObserver observe(@NonNull String projectName) throws IllegalArgumentException, IOException {
+                if ("basic".equalsIgnoreCase(projectName)) {
+                    throw new IOException("Failed to get repo basic");
+                }
+                projectNames.add(projectName);
+                return new NoOpProjectObserver();
+            }
+
+            @Override
+            public void addAttribute(@NonNull String key, @Nullable Object value)
+                    throws IllegalArgumentException, ClassCastException {}
+        };
+
+        navigator.visitSources(SCMSourceObserver.filter(observer, "basic", "yolo"));
+
+        assertThat(projectNames, containsInAnyOrder("yolo"));
     }
 
     @Test


### PR DESCRIPTION
# Description

In case a single repository processing fails during the Organizsation scan, the entire scan would be interrupted. Propose to handle the exception to no report the error and not break the loop.
See [JENKINS-75471](https://issues.jenkins.io/browse/JENKINS-75471) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

