### PR TITLE
Fix JENKINS-75500: Report build status to GitHub merge queue

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java
@@ -47,6 +47,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.AbstractGitSCMSource.SCMRevisionImpl;
+import hudson.plugins.git.util.BuildData;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMRevision;
@@ -79,6 +80,20 @@ public class GitHubBuildStatusNotification {
                     if (repo != null) {
                         Result result = build.getResult();
                         String revisionToNotify = resolveHeadCommit(revision);
+                        
+                        // Check if we're in a merge queue context by looking at the actual built commit
+                        BuildData buildData = build.getAction(BuildData.class);
+                        if (buildData != null && buildData.getLastBuiltRevision() != null) {
+                            String builtCommit = buildData.getLastBuiltRevision().getSha1String();
+                            // If the built commit differs from what we'd normally report, and we're building a PR,
+                            // this might be a merge queue build
+                            if (builtCommit != null && !builtCommit.equals(revisionToNotify) && revision instanceof PullRequestSCMRevision) {
+                                LOGGER.log(Level.FINE, "Detected possible merge queue build. Using actual built commit {0} instead of PR head {1}", 
+                                    new Object[]{builtCommit, revisionToNotify});
+                                revisionToNotify = builtCommit;
+                            }
+                        }
+                        
                         SCMHead head = revision.getHead();
                         List<AbstractGitHubNotificationStrategy> strategies = new GitHubSCMSourceContext(
                                         null, SCMHeadObserver.none())


### PR DESCRIPTION
When GitHub merge queue is enabled, it creates temporary branches with different commit SHAs than the PR head. This change detects when the actual built commit differs from the PR head and reports status to the correct SHA, allowing merge queue to complete successfully.

- Check BuildData for actual built commit
- Compare with PR head commit
- Use actual commit SHA for status reporting in merge queue context

[JENKINS-75500](https://issues.jenkins.io/browse/JENKINS-75500) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

