### PR TITLE
Use proper URI for ssh resolved repositories

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/SshRepositoryUriResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/SshRepositoryUriResolver.java
@@ -30,6 +30,6 @@ public class SshRepositoryUriResolver extends RepositoryUriResolver {
     /** {@inheritDoc} */
     @Override
     public String getRepositoryUri(String apiUri, String owner, String repository) {
-        return "git@" + hostnameFromApiUri(apiUri) + ":" + owner + "/" + repository + ".git";
+        return "ssh://git@" + hostnameFromApiUri(apiUri) + ":" + owner + "/" + repository + ".git";
     }
 }


### PR DESCRIPTION
To remove the following warning: 

WARNING c.c.j.p.d.scmurl.ScmInfoResolver#scmUri: SCM URL (provider git) is not a valid URI and will be ignored: git@host:org/repo.git.git

# Description

A brief summary describing the changes in this pull request. See 
[JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

