### PR TITLE
Fix ready_for_review pull request event handling

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestGHEventSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestGHEventSubscriber.java
@@ -120,13 +120,12 @@ public class PullRequestGHEventSubscriber extends GHEventsSubscriber {
                     return;
                 }
 
-                if ("opened".equals(action)) {
+                if ("opened".equals(action) || "ready_for_review".equals(action)) {
                     fireAfterDelay(new SCMHeadEventImpl(
                             SCMEvent.Type.CREATED, event.getTimestamp(), p, changedRepository, event.getOrigin()));
                 } else if ("reopened".equals(action)
                         || "synchronize".equals(action)
                         || "edited".equals(action)
-                        || "ready_for_review".equals(action)
                         || "converted_to_draft".equals(action)) {
                     fireAfterDelay(new SCMHeadEventImpl(
                             SCMEvent.Type.UPDATED, event.getTimestamp(), p, changedRepository, event.getOrigin()));

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/EventsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/EventsTest.java
@@ -147,10 +147,10 @@ public class EventsTest {
     }
 
     @Test
-    public void given_ghPullRequestEventReadyForReview_then_updatedHeadEventFired() throws Exception {
+    public void given_ghPullRequestEventReadyForReview_then_createdHeadEventFired() throws Exception {
         PullRequestGHEventSubscriber subscriber = new PullRequestGHEventSubscriber();
 
-        firedEventType = SCMEvent.Type.UPDATED;
+        firedEventType = SCMEvent.Type.CREATED;
         ghEvent = callOnEvent(subscriber, "EventsTest/pullRequestEventUpdatedReadyForReview.json");
         waitAndAssertReceived(true);
     }


### PR DESCRIPTION
# Description

Fix handling of the GitHub `ready_for_review` pull request event.

Draft pull requests are intentionally not indexed, so no Jenkins job exists for them. When such a pull request becomes ready for review, the event must be treated as `SCMEvent.Type.CREATED`, allowing Jenkins to discover the PR and create its job.

See [GitHub Issue #1514](https://github.com/jenkinsci/github-branch-source-plugin/issues/1514).

# Submitter checklist
- [x] Link to issue in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [x] No documentation changes are needed for this internal event-handling fix.

# Users/aliases to notify

## Manual test instructions

1. Install the built HPI in a test Jenkins instance.
2. Configure a GitHub Multibranch Pipeline with the `Ignore pull requests marked as drafts` trait.
3. Open a draft pull request.
4. Verify that Jenkins does not create a job for the draft PR.
5. Mark the pull request as ready for review.
6. Verify that Jenkins receives the webhook, discovers the PR, creates the job, and triggers the initial build.
