### PR TITLE
Prevent testProviderRefresh test failures due to log ordering differences

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
@@ -287,27 +287,58 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
 
             List<String> credentialsLog = getOutputLines();
 
+            // Assert that individual messages occur at least once in the credentials log
+            String generatingMsg = "Generating App Installation Token for app ID 54321";
+            String failedMsg =
+                    "Failed to generate new GitHub App Installation Token for app ID 54321: cached token is stale but has not expired";
+
+            // Be sure the expected messages are in the log
+            assertThat(credentialsLog, hasItem(generatingMsg));
+            assertThat(credentialsLog, hasItem(failedMsg));
+
             // Verify correct messages from GitHubAppCredential logger indicating token was retrieved on
             // agent
-            assertThat(
-                    "Creds should cache on master",
-                    credentialsLog,
-                    contains(
-                            // refresh on controller
-                            "Generating App Installation Token for app ID 54321",
-                            // next call uses cached token
-                            // sleep and then refresh stale token
-                            "Generating App Installation Token for app ID 54321",
-                            // next call (error forced by wiremock)
-                            "Failed to generate new GitHub App Installation Token for app ID 54321: cached token is stale but has not expired",
-                            // next call refreshes the still stale token
-                            "Generating App Installation Token for app ID 54321",
-                            // sleep and then refresh stale token hits another error forced by wiremock
-                            "Failed to generate new GitHub App Installation Token for app ID 54321: cached token is stale but has not expired",
-                            // next call refreshes the still stale token
-                            "Generating App Installation Token for app ID 54321"
-                            // next call uses cached token
-                            ));
+            if (credentialsLog.get(2).equals(failedMsg)) {
+                assertThat(
+                        "Creds should cache on master - typical order",
+                        credentialsLog,
+                        contains(
+                                // refresh on controller
+                                generatingMsg,
+                                // next call uses cached token
+                                // sleep and then refresh stale token
+                                generatingMsg,
+                                // next call (error forced by wiremock)
+                                failedMsg,
+                                // next call refreshes the still stale token
+                                generatingMsg,
+                                // sleep and then refresh stale token hits another error forced by wiremock
+                                failedMsg,
+                                // next call refreshes the still stale token
+                                generatingMsg
+                                // next call uses cached token
+                                ));
+            } else {
+                assertThat(
+                        "Creds should cache on master - alternate order",
+                        credentialsLog,
+                        contains(
+                                // refresh on controller
+                                generatingMsg,
+                                // next call uses cached token
+                                // sleep and then refresh stale token
+                                generatingMsg,
+                                // next call refreshes the still stale token
+                                generatingMsg,
+                                // next call (error forced by wiremock)
+                                failedMsg,
+                                // sleep and then refresh stale token hits another error forced by wiremock
+                                failedMsg,
+                                // next call refreshes the still stale token
+                                generatingMsg
+                                // next call uses cached token
+                                ));
+            }
 
             // Getting the token for via AuthorizationProvider on controller should not check rate_limit
             githubApi.verify(


### PR DESCRIPTION
# Prevent testProviderRefresh test failures due to log ordering differences

Accept either the typical ordering of log messages or an alternate ordering of log messages in testProviderRefresh.  The same messages are used in each case, but the sequence of messages changes.

Accepting either ordering assures that we won't have plugin BOM failures due to timing differences or other differences in test infrastructure.

Change prompted by test failures in:

* https://github.com/jenkinsci/bom/pull/5718
* https://github.com/jenkinsci/bom/pull/5720

Discussion started when https://github.com/jenkinsci/bom/pull/5718#issuecomment-3324993588 detected a failure in this test when run within the plugin bill of materials.

Discussion continued when https://github.com/jenkinsci/bom/pull/5720#issuecomment-3328261892 tested more deeply and found that it failed more than 5% of my test runs locally.

Additional local testing confirmed that the order of the log messages was sometimes slightly different than the original assertion expected. This change accepts either ordering.

## Testing done

* Before this change, the test would fail 5% of the time on in the 60+ tests I ran on my AMD Ryzen 5 5600X 6-Core Processor on Red Hat Enterprise Linux 8 when run with
  `mvn -Dtest=GithubAppCredentialsTest#testProviderRefresh test`

* After this change, the test passes 100% of the time in the 36 test runs that I ran

No documentation changes are needed.  This is only a change in a test.

May be easier to review with [whitespace ignored](https://github.com/jenkinsci/github-branch-source-plugin/pull/897/files?w=1).

# Submitter checklist
- ~Link to JIRA ticket in description, if appropriate.~
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- ~Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.~

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

* @jtnord (most recent editor of the test)
* @bitwiseman (original author of the test)
* @Dohbedoh (participant in okhttp API pull request)
