### PR TITLE
bugfix: regression in default permissions strategy initialization in GitHubAppCredentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -21,6 +21,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
@@ -596,12 +597,15 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
         }
     }
 
-    private Object readResolve() {
+    @Serial
+    Object readResolve() {
         cachedCredentials = new ConcurrentHashMap<>();
-        if (repositoryAccessStrategy == null || defaultPermissionsStrategy == null) {
+        if (repositoryAccessStrategy == null) {
             setRepositoryAccessStrategy(new AccessSpecifiedRepositories(owner, List.of()));
-            setDefaultPermissionsStrategy(DefaultPermissionsStrategy.INHERIT_ALL);
             MigrationAdminMonitor.addMigratedCredentialId(getId());
+        }
+        if (defaultPermissionsStrategy == null) {
+            setDefaultPermissionsStrategy(DefaultPermissionsStrategy.INHERIT_ALL);
         }
         owner = null;
         context = new GitHubAppUsageContext();


### PR DESCRIPTION
# Description
Fixes regression in `GitHubAppCredentials.readResolve()` when CasC doesn't specify default permissions.
See [JENKINS-76072](https://issues.jenkins-ci.org/browse/JENKINS-76072) for further information. 

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

