### PR TITLE
Support job-dsl native syntax for folder-scoped github app credentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -41,6 +41,7 @@ import jenkins.security.SlaveToMasterCallable;
 import jenkins.util.JenkinsJVM;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.github_branch_source.app_credentials.AccessSpecifiedRepositories;
 import org.jenkinsci.plugins.github_branch_source.app_credentials.AccessibleRepositories;
 import org.jenkinsci.plugins.github_branch_source.app_credentials.DefaultPermissionsStrategy;
@@ -785,6 +786,7 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
     }
 
     /** {@inheritDoc} */
+    @Symbol("gitHubApp")
     @Extension
     public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
 


### PR DESCRIPTION
# Description

These changes allows users to easily define folder-scoped github app credentials via job-dsl plugin. Without it, users would have to use the all-mighty "configure" callback to add those settings by xml modification. Sample job-dsl of what now works:

```groovy
organizationFolder('sample') {
    organizations {
        github {
            repoOwner("jenkinsci")
            credentialsId("<credentials-id>")
        }
    }
    properties {
        folderCredentialsProperty {
            domainCredentials {
                domainCredentials {
                    domain {
                        name('folder.sample')
                        description('Folder-scoped credentials')
                    }
                    credentials {
                        // 👇 THIS HERE IS THE IMPORTANT PART
                        gitHubApp {
                            id('folder-scoped-github-app-credentials')
                            description('GitHub App for accessing repositories')
                            appID("...")
                            privateKey(Secret.fromString("""..."""))
                            repositoryAccessStrategy {
                                specificRepositories {
                                    owner('organisation-name')
                                    repositories(['repo-1', 'repo-2'])
                                }
                            }
                            defaultPermissionsStrategy('CONTENTS_READ')
                            scope('GLOBAL')
                        }
                        // ☝️ THIS HERE IS THE IMPORTANT PART
                    }
                }
            }
        }
    }
}
```

I am not sure if you want a test for this, and if it is even possible. Let me know if it is. I am happy to add one.

<!--
In the lists below, fill in the empty checkboxes [ ] with checks by replacing the space with an x, like [x].
-->
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Automated tests have been added to exercise the changes
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [ ] Link to jenkins.io PR, or an explanation for why no doc changes are needed

# Users/aliases to notify

