### PR TITLE
[JENKINS-75058] Fix `MigrationAdminMonitor` dismiss link

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/github_branch_source/app_credentials/MigrationAdminMonitor/message.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github_branch_source/app_credentials/MigrationAdminMonitor/message.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
     <div class="alert alert-warning">
-        <form id="${it.id}" method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
+        <form method="post" action="${rootURL}/${it.url}/disable">
             <f:submit name="clear" value="${%Dismiss}"/>
         </form>
         ${%blurb}


### PR DESCRIPTION
# Description

Follow-up for https://github.com/jenkinsci/github-branch-source-plugin/pull/822

The new [`MigrationAdminMonitor`](https://github.com/jenkinsci/github-branch-source-plugin/blob/ff8e48e08e60041c219240f5b7b7c03a8401c572/src/main/java/org/jenkinsci/plugins/github_branch_source/app_credentials/MigrationAdminMonitor.java) dismiss link was broken.

This fixes the redirection link:


https://github.com/user-attachments/assets/6bc97960-eab3-4c10-83af-1694600d278b


See 
[JENKINS-75058](https://issues.jenkins-ci.org/browse/JENKINS-75058) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

