### PR TITLE
Make readResolve protected so it runs while deserializing out-of-package subclasses

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials.java
@@ -600,8 +600,11 @@ public class GitHubAppCredentials extends BaseStandardCredentials implements Sta
         }
     }
 
+    // Must be at least protected: XStream skips an inherited package-private readResolve for a subclass
+    // in a different package, leaving transients null on deserialization. See
+    // https://github.com/x-stream/xstream/blob/a0f1637e977e6f682f483873b5877e6fe18247b8/xstream/src/java/com/thoughtworks/xstream/core/util/SerializationMembers.java#L193-L198
     @Serial
-    Object readResolve() {
+    protected Object readResolve() {
         cachedCredentials = new ConcurrentHashMap<>();
         if (repositoryAccessStrategy == null) {
             setRepositoryAccessStrategy(new AccessSpecifiedRepositories(owner, List.of()));


### PR DESCRIPTION
Proposing to make the `readResolve` here `protected` so it resolves in our subclass implementation as pointed in the javadoc. Otherwise when calling `org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials#contextualize` results in NPE in subclasses. We (CloudBees) subclass it in our hashicorp vault plugin (https://docs.cloudbees.com/docs/cloudbees-ci/latest/secure/hashicorp-vault-plugin), where NPE would occur upon restart of Jenkins
```
java.lang.NullPointerException: Cannot invoke "java.util.Map.computeIfAbsent(Object, java.util.function.Function)" because "this.cachedCredentials" is null
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.contextualize(GitHubAppCredentials.java:447)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.Connector.lookupScanCredentials(Connector.java:317)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.getCredentials(GitHubSCMSource.java:386)
	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.retrieveActions(GitHubSCMSource.java:1972)
	at PluginClassLoader for scm-api//jenkins.scm.api.SCMSource.fetchActions(SCMSource.java:843)
	at PluginClassLoader for branch-api//jenkins.branch.MultiBranchProject.computeChildren(MultiBranchProject.java:650)
```