### PR TITLE
[JENKINS-76302] Make GH org avatars work with CSP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <jenkins.baseline>2.528</jenkins.baseline>
     <jenkins.version>2.539</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
+    <useBeta>true</useBeta>
   </properties>
 
   <dependencyManagement>
@@ -87,12 +88,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>access-modifier-suppressions</artifactId>
-      <version>${access-modifier-checker.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubOrgMetadataAction.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubOrgMetadataAction.java
@@ -34,7 +34,6 @@ import java.util.Objects;
 import jenkins.scm.api.metadata.AvatarMetadataAction;
 import jenkins.security.csp.AvatarContributor;
 import org.apache.commons.lang3.StringUtils;
-import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.stapler.Stapler;
 
@@ -44,7 +43,6 @@ import org.kohsuke.stapler.Stapler;
  *
  * @author Kohsuke Kawaguchi
  */
-@SuppressRestrictedWarnings(AvatarContributor.class)
 public class GitHubOrgMetadataAction extends AvatarMetadataAction {
     @CheckForNull
     private final String avatar;


### PR DESCRIPTION
# Description

This ensures GitHub org avatar images (the "folder icon") work in forthcoming Jenkins core releases when CSP protection is enforced.

See [JENKINS-76302](https://issues.jenkins-ci.org/browse/JENKINS-76302) for further information.

To manually test, create a GH organization folder and the icon needs to work while CSP is enforced (see core PR).

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

