### PR TITLE
Fix GitHub App token expiry on Windows static agents

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -115,7 +115,6 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
      * The string parameter is the credential key (e.g. {@code git:https://github.com}).
      * Non-final to allow replacement in tests.
      */
-    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Non-final for testing purposes")
     @Restricted(NoExternalUse.class)
     static Consumer<String> windowsCredentialCleaner = key -> {
         try {

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -107,9 +107,8 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
      * Non-final so it can be adjusted from the Jenkins script console if needed.
      */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Non-final for script console override")
-    public static boolean CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE = Boolean.parseBoolean(
-            System.getProperty(
-                    GitHubAppCredentials.class.getName() + ".CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE", "true"));
+    public static boolean CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE = Boolean.parseBoolean(System.getProperty(
+            GitHubAppCredentials.class.getName() + ".CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE", "true"));
 
     /**
      * Replaceable executor for Windows Credential Manager key deletion.
@@ -120,17 +119,17 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
     @Restricted(NoExternalUse.class)
     static Consumer<String> windowsCredentialCleaner = key -> {
         try {
-            Process process =
-                    new ProcessBuilder("cmdkey", "/delete:" + key).redirectErrorStream(true).start();
+            Process process = new ProcessBuilder("cmdkey", "/delete:" + key)
+                    .redirectErrorStream(true)
+                    .start();
             boolean finished = process.waitFor(5, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
                 LOGGER.log(Level.WARNING, "Timed out clearing Windows Credential Manager entry: {0}", key);
             } else {
-                LOGGER.log(
-                        Level.FINE,
-                        "Cleared Windows Credential Manager entry: {0} (exit: {1})",
-                        new Object[] {key, process.exitValue()});
+                LOGGER.log(Level.FINE, "Cleared Windows Credential Manager entry: {0} (exit: {1})", new Object[] {
+                    key, process.exitValue()
+                });
             }
         } catch (IOException | InterruptedException e) {
             LOGGER.log(Level.WARNING, "Failed to clear Windows Credential Manager entry: " + key, e);

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -23,6 +23,7 @@ import hudson.util.Secret;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
+import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
 import java.time.Instant;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -94,6 +96,46 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Non-final for modification from script console")
     public static boolean ALLOW_UNSAFE_REPOSITORY_INFERENCE =
             Boolean.getBoolean(GitHubAppCredentials.class.getName() + ".ALLOW_UNSAFE_REPOSITORY_INFERENCE");
+
+    /**
+     * On Windows agents, clears the Windows Credential Manager cache entry for the GitHub host
+     * before each Git credential use. This prevents Git from serving an expired GitHub App
+     * installation token that was cached by a previous build, and ensures Git falls through to
+     * {@code GIT_ASKPASS} to receive the fresh token Jenkins is about to provide.
+     *
+     * <p>Disable only if the {@code cmdkey} invocations cause problems in your environment.
+     * Non-final so it can be adjusted from the Jenkins script console if needed.
+     */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Non-final for script console override")
+    public static boolean CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE = Boolean.parseBoolean(
+            System.getProperty(
+                    GitHubAppCredentials.class.getName() + ".CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE", "true"));
+
+    /**
+     * Replaceable executor for Windows Credential Manager key deletion.
+     * The string parameter is the credential key (e.g. {@code git:https://github.com}).
+     * Non-final to allow replacement in tests.
+     */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Non-final for testing purposes")
+    @Restricted(NoExternalUse.class)
+    static Consumer<String> windowsCredentialCleaner = key -> {
+        try {
+            Process process =
+                    new ProcessBuilder("cmdkey", "/delete:" + key).redirectErrorStream(true).start();
+            boolean finished = process.waitFor(5, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                LOGGER.log(Level.WARNING, "Timed out clearing Windows Credential Manager entry: {0}", key);
+            } else {
+                LOGGER.log(
+                        Level.FINE,
+                        "Cleared Windows Credential Manager entry: {0} (exit: {1})",
+                        new Object[] {key, process.exitValue()});
+            }
+        } catch (IOException | InterruptedException e) {
+            LOGGER.log(Level.WARNING, "Failed to clear Windows Credential Manager entry: " + key, e);
+        }
+    };
 
     @NonNull
     private final String appID;
@@ -613,6 +655,45 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
     }
 
     /**
+     * Derives the Git repository host from a GitHub API URI.
+     *
+     * <p>Returns {@code github.com} for the standard endpoint ({@code https://api.github.com}), or
+     * the host component of the URI for GitHub Enterprise Server instances.
+     *
+     * @param apiUri the GitHub API URI (e.g. {@code https://api.github.com})
+     * @return the corresponding Git repository host (e.g. {@code github.com})
+     */
+    static String deriveGitHostFromApiUri(String apiUri) {
+        try {
+            String host = new URI(apiUri).getHost();
+            if (host == null) {
+                return "github.com";
+            }
+            return "api.github.com".equals(host) ? "github.com" : host;
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "Could not parse API URI to derive git host: " + apiUri, e);
+            return "github.com";
+        }
+    }
+
+    /**
+     * Clears cached GitHub credentials from the Windows Credential Manager for the host
+     * corresponding to {@code apiUri}.
+     *
+     * <p>Removes both the modern ({@code git:https://host}) and legacy
+     * ({@code LegacyGenericCredential:https://host}) key formats used by the Windows git credential
+     * helpers, so that Git falls through to {@code GIT_ASKPASS} and uses the fresh token Jenkins is
+     * about to provide.
+     *
+     * @param apiUri the GitHub API URI used to derive the Git repository host
+     */
+    static void clearWindowsCredentialManagerCache(String apiUri) {
+        String httpsUrl = "https://" + deriveGitHostFromApiUri(apiUri);
+        windowsCredentialCleaner.accept("git:" + httpsUrl);
+        windowsCredentialCleaner.accept("LegacyGenericCredential:" + httpsUrl);
+    }
+
+    /**
      * Ensures that the credentials state as serialized via Remoting to an agent calls back to the
      * controller. Benefits:
      *
@@ -636,6 +717,8 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
             implements StandardUsernamePasswordCredentials {
 
         private final String appID;
+        /** The GitHub API URI, used to derive the git host for Windows Credential Manager clearing. */
+        private final String apiUri;
         /**
          * An encrypted form of all data needed to refresh the token. Used to prevent {@link GetToken}
          * from being abused by compromised build agents.
@@ -650,6 +733,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
             super(onMaster.getScope(), onMaster.getId(), onMaster.getDescription());
             JenkinsJVM.checkJenkinsJVM();
             appID = onMaster.getAppID();
+            apiUri = onMaster.actualApiUri();
             JSONObject j = new JSONObject();
             j.put("appID", appID);
             j.put("privateKey", onMaster.getPrivateKey().getPlainText());
@@ -706,6 +790,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
         public Secret getPassword() {
             JenkinsJVM.checkNotJenkinsJVM();
             try {
+                final Secret token;
                 synchronized (this) {
                     try {
                         if (cachedToken == null || cachedToken.isStale()) {
@@ -741,10 +826,22 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
                         }
                     }
                     LOGGER.log(Level.FINEST, "Returned GitHub App Installation Token for app ID {0} on agent", appID);
-
-                    return cachedToken.getToken();
+                    token = cachedToken.getToken();
                 }
 
+                // On Windows agents, evict the cached credential from Windows Credential Manager
+                // so that Git does not serve the previously-cached (possibly expired) token to the
+                // next Git operation instead of calling GIT_ASKPASS for the fresh token we just
+                // obtained above.  This is the Windows equivalent of the token-refresh fix on
+                // Linux; see also CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE.
+                if (CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE
+                        && System.getProperty("os.name", "")
+                                .toLowerCase(Locale.ROOT)
+                                .startsWith("windows")) {
+                    clearWindowsCredentialManagerCache(apiUri);
+                }
+
+                return token;
             } catch (IOException | InterruptedException x) {
                 throw new RuntimeException(x);
             }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
@@ -516,11 +516,12 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
             result.addAll(agentLogs);
         }
 
-        // sort the logs into chronological order
-        // then just format the message.
+        // sort the logs into chronological order, then just format the message.
+        // Agent JVM has its own static field copy (defaults true), so filter its wincred messages.
         return result.stream()
                 .sorted(Comparator.comparingLong(LogRecord::getMillis))
                 .map(formatter::formatMessage)
+                .filter(msg -> !msg.startsWith("Cleared Windows Credential Manager"))
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsTest.java
@@ -353,12 +353,18 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
     @Test
     public void testAgentRefresh() throws Exception {
         final long notStaleSeconds = GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS;
+        final boolean originalClearWindowsCache = GitHubAppCredentials.CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE;
         try {
             appCredentials.setApiUri(githubApi.baseUrl());
 
             // We want to demonstrate successful caching without waiting for a the default 1 minute
             // Must set this to a large enough number to avoid flaky test
             GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = 10;
+
+            // Disable Windows Credential Manager cache clearing so its log messages do not
+            // interfere with the strict log-sequence assertions below. The clearing behaviour
+            // is tested separately in GithubAppCredentialsWindowsAgentTest.
+            GitHubAppCredentials.CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE = false;
 
             // Ensure we are working from sufficiently clean cache state
             Thread.sleep(Duration.ofSeconds(GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS + 2)
@@ -463,6 +469,7 @@ public class GithubAppCredentialsTest extends AbstractGitHubWireMockTest {
                     0, RequestPatternBuilder.newRequestPattern(RequestMethod.GET, urlPathEqualTo("/rate_limit")));
         } finally {
             GitHubAppCredentials.AppInstallationToken.NOT_STALE_MINIMUM_SECONDS = notStaleSeconds;
+            GitHubAppCredentials.CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE = originalClearWindowsCache;
             logRecorder.doClear();
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsWindowsAgentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsWindowsAgentTest.java
@@ -1,0 +1,125 @@
+package org.jenkinsci.plugins.github_branch_source;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for the Windows Credential Manager cache-clearing logic added to
+ * {@link GitHubAppCredentials}.
+ *
+ * <p>These tests exercise the static helper methods
+ * ({@link GitHubAppCredentials#deriveGitHostFromApiUri} and
+ * {@link GitHubAppCredentials#clearWindowsCredentialManagerCache}) and verify that the right
+ * credential keys are evicted. They run on any OS because the {@link
+ * GitHubAppCredentials#windowsCredentialCleaner} field is replaced with a recording stub.
+ */
+public class GithubAppCredentialsWindowsAgentTest {
+
+    private Consumer<String> originalCleaner;
+    private boolean originalClearFlag;
+    private List<String> deletedKeys;
+
+    @Before
+    public void setUp() {
+        originalCleaner = GitHubAppCredentials.windowsCredentialCleaner;
+        originalClearFlag = GitHubAppCredentials.CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE;
+        deletedKeys = new ArrayList<>();
+        GitHubAppCredentials.windowsCredentialCleaner = deletedKeys::add;
+        GitHubAppCredentials.CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE = true;
+    }
+
+    @After
+    public void tearDown() {
+        GitHubAppCredentials.windowsCredentialCleaner = originalCleaner;
+        GitHubAppCredentials.CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE = originalClearFlag;
+    }
+
+    // -------------------------------------------------------------------------
+    // deriveGitHostFromApiUri
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void deriveGitHost_standardGitHub() {
+        assertThat(GitHubAppCredentials.deriveGitHostFromApiUri("https://api.github.com"), is("github.com"));
+    }
+
+    @Test
+    public void deriveGitHost_githubEnterprise() {
+        assertThat(
+                GitHubAppCredentials.deriveGitHostFromApiUri("https://ghe.example.com/api/v3"),
+                is("ghe.example.com"));
+    }
+
+    @Test
+    public void deriveGitHost_enterpriseWithPort() {
+        assertThat(
+                GitHubAppCredentials.deriveGitHostFromApiUri("https://github.corp.example.com:8443/api/v3"),
+                is("github.corp.example.com"));
+    }
+
+    @Test
+    public void deriveGitHost_malformedUri_fallsBackToGithubCom() {
+        assertThat(GitHubAppCredentials.deriveGitHostFromApiUri("not a uri ://???"), is("github.com"));
+    }
+
+    @Test
+    public void deriveGitHost_emptyString_fallsBackToGithubCom() {
+        assertThat(GitHubAppCredentials.deriveGitHostFromApiUri(""), is("github.com"));
+    }
+
+    // -------------------------------------------------------------------------
+    // clearWindowsCredentialManagerCache – key format
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void clearCache_standardGitHub_deletesExpectedKeys() {
+        GitHubAppCredentials.clearWindowsCredentialManagerCache("https://api.github.com");
+
+        assertThat(
+                deletedKeys,
+                contains("git:https://github.com", "LegacyGenericCredential:https://github.com"));
+    }
+
+    @Test
+    public void clearCache_githubEnterprise_deletesExpectedKeys() {
+        GitHubAppCredentials.clearWindowsCredentialManagerCache("https://ghe.example.com/api/v3");
+
+        assertThat(
+                deletedKeys,
+                contains(
+                        "git:https://ghe.example.com",
+                        "LegacyGenericCredential:https://ghe.example.com"));
+    }
+
+    @Test
+    public void clearCache_alwaysDeletesBothKeyFormats() {
+        GitHubAppCredentials.clearWindowsCredentialManagerCache("https://api.github.com");
+
+        assertThat("Both wincred and GCM key formats must be cleared", deletedKeys.size(), is(2));
+    }
+
+    // -------------------------------------------------------------------------
+    // CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE flag
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void clearCache_flagDisabled_doesNotDeleteKeys() {
+        GitHubAppCredentials.CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE = false;
+
+        // Simulate what getPassword() does when the flag is false
+        if (GitHubAppCredentials.CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE) {
+            GitHubAppCredentials.clearWindowsCredentialManagerCache("https://api.github.com");
+        }
+
+        assertThat(deletedKeys, is(empty()));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsWindowsAgentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GithubAppCredentialsWindowsAgentTest.java
@@ -55,8 +55,7 @@ public class GithubAppCredentialsWindowsAgentTest {
     @Test
     public void deriveGitHost_githubEnterprise() {
         assertThat(
-                GitHubAppCredentials.deriveGitHostFromApiUri("https://ghe.example.com/api/v3"),
-                is("ghe.example.com"));
+                GitHubAppCredentials.deriveGitHostFromApiUri("https://ghe.example.com/api/v3"), is("ghe.example.com"));
     }
 
     @Test
@@ -84,9 +83,7 @@ public class GithubAppCredentialsWindowsAgentTest {
     public void clearCache_standardGitHub_deletesExpectedKeys() {
         GitHubAppCredentials.clearWindowsCredentialManagerCache("https://api.github.com");
 
-        assertThat(
-                deletedKeys,
-                contains("git:https://github.com", "LegacyGenericCredential:https://github.com"));
+        assertThat(deletedKeys, contains("git:https://github.com", "LegacyGenericCredential:https://github.com"));
     }
 
     @Test
@@ -95,9 +92,7 @@ public class GithubAppCredentialsWindowsAgentTest {
 
         assertThat(
                 deletedKeys,
-                contains(
-                        "git:https://ghe.example.com",
-                        "LegacyGenericCredential:https://ghe.example.com"));
+                contains("git:https://ghe.example.com", "LegacyGenericCredential:https://ghe.example.com"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #1515

On Windows, git credential helpers (`wincred` / `git-credential-manager`) cache GitHub App installation tokens in **Windows Credential Manager** and serve them directly on subsequent Git operations, bypassing `GIT_ASKPASS` entirely. This causes `Authentication failed` errors every ~1 hour on permanent Windows nodes even though Jenkins correctly generates a fresh token.

**Root cause:** PR #291 fixed token refresh for Linux static agents via `DelegatingGitHubAppCredentials`. On Linux, Git always calls `GIT_ASKPASS` to get credentials. On Windows, Git checks Windows Credential Manager first — if a cached entry exists it never calls `GIT_ASKPASS`, so the expired cached token is used instead of the fresh one Jenkins prepared.

**Observed pattern from the field:**
```
Build 7  ✅ 1:19 PM  (token generated)
Build 14 ❌ 2:34 PM  (~1hr 15min later — token expired in WCM)
Build 15 ✅ 2:35 PM  (immediate retry — fresh token)
Build 16 ❌ 4:12 PM  (~1hr 37min later — token expired again)
Build 17 ✅ 4:12 PM  (immediate retry — fresh token)
```

## Fix

Inside `DelegatingGitHubAppCredentials.getPassword()` (runs on the agent JVM), after obtaining a fresh token, detect Windows via `os.name` and run:

```
cmdkey /delete:git:https://<host>
cmdkey /delete:LegacyGenericCredential:https://<host>
```

This evicts the stale cached entry so Git falls through to `GIT_ASKPASS` and uses the fresh token Jenkins provides. Both the modern (`git:`) and legacy (`LegacyGenericCredential:`) key formats are cleared to cover all Windows Git credential helper variants.

The clearing is:
- **No-op** when WCM has no entry for that host (`cmdkey` exits 1, silently ignored)
- **Skipped entirely** on non-Windows agents (Linux, macOS)
- **Skipped** on ephemeral agents where WCM is empty at startup anyway

## Changes

- **`GitHubAppCredentials.java`**
  - `CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE` — public flag (default `true`), disableable from script console without redeployment
  - `windowsCredentialCleaner` — replaceable `Consumer<String>` so tests never invoke `cmdkey`
  - `deriveGitHostFromApiUri()` — maps `https://api.github.com` → `github.com`; passes GHE host through unchanged
  - `clearWindowsCredentialManagerCache()` — clears both WCM key formats
  - `DelegatingGitHubAppCredentials.apiUri` — stored in plaintext (not sensitive) for host derivation on the agent
  - `DelegatingGitHubAppCredentials.getPassword()` — calls cache clearing after token refresh, outside the `synchronized` block

- **`GithubAppCredentialsWindowsAgentTest.java`** _(new)_
  - Unit tests for `deriveGitHostFromApiUri()` (standard GitHub, GHE, port, malformed URI, empty)
  - Unit tests for `clearWindowsCredentialManagerCache()` key format and flag behaviour
  - Uses a recording stub for `windowsCredentialCleaner` — runs on any OS, never invokes `cmdkey`

## Verification

Tested on GKE Jenkins controller with a permanent Windows agent (Git 2.51.0.windows.2). Agent log after triggering token refresh:

```
Cleared Windows Credential Manager entry: git:https://github.com (exit: 0)
Cleared Windows Credential Manager entry: LegacyGenericCredential:https://github.com (exit: 1)
```

Exit 0 = entry evicted. Exit 1 on `LegacyGenericCredential` = key not present (normal — this Windows agent uses the modern `git:` format only). Both checkouts succeeded after the 60s stale threshold was crossed.

## Backwards compatibility

| Scenario | Behaviour |
|---|---|
| Linux / macOS agents | `os.name` check fails — no `cmdkey` call, zero change |
| Ephemeral Windows agents | WCM is empty at pod startup; `cmdkey /delete` is a no-op (exit 1) |
| GHE instances | `deriveGitHostFromApiUri` extracts GHE host correctly |
| `cmdkey` not on PATH | Exception caught, logged at `WARNING`, build continues |
| Opt-out | Set `GitHubAppCredentials.CLEAR_WINDOWS_CREDENTIAL_MANAGER_CACHE=false` via system property or script console |