### PR TITLE
Possible flake fix

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/ForkPullRequestDiscoveryTrait2Test.java
@@ -83,5 +83,6 @@ public class ForkPullRequestDiscoveryTrait2Test {
         assertEquals(
                 trust.getClass(),
                 ((ForkPullRequestDiscoveryTrait) traits.get(0)).getTrust().getClass());
+        r.waitUntilNoActivity();
     }
 }


### PR DESCRIPTION
[This flake](https://github.com/jenkinsci/github-branch-source-plugin/pull/1504/checks?check_run_id=68119284762) from #1504 seems to be a test problem

```
Z:\agent\workspace\hub-branch-source-plugin_PR-1504\target\tmp\j h6248222677314807097\jobs\test0\indexing\indexing.log: The process cannot access the file because it is being used by another process
```

```
  64.126 [id=28]	WARNING	o.j.h.t.RemainingActivityListener#onTearDown: BranchIndexing[test0] still seems to be running, which could break deletion of log files or metadata
```

The patch addresses the warning at least, so may fix the flake as well.
