### PR TITLE
[BEE-62243] Use `AccessSpecifiedRepositories` as default access strategy for GitHub App credentials

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsJCasCCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentialsJCasCCompatibilityTest.java
@@ -51,7 +51,8 @@ public class GitHubAppCredentialsJCasCCompatibilityTest {
         List<Credentials> credentials = domainCredentials.get(0).getCredentials();
         assertThat(credentials.size(), is(7));
 
-        assertGitHubAppCredential(credentials.get(0), "github-app", "GitHub app 1111");
+        assertGitHubAppCredential(
+                credentials.get(0), "github-app", "GitHub app 1111", new AccessSpecifiedRepositories(null, List.of()));
         assertGitHubAppCredential(
                 credentials.get(1), "old-owner", "", new AccessSpecifiedRepositories("test", List.of()));
         assertGitHubAppCredential(
@@ -104,10 +105,6 @@ public class GitHubAppCredentialsJCasCCompatibilityTest {
         Mapping configNode = Objects.requireNonNull(root.describe(root.getTargetComponent(context), context))
                 .asMapping();
         return configNode;
-    }
-
-    private static void assertGitHubAppCredential(Credentials credentials, String id, String description) {
-        assertGitHubAppCredential(credentials, id, description, new AccessInferredOwner());
     }
 
     private static void assertGitHubAppCredential(

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/app_credentials/MigrationAdminMonitorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/app_credentials/MigrationAdminMonitorTest.java
@@ -41,16 +41,19 @@ public class MigrationAdminMonitorTest {
                 CredentialsProvider.lookupCredentialsInItemGroup(GitHubAppCredentials.class, r.jenkins, ACL.SYSTEM2),
                 CredentialsMatchers.withId("old-credentials-with-owner"));
         assertThat(credentialsWithOwner.getOwner(), nullValue());
-        var strategy = (AccessSpecifiedRepositories) credentialsWithOwner.getRepositoryAccessStrategy();
-        assertThat(strategy.getOwner(), is("cloudBeers"));
-        assertThat(strategy.getRepositories(), empty());
+        var strategyWithOwner = (AccessSpecifiedRepositories) credentialsWithOwner.getRepositoryAccessStrategy();
+        assertThat(strategyWithOwner.getOwner(), is("cloudBeers"));
+        assertThat(strategyWithOwner.getRepositories(), empty());
         assertThat(credentialsWithOwner.getDefaultPermissionsStrategy(), is(DefaultPermissionsStrategy.INHERIT_ALL));
 
         var credentialsNoOwner = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentialsInItemGroup(GitHubAppCredentials.class, r.jenkins, ACL.SYSTEM2),
                 CredentialsMatchers.withId("old-credentials-no-owner"));
         assertThat(credentialsNoOwner.getOwner(), nullValue());
-        assertThat(credentialsNoOwner.getRepositoryAccessStrategy(), instanceOf(AccessInferredOwner.class));
+        assertThat(credentialsNoOwner.getRepositoryAccessStrategy(), instanceOf(AccessSpecifiedRepositories.class));
+        var strategyWithNoOwner = (AccessSpecifiedRepositories) credentialsNoOwner.getRepositoryAccessStrategy();
+        assertThat(strategyWithNoOwner.getOwner(), nullValue());
+        assertThat(strategyWithNoOwner.getRepositories(), empty());
         assertThat(credentialsNoOwner.getDefaultPermissionsStrategy(), is(DefaultPermissionsStrategy.INHERIT_ALL));
 
         var monitor = ExtensionList.lookupSingleton(MigrationAdminMonitor.class);

--- a/src/test/resources/org/jenkinsci/plugins/github_branch_source/github-app-jcasc-minimal-expected-export.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/github_branch_source/github-app-jcasc-minimal-expected-export.yaml
@@ -6,7 +6,6 @@ system:
         description: "GitHub app 1111"
         id: "github-app"
         privateKey: "some-secret-value"
-        repositoryAccessStrategy: "inferOwner"
     - gitHubApp:
         appID: "1111"
         id: "old-owner"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/github-branch-source-plugin/pull/822 introduced new options to dynamically restricts access to the repositories. This comes with [backward compatibility](https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc#backwards-compatibility) limitations.

This aims to improve backwards compatibility by using `AccessSpecifiedRepositories` as default access strategy instead of `AccessInferredOwner`.

The existing credentials  is migrated to `AccessSpecifiedRepositories`:
* the owner is set with the original credentials owner
* the list of repository is set with empty list

In case of  empty `owner` and when the credentials are used in a context where inference is supported, the inferred owner is used to compute permissions.

See [JENKINS-76056](https://issues.jenkins-ci.org/browse/JENKINS-76056) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

