### PR TITLE
Fix Casc test upgrading after upgrading to CasC 1995.v540b_50a_eb_0c1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,14 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
+      <!-- TODO: remove when included in jenkins-bom via parent -->
       <version>1995.v540b_50a_eb_0c1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
+      <!-- TODO: remove when included in jenkins-bom via parent -->
       <version>1995.v540b_50a_eb_0c1</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.26</version>
+    <version>5.24</version>
     <relativePath />
   </parent>
 
@@ -44,7 +44,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4948.vcf1d17350668</version>
+        <version>5294.va_d2e144c80e1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.19</version>
+    <version>5.26</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,11 +91,13 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
+      <version>1995.v540b_50a_eb_0c1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
+      <version>1995.v540b_50a_eb_0c1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/resources/org/jenkinsci/plugins/github_branch_source/github-app-jcasc-minimal-expected-export.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/github_branch_source/github-app-jcasc-minimal-expected-export.yaml
@@ -1,3 +1,7 @@
+folder: {
+  }
+providerImpl: {
+  }
 system:
   domainCredentials:
   - credentials:
@@ -6,6 +10,9 @@ system:
         description: "GitHub app 1111"
         id: "github-app"
         privateKey: "some-secret-value"
+        repositoryAccessStrategy:
+          specificRepositories: {
+            }
     - gitHubApp:
         appID: "1111"
         id: "old-owner"
@@ -17,6 +24,9 @@ system:
         appID: "1111"
         id: "new-specific-empty"
         privateKey: "some-secret-value"
+        repositoryAccessStrategy:
+          specificRepositories: {
+            }
     - gitHubApp:
         appID: "1111"
         id: "new-specific-owner"
@@ -46,3 +56,7 @@ system:
         id: "new-infer-repo"
         privateKey: "some-secret-value"
         repositoryAccessStrategy: "inferRepository"
+    domain: {
+      }
+user: {
+  }


### PR DESCRIPTION
# Description

After the changes implemented on https://github.com/jenkinsci/configuration-as-code-plugin/pull/2712, there are some failing CasC test on the plugin:

com.cloudbees.jenkins.plugins.platform.CasCTest#smokeExport

The idea behind this PR is to upgrade the CasC plugin dependencies to 1995.v540b_50a_eb_0c1 and fix the failing tests.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

