### PR TITLE
Migrate from com.github.tomakehurst to org.wiremock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,12 +86,6 @@
       <artifactId>workflow-support</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
-      <version>2.35.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <scope>test</scope>
@@ -137,6 +131,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>3.12.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMProbeTest.java
@@ -4,7 +4,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.Assert.*;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
@@ -32,10 +31,8 @@ public class GitHubSCMProbeTest {
     public WireMockRule githubApi = factory.getRule(WireMockConfiguration.options()
             .dynamicPort()
             .usingFilesUnderClasspath("cache_failure")
-            .extensions(ResponseTemplateTransformer.builder()
-                    .global(true)
-                    .maxCacheEntries(0L)
-                    .build()));
+            .globalTemplating(true)
+            .withMaxTemplateCacheEntries(0L));
 
     private GitHubSCMProbe probe;
 


### PR DESCRIPTION
## Migrate from `com.github.tomakehurst` to `org.wiremock`

In 2023 [WireMock](https://wiremock.org) updated their `groupId` and `artifactId` with the most recent major release of WireMock 3.
See [the announcement](https://www.wiremock.io/post/wiremock-3-goes-ga) for more details on the topic.

This PR migrates the `groupId` and `artifactId` to the new coordinates and also updates to the latest version.
This change enables receiving further updates on the dependency (e.g. via dependabot or renovate).

### Testing done

None. Rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
