### PR TITLE
[JENKINS-76235] Fix 500 error when saving organization folder with credentials using an invalid owner

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -1696,7 +1696,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
             } finally {
                 Connector.release(hub);
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             DescriptorImpl.LOGGER.log(Level.WARNING, e.getMessage(), e);
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigatorTest.java
@@ -25,9 +25,13 @@
 
 package org.jenkinsci.plugins.github_branch_source;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -67,6 +71,7 @@ import jenkins.scm.impl.NoOpProjectObserver;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.MockFolder;
 import org.mockito.Mock;
@@ -574,6 +579,30 @@ public class GitHubSCMNavigatorTest extends AbstractGitHubWireMockTest {
             r.jenkins.setAuthorizationStrategy(strategy);
             r.jenkins.remove(dummy);
         }
+    }
+
+    @Issue("JENKINS-76235")
+    @Test
+    public void afterSaveWithGitHubAppOwnerMismatch() {
+        // Given GitHub App credentials
+        githubApi.stubFor(get(urlEqualTo("/app"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":54321,\"name\":\"test-app\"}")));
+        githubApi.stubFor(get(urlEqualTo("/app/installations"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\"id\":654321,\"account\":{\"login\":\"corp\"},\"app_id\":54321}]")));
+        GitHubAppCredentials appCredentials = GitHubApp.createCredentials("test-app-creds");
+        appCredentials.setApiUri(githubApi.baseUrl());
+        // And using a owner that doesn't have the application installed
+        appCredentials.setOwner("org-or-user-without-app");
+        setCredentials(Collections.singletonList(appCredentials));
+
+        // When creating a SCMNavigator and calling afterSave
+        navigator = navigatorForRepoOwner("corp", appCredentials.getId());
+        assertDoesNotThrow(() -> navigator.afterSave(Mockito.mock(SCMNavigatorOwner.class)));
+        // Then no exception
     }
 
     private SCMSourceObserver getObserver(Collection<String> names) {


### PR DESCRIPTION
See [JENKINS-76235](https://issues.jenkins.io/browse/JENKINS-76235) for reproduction steps and screen-cast.

When saving an organization folder, the system automatically checks the connection for registered webhooks.
This check fails gracefully with an `IOException`, but it may also throw an `IllegalArgumentException` if the issue is related to the connection’s owner.

This PR catches all possible exceptions, making the `afterSave` process a best-effort operation.

Original exception, app is installed in `test-corp`, but Owner in 'Specify specific repositories' is `owner-creds`:
```
java.lang.IllegalArgumentException: Found multiple installations for GitHub app ID XXXX but none match credential owner "owner-creds". Configure the repository access strategy for the credential to use one of these owners: test-corp
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.generateAppInstallationToken(GitHubAppCredentials.java:321)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.getToken(GitHubAppCredentials.java:393)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials$CredentialsTokenProvider.getEncodedAuthorization(GitHubAppCredentials.java:265)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.prepareConnectorRequest(GitHubClient.java:616)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:455)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.fetch(GitHubClient.java:159)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.checkApiUrlValidity(GitHubClient.java:390)
	at PluginClassLoader for github-api//org.kohsuke.github.GitHub.checkApiUrlValidity(GitHub.java:1310)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.ApiRateLimitChecker.verifyConnection(ApiRateLimitChecker.java:192)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.Connector$GitHubConnection.verifyConnection(Connector.java:738)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.Connector.connect(Connector.java:435)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator.afterSave(GitHubSCMNavigator.java:1693)
```

:speaking_head:  While working on the fix, I noticed another issue ([JENKINS-76236](https://issues.jenkins.io/browse/JENKINS-76236)), but I do not currently plan to address it myself.



# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

