### PR TITLE
Add support for Github stacked pull requests behind opt in system property

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilder.java
@@ -282,11 +282,10 @@ public class GitHubSCMBuilder extends GitSCMBuilder<GitHubSCMBuilder> {
                     }
                 }
                 if (gitHubMergeHash != null) {
-                    // fetch refs/pull/<n>/merge so the merge commit is available to check out below;
-                    // it must use a destination distinct from the pull head ref that the constructor
-                    // already fetches, otherwise git refuses to fetch two sources into one ref
-                    withRefSpec("+refs/pull/" + head.getId() + "/merge:refs/remotes/@{remote}/" + head.getName()
-                            + "-merge");
+                    // fetch the exact merge commit sha rather than refs/pull/<n>/merge, which GitHub live-recomputes
+                    // and may no longer point at the recorded hash we check out below; the destination must be distinct
+                    // from the pullhead ref the constructor fetches, else git refuses two sources into one ref
+                    withRefSpec("+" + gitHubMergeHash + ":refs/remotes/@{remote}/" + head.getName() + "-merge");
                 } else if (head.isMerge()) {
                     // add the target branch to ensure that the revision we want to merge is also available
                     String name = head.getTarget().getName();

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilder.java
@@ -272,7 +272,22 @@ public class GitHubSCMBuilder extends GitSCMBuilder<GitHubSCMBuilder> {
 
             if (h instanceof PullRequestSCMHead) {
                 PullRequestSCMHead head = (PullRequestSCMHead) h;
-                if (head.isMerge()) {
+                // preview: build GitHub's precomputed merge commit directly instead of merging
+                // locally, when enabled and a usable merge hash is available (issue #1545)
+                String gitHubMergeHash = null;
+                if (GitHubSCMSource.preferGitHubMergeCommit && head.isMerge() && r instanceof PullRequestSCMRevision) {
+                    String mergeHash = ((PullRequestSCMRevision) r).getMergeHash();
+                    if (mergeHash != null && !PullRequestSCMRevision.NOT_MERGEABLE_HASH.equals(mergeHash)) {
+                        gitHubMergeHash = mergeHash;
+                    }
+                }
+                if (gitHubMergeHash != null) {
+                    // fetch refs/pull/<n>/merge so the merge commit is available to check out below;
+                    // it must use a destination distinct from the pull head ref that the constructor
+                    // already fetches, otherwise git refuses to fetch two sources into one ref
+                    withRefSpec("+refs/pull/" + head.getId() + "/merge:refs/remotes/@{remote}/" + head.getName()
+                            + "-merge");
+                } else if (head.isMerge()) {
                     // add the target branch to ensure that the revision we want to merge is also available
                     String name = head.getTarget().getName();
                     String localName = "remotes/" + remoteName() + "/" + name;
@@ -324,7 +339,12 @@ public class GitHubSCMBuilder extends GitSCMBuilder<GitHubSCMBuilder> {
                 }
                 if (r instanceof PullRequestSCMRevision) {
                     PullRequestSCMRevision rev = (PullRequestSCMRevision) r;
-                    withRevision(new AbstractGitSCMSource.SCMRevisionImpl(head, rev.getPullHash()));
+                    if (GitHubSCMSource.preferGitHubMergeCommit && gitHubMergeHash != null) {
+                        // check out github's precomputed merge commit itself
+                        withRevision(new AbstractGitSCMSource.SCMRevisionImpl(head, gitHubMergeHash));
+                    } else {
+                        withRevision(new AbstractGitSCMSource.SCMRevisionImpl(head, rev.getPullHash()));
+                    }
                 }
             }
             return super.build();

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -180,6 +180,17 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
     private static /* mostly final */ int mergeableStatusRetries = SystemProperties.getInteger(
             GitHubSCMSource.class.getName() + ".mergeableStatusRetries", Integer.valueOf(4));
 
+    /**
+     * Preview: for merge-strategy PRs, build GitHub's precomputed merge commit ({@code
+     * refs/pull/N/merge}) directly instead of reconstructing the merge locally against the base
+     * branch. Fixes stacked PRs whose base PR is behind the target branch (issue #1545), where the
+     * derived base commit is a synthetic merge ref unreachable from any branch. Opt-in and subject to
+     * change; affects all merge-strategy PRs, not only stacked ones.
+     */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Non-final for modification from script console")
+    static /* mostly final */ boolean preferGitHubMergeCommit =
+            SystemProperties.getBoolean(GitHubSCMSource.class.getName() + ".preferGitHubMergeCommit");
+
     //////////////////////////////////////////////////////////////////////
     // Configuration fields
     //////////////////////////////////////////////////////////////////////

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -187,7 +187,6 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
      * derived base commit is a synthetic merge ref unreachable from any branch. Opt-in and subject to
      * change; affects all merge-strategy PRs, not only stacked ones.
      */
-    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Non-final for modification from script console")
     static /* mostly final */ boolean preferGitHubMergeCommit =
             SystemProperties.getBoolean(GitHubSCMSource.class.getName() + ".preferGitHubMergeCommit");
 

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
@@ -1920,8 +1920,7 @@ public class GitHubSCMBuilderTest {
             // the fetched object consistent with the revision checked out below
             UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
             assertThat(
-                    config.getRefspec(),
-                    containsString("+" + STACKED_MERGE_HASH + ":refs/remotes/origin/PR-2-merge"));
+                    config.getRefspec(), containsString("+" + STACKED_MERGE_HASH + ":refs/remotes/origin/PR-2-merge"));
             // every fetch refspec must target a distinct destination, or git fetch aborts with
             // "Cannot fetch both ... to ..." - the merge ref must not reuse the pull head destination
             RemoteConfig origin = actual.getRepositoryByName("origin");

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
@@ -6,6 +6,7 @@ import static jenkins.plugins.git.AbstractGitSCMSource.SCMRevisionImpl;
 import static jenkins.plugins.git.AbstractGitSCMSource.SpecificRevisionBuildChooser;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -29,9 +30,12 @@ import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.impl.BuildChooserSetting;
 import hudson.util.LogTaskListener;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.plugins.git.AbstractGitSCMSource;
@@ -39,6 +43,7 @@ import jenkins.plugins.git.GitSCMSourceDefaults;
 import jenkins.plugins.git.MergeWithGitSCMExtension;
 import jenkins.scm.api.SCMHeadOrigin;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
+import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
@@ -1875,6 +1880,104 @@ public class GitHubSCMBuilderTest {
         assertThat(merge, notNullValue());
         assertThat(merge.getBaseName(), is("remotes/origin/test-branch"));
         assertThat(merge.getBaseHash(), is("deadbeefcafebabedeadbeefcafebabedeadbeef"));
+    }
+
+    // issue #1545 : SHAs taken from a live stacked-PR reproduction (PR whose base is another open PR's
+    // branch, that base PR being behind the target). baseHash is github's synthetic merge preview of the
+    // base PR, which is unreachable from any real branch; mergeHash is github's precomputed merge commit.
+    private static final String STACKED_BASE_HASH = "4546cf2e229fba1330fb9bc9ecd7555127fe6ef4";
+    private static final String STACKED_PULL_HASH = "263a673b389c5c2f3b6220362aa9c47301b28763";
+    private static final String STACKED_MERGE_HASH = "e3153159a0f16ffdd3f7b691da6ce73852acf34d";
+
+    private static PullRequestSCMHead stackedPullRequestHead() {
+        return new PullRequestSCMHead(
+                "PR-2",
+                "tester",
+                "test-repo",
+                "issue-1545-stacked",
+                2,
+                new BranchSCMHead("issue-1545-base"),
+                SCMHeadOrigin.DEFAULT,
+                ChangeRequestCheckoutStrategy.MERGE);
+    }
+
+    @Test
+    public void given__cloud_stackedPullMerge_rev__when__preferGitHubMergeCommit__then__mergeCommitCheckedOut()
+            throws Exception {
+        createGitHubSCMSourceForTest(false, null);
+        PullRequestSCMHead head = stackedPullRequestHead();
+        PullRequestSCMRevision revision =
+                new PullRequestSCMRevision(head, STACKED_BASE_HASH, STACKED_PULL_HASH, STACKED_MERGE_HASH);
+        source.setCredentialsId(null);
+        boolean original = GitHubSCMSource.preferGitHubMergeCommit;
+        GitHubSCMSource.preferGitHubMergeCommit = true;
+        try {
+            GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
+            instance.withGitHubRemote();
+            GitSCM actual = instance.build();
+            // github's precomputed merge commit is fetched instead of merging locally
+            UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
+            assertThat(config.getRefspec(), containsString("+refs/pull/2/merge:refs/remotes/origin/PR-2-merge"));
+            // every fetch refspec must target a distinct destination, or git fetch aborts with
+            // "Cannot fetch both ... to ..." - the merge ref must not reuse the pull head destination
+            RemoteConfig origin = actual.getRepositoryByName("origin");
+            List<String> destinations = new ArrayList<>();
+            for (RefSpec spec : origin.getFetchRefSpecs()) {
+                destinations.add(spec.getDestination());
+            }
+            assertThat(destinations.size(), is(new HashSet<>(destinations).size()));
+            // no local merge is performed against the unreachable base hash
+            assertThat(getExtension(actual, MergeWithGitSCMExtension.class), nullValue());
+            assertThat(
+                    actual.getExtensions(),
+                    containsInAnyOrder(instanceOf(GitSCMSourceDefaults.class), instanceOf(BuildChooserSetting.class)));
+            // the merge commit itself is the checked-out revision, not the pull head
+            BuildChooserSetting chooser = getExtension(actual, BuildChooserSetting.class);
+            AbstractGitSCMSource.SpecificRevisionBuildChooser revChooser =
+                    (AbstractGitSCMSource.SpecificRevisionBuildChooser) chooser.getBuildChooser();
+            Collection<Revision> revisions = revChooser.getCandidateRevisions(
+                    false,
+                    "issue-1545-base",
+                    Mockito.mock(GitClient.class),
+                    new LogTaskListener(Logger.getAnonymousLogger(), Level.FINEST),
+                    null,
+                    null);
+            assertThat(revisions, hasSize(1));
+            assertThat(revisions.iterator().next().getSha1String(), is(STACKED_MERGE_HASH));
+        } finally {
+            GitHubSCMSource.preferGitHubMergeCommit = original;
+        }
+    }
+
+    @Test
+    public void given__cloud_stackedPullMerge_rev__when__flagOff__then__localMergeAgainstUnreachableBase()
+            throws Exception {
+        createGitHubSCMSourceForTest(false, null);
+        PullRequestSCMHead head = stackedPullRequestHead();
+        PullRequestSCMRevision revision =
+                new PullRequestSCMRevision(head, STACKED_BASE_HASH, STACKED_PULL_HASH, STACKED_MERGE_HASH);
+        source.setCredentialsId(null);
+        // flag defaults to off: the merge hash is ignored and the merge is reconstructed locally against the
+        // unreachable base hash, which is the failure reproduced by issue #1545
+        GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
+        instance.withGitHubRemote();
+        GitSCM actual = instance.build();
+        MergeWithGitSCMExtension merge = getExtension(actual, MergeWithGitSCMExtension.class);
+        assertThat(merge, notNullValue());
+        assertThat(merge.getBaseName(), is("remotes/origin/issue-1545-base"));
+        assertThat(merge.getBaseHash(), is(STACKED_BASE_HASH));
+        BuildChooserSetting chooser = getExtension(actual, BuildChooserSetting.class);
+        AbstractGitSCMSource.SpecificRevisionBuildChooser revChooser =
+                (AbstractGitSCMSource.SpecificRevisionBuildChooser) chooser.getBuildChooser();
+        Collection<Revision> revisions = revChooser.getCandidateRevisions(
+                false,
+                "issue-1545-base",
+                Mockito.mock(GitClient.class),
+                new LogTaskListener(Logger.getAnonymousLogger(), Level.FINEST),
+                null,
+                null);
+        assertThat(revisions, hasSize(1));
+        assertThat(revisions.iterator().next().getSha1String(), is(STACKED_PULL_HASH));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMBuilderTest.java
@@ -1915,9 +1915,13 @@ public class GitHubSCMBuilderTest {
             GitHubSCMBuilder instance = new GitHubSCMBuilder(source, head, revision);
             instance.withGitHubRemote();
             GitSCM actual = instance.build();
-            // github's precomputed merge commit is fetched instead of merging locally
+            // github's precomputed merge commit is fetched directly by sha instead of merging locally;
+            // fetching the exact recorded sha (not refs/pull/2/merge, which github live-recomputes) keeps
+            // the fetched object consistent with the revision checked out below
             UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
-            assertThat(config.getRefspec(), containsString("+refs/pull/2/merge:refs/remotes/origin/PR-2-merge"));
+            assertThat(
+                    config.getRefspec(),
+                    containsString("+" + STACKED_MERGE_HASH + ":refs/remotes/origin/PR-2-merge"));
             // every fetch refspec must target a distinct destination, or git fetch aborts with
             // "Cannot fetch both ... to ..." - the merge ref must not reuse the pull head destination
             RemoteConfig origin = actual.getRepositoryByName("origin");


### PR DESCRIPTION
This pull request adds support for [Github Stacked Pull Requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) (behind a feature flag) by fixing a merge-strategy build failure caused by stacked pull requests. This is my first contribution to this repo or to a Jenkins plugin, so I have some questions/notes in the reviewers section to confirm my approach/design. Additionally I have put this up for review to get feedback now, but in addition to the unit tests, I have deployed this plugin to our Jenkins instance to run for the next week or two to see if we run into issues with it enabled. From my testing this all addresses our issues. 

# Description

When a stacked pull request targets the branch of another open pull request (PR B "the child" and PR A "the base"), the build of PR B fails at checkout with this error:

```
merge: <sha> - not something we can merge
```

The failure occurs when PR A is behind the target branch. In this case GitHub sets the base parent of the merge commit of PR B to the merge preview of PR A (`refs/pull/A/merge`), but no branch contains this commit. The plugin then uses this commit as the base and tries to merge against it, but Git cannot find the commit, so the build fails.

This pull request adds an opt-in system property which defaults to off. When enabled the plugin fetches `refs/pull/N/merge` and checks out the GitHub merge commit directly. My thought/design of this is that the plugin could either replicate the logic or just rely on GitHub's logic, and I thought it would be easier/more robust to use their logic. The merge commit is fetched into its own ref (`…/<name>-merge`) so it does not collide with the pull-head ref.

The new property is:

```
org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.preferGitHubMergeCommit
```

Related to [#1545](https://github.com/jenkinsci/github-branch-source-plugin/issues/1545)

### Notes/Questions for Reviewers

- The plugin defers to GitHub's own logic for what the merge commit is and doesn't use Git locally. Is this the correct approach? Should I evaluate something different?
- The option changes the behavior for all merge pull requests, not just for stacked pull requests only. My thought was this is okay given that the alternative was to recreate and then have to maintain parallel logic to what Github is already doing so instead of a branching case, just rely on Github.
- I left this as a system property to start to allow for this be gradually added, once Github Stacked PRs are out of public preview this could graduate to a UI setting or maybe the default?
- This does not change when builds are triggered: `equivalent()` is untouched, so JENKINS-57583 ("don't rebuild a merge PR when only the target branch changed") still holds. A consequence is that a stacked PR does not automatically rebuild when only its base PR advances, the same as any merge PR today.

### Reviewer's manual test instructions

1. Create PR A with a target of `master`.
2. Create PR B with a target of the branch of PR A.
3. Add a commit to `master`, so PR A is behind `master`.
4. Set the pull request strategy to merge, then build PR B. The build fails.
5. Enable the option by running `org.jenkinsci.plugins.github_branch_source.GitHubSCMSource.preferGitHubMergeCommit = true` in the Script Console.
6. Build PR B again. The build completes.
7. Set the option back to `false` (or remove the property and restart). The behavior returns to the default.

# Submitter checklist

- [x] Link to Github ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist

- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes

- [x] Link to jenkins.io PR, or an explanation for why no doc changes are needed

No documentation change is required. The option is an opt-in system property for preview. Happy to add documentation if requested.

# Users/aliases to notify