### PR TITLE
Fixed issue while validating the multibranch pipeline configuration 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -2135,9 +2135,9 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
             } catch (IllegalArgumentException e) {
                 return FormValidation.error(e, e.getMessage());
             }
-
+            final String repoOwnerOrDefault = StringUtils.isBlank(repoOwner) ? info.getRepoOwner() : repoOwner;
             StandardCredentials credentials =
-                    Connector.lookupScanCredentials(context, info.getApiUri(), credentialsId, repoOwner);
+                    Connector.lookupScanCredentials(context, info.getApiUri(), credentialsId, repoOwnerOrDefault);
             StringBuilder sb = new StringBuilder();
             try {
                 GitHub github = Connector.connect(info.getApiUri(), credentials);


### PR DESCRIPTION
# Description

This is a follow up PR for [JENKINS-73474](https://issues.jenkins.io/browse/JENKINS-73474) where I'm fixing the issue while validating configuration when owner is set to empty.

## Issue:
On click of validate, it iterates through all the `GHAppInstallation` & check for valid repo `owner` match but since its empty hence no match founds & throws an error.
https://github.com/jenkinsci/github-branch-source-plugin/blob/fa7d4120f9c2f7b600fe3f3f8e477b7587a42e0b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java#L230-L244

whereas when user configures the Github app credentials at time also `Test Connections` executes successfully without an error while owner is empty. It executes successfully because it reads the owner name from `GHAppInstallation`.

https://github.com/jenkinsci/github-branch-source-plugin/blob/fa7d4120f9c2f7b600fe3f3f8e477b7587a42e0b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java#L708-L720

## Fix
Reading the repo owner name from the path & then verifying the connection. If its valid url then its executes successfully else it throws an error.

# Manual Tests

**Prerequisites:**
New Item -> Multibranch pipeline -> Branch Source -> Add Github -> In Github section ->
 Add new credentials where kind 'Github App' -> Add the appid & pem key -> In Advanced section keep owner as blank
 
- `vwagh-org1` has the repo named as `multibranch-p1`
- `vwagh-org2` ***not installed*** the github auth yet

## Case1: Invalid repo path
In Multibranch pipeline -> select the github credentials -> put the repository HTTPS url 
i.e. https://github.com/vwagh-org2/multibranch-p1 -> Validate -> Angry jenkins 

```
2025-05-29 09:10:52.599+0000 [id=128]	WARNING	h.i.i.InstallUncaughtExceptionHandler#handleException: Caught unhandled exception with ID a9c246e9-f79b-4dcc-bf3d-fe78c5f9054f
java.lang.IllegalArgumentException: Owner mismatch: vwagh-org1 vs. vwagh-org2
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.withOwner(GitHubAppCredentials.java:342)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.Connector.lookupScanCredentials(Connector.java:311)

```

## Case2: Valid repo path
Configure the repo url to https://github.com/vwagh-org1/multibranch-p1 -> Validate successfully.

## Case3: Configure the wrong owner (i.e. org name) + test connection
Update credentials -> Advanced -> set owner to 'vwagh-org2' -> Test Connection -> Error

because vwagh-org2 don't have install the github auth yet

```
java.lang.IllegalArgumentException: Found multiple installations for GitHub app ID 1333318 but none match credential owner "vwagh-org2". Set the right owner in the credential advanced options to one of: vwagh-org1, vwagh-dev
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.generateAppInstallationToken(GitHubAppCredentials.java:243)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.getToken(GitHubAppCredentials.java:294)
```

## Case4: Install git auth + test connection
Next install the github auth on `vwagh-org2` -> Test Connection -> Its successful.


## Case5: Configured wrong org + but valid repo path
Configure the wrong owner name i.e. `vwagh-org2` -> Goto multibranch pipeline -> Configure -> put correct repo url
https://github.com/vwagh-org1/multibranch-p1 -> Angry Jenkins

Error logs
```
2025-05-29 07:16:48.889+0000 [id=38]	WARNING	h.i.i.InstallUncaughtExceptionHandler#handleException: Caught unhandled exception with ID 7e581786-f584-4218-88a4-de2772dfac52
java.lang.IllegalArgumentException: Owner mismatch: vwagh-org2 vs. vwagh-org1
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.withOwner(GitHubAppCredentials.java:342)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.Connector.lookupScanCredentials(Connector.java:311)
```	
	
## Case6: Configured valid org + valid repo path + Scan the repo
Configure the wrong owner name i.e. vwagh-org1 -> Goto multibranch pipeline -> Configure -> put correct repo url
`https://github.com/vwagh-org1/multibranch-p1` -> Validates successfully

Next scan the repo -> pipeline for main branch run successfully

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

