### PR TITLE
Use symbol for scm navigator

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1757,7 +1757,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
         /** {@inheritDoc} */
         @Override
         public String getIconClassName() {
-            return "icon-github-scm-navigator";
+            return "symbol-logo-github plugin-ionicons-api";
         }
 
         /** {@inheritDoc} */


### PR DESCRIPTION
# Description

The symbol ensures that command palette will show the symbol and not fall back to a default icon.

Before:
![image](https://github.com/user-attachments/assets/650c9f2b-e377-42e3-8909-e6930cd7280c)

After:
![image](https://github.com/user-attachments/assets/25a1b71a-9424-496e-b948-d70c4adc341a)


<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [x] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

