### PR TITLE
Re-resolve cached scan credentials after a TTL

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -126,7 +126,14 @@ public class Connector {
     }
 
     private static long defaultCredentialsTtlMillis() {
-        int seconds = SystemProperties.getInteger(Connector.class.getName() + ".credentialsTtlSeconds", 60);
+        return credentialsTtlMillis(
+                SystemProperties.getInteger(Connector.class.getName() + ".credentialsTtlSeconds", 60));
+    }
+
+    /**
+     * Maps a configured TTL in seconds onto {@link #credentialsTtlMillis}, any negative value meaning no expiry.
+     */
+    static long credentialsTtlMillis(int seconds) {
         return seconds < 0 ? -1L : TimeUnit.SECONDS.toMillis(seconds);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -94,6 +94,14 @@ public class Connector {
     private static final Map<TaskListener, Map<GitHub, Void>> checked = new WeakHashMap<>();
     private static final long API_URL_REVALIDATE_MILLIS = TimeUnit.MINUTES.toMillis(5);
 
+    /**
+     * How long a credentials object resolved by {@link #lookupScanCredentials(Item, String, String, String)} may
+     * be reused before it is resolved again. Callers that hold on to a credentials object see a change to that
+     * credential only once this has elapsed. Set to {@code 0} to resolve on every use.
+     */
+    /* mostly final */ static long credentialsTtlMillis = TimeUnit.SECONDS.toMillis(
+            Math.max(0, SystemProperties.getInteger(Connector.class.getName() + ".credentialsTtlSeconds", 60)));
+
     private static final Random ENTROPY = new Random();
     private static final String SALT = Long.toHexString(ENTROPY.nextLong());
     private static final OkHttpClient baseClient =
@@ -101,6 +109,17 @@ public class Connector {
 
     private Connector() {
         throw new IllegalAccessError("Utility class");
+    }
+
+    /**
+     * Whether a credentials object resolved at the given time should be resolved again.
+     *
+     * @param resolvedAtMillis when the credentials object was resolved, as {@link System#currentTimeMillis()}
+     * @return {@code true} if {@link #credentialsTtlMillis} has elapsed since then
+     */
+    static boolean isCredentialsStale(long resolvedAtMillis) {
+        long ttl = credentialsTtlMillis;
+        return ttl <= 0 || System.currentTimeMillis() - resolvedAtMillis >= ttl;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java
@@ -97,10 +97,10 @@ public class Connector {
     /**
      * How long a credentials object resolved by {@link #lookupScanCredentials(Item, String, String, String)} may
      * be reused before it is resolved again. Callers that hold on to a credentials object see a change to that
-     * credential only once this has elapsed. Set to {@code 0} to resolve on every use.
+     * credential only once this has elapsed. {@code 0} resolves on every use, a negative value reuses the
+     * credentials object until something forces a refresh.
      */
-    /* mostly final */ static long credentialsTtlMillis = TimeUnit.SECONDS.toMillis(
-            Math.max(0, SystemProperties.getInteger(Connector.class.getName() + ".credentialsTtlSeconds", 60)));
+    /* mostly final */ static long credentialsTtlMillis = defaultCredentialsTtlMillis();
 
     private static final Random ENTROPY = new Random();
     private static final String SALT = Long.toHexString(ENTROPY.nextLong());
@@ -119,7 +119,15 @@ public class Connector {
      */
     static boolean isCredentialsStale(long resolvedAtMillis) {
         long ttl = credentialsTtlMillis;
-        return ttl <= 0 || System.currentTimeMillis() - resolvedAtMillis >= ttl;
+        if (ttl < 0) {
+            return false;
+        }
+        return ttl == 0 || System.currentTimeMillis() - resolvedAtMillis >= ttl;
+    }
+
+    private static long defaultCredentialsTtlMillis() {
+        int seconds = SystemProperties.getInteger(Connector.class.getName() + ".credentialsTtlSeconds", 60);
+        return seconds < 0 ? -1L : TimeUnit.SECONDS.toMillis(seconds);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -269,7 +269,7 @@ public class GitHubSCMNavigator extends SCMNavigator {
 
     @CheckForNull
     @Restricted(NoExternalUse.class)
-    StandardCredentials getCredentials(@CheckForNull Item context, boolean forceRefresh) {
+    private StandardCredentials getCredentials(@CheckForNull Item context, boolean forceRefresh) {
         if (credentials == null || forceRefresh || Connector.isCredentialsStale(credentialsResolvedAt)) {
             credentials = Connector.lookupScanCredentials(context, getApiUri(), getCredentialsId(), getRepoOwner());
             credentialsResolvedAt = System.currentTimeMillis();

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMNavigator.java
@@ -224,6 +224,8 @@ public class GitHubSCMNavigator extends SCMNavigator {
     /** The cache of the credentials object */
     @CheckForNull
     private transient volatile StandardCredentials credentials;
+    /** When {@link #credentials} was resolved, as {@link System#currentTimeMillis()}. */
+    private transient volatile long credentialsResolvedAt;
 
     /**
      * Constructor.
@@ -267,9 +269,10 @@ public class GitHubSCMNavigator extends SCMNavigator {
 
     @CheckForNull
     @Restricted(NoExternalUse.class)
-    private StandardCredentials getCredentials(@CheckForNull Item context, boolean forceRefresh) {
-        if (credentials == null || forceRefresh) {
+    StandardCredentials getCredentials(@CheckForNull Item context, boolean forceRefresh) {
+        if (credentials == null || forceRefresh || Connector.isCredentialsStale(credentialsResolvedAt)) {
             credentials = Connector.lookupScanCredentials(context, getApiUri(), getCredentialsId(), getRepoOwner());
+            credentialsResolvedAt = System.currentTimeMillis();
         }
         return credentials;
     }

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -383,7 +383,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
 
     @CheckForNull
     @Restricted(NoExternalUse.class)
-    StandardCredentials getCredentials(@CheckForNull Item context, boolean forceRefresh) {
+    private StandardCredentials getCredentials(@CheckForNull Item context, boolean forceRefresh) {
         if (credentials == null || forceRefresh || Connector.isCredentialsStale(credentialsResolvedAt)) {
             credentials = Connector.lookupScanCredentials(context, getApiUri(), getCredentialsId(), getRepoOwner());
             credentialsResolvedAt = System.currentTimeMillis();

--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -276,6 +276,8 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
     /** The cache of the credentials object */
     @CheckForNull
     private transient volatile StandardCredentials credentials;
+    /** When {@link #credentials} was resolved, as {@link System#currentTimeMillis()}. */
+    private transient volatile long credentialsResolvedAt;
 
     /**
      * Used during upgrade from 1.x to 2.2.0+ only.
@@ -381,9 +383,10 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
 
     @CheckForNull
     @Restricted(NoExternalUse.class)
-    private StandardCredentials getCredentials(@CheckForNull Item context, boolean forceRefresh) {
-        if (credentials == null || forceRefresh) {
+    StandardCredentials getCredentials(@CheckForNull Item context, boolean forceRefresh) {
+        if (credentials == null || forceRefresh || Connector.isCredentialsStale(credentialsResolvedAt)) {
             credentials = Connector.lookupScanCredentials(context, getApiUri(), getCredentialsId(), getRepoOwner());
+            credentialsResolvedAt = System.currentTimeMillis();
         }
         return credentials;
     }

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/CredentialsRefreshTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/CredentialsRefreshTest.java
@@ -28,6 +28,8 @@ package org.jenkinsci.plugins.github_branch_source;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -37,6 +39,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.model.Item;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import org.junit.After;
@@ -70,14 +73,14 @@ public class CredentialsRefreshTest {
         GitHubSCMSource source = new GitHubSCMSource("cloudbeers", "yolo", null, false);
         source.setCredentialsId(CREDENTIALS_ID);
 
-        StandardCredentials resolved = source.getCredentials(context, false);
+        StandardCredentials resolved = resolve(source, context);
         assertThat(password(resolved), is("first-secret"));
 
         store("second-secret");
-        assertThat(source.getCredentials(context, false), sameInstance(resolved));
+        assertThat(resolve(source, context), sameInstance(resolved));
 
-        Connector.credentialsTtlMillis = 0;
-        assertThat(password(source.getCredentials(context, false)), is("second-secret"));
+        expireTtl();
+        assertThat(password(resolve(source, context)), is("second-secret"));
     }
 
     @Test
@@ -88,14 +91,45 @@ public class CredentialsRefreshTest {
         GitHubSCMNavigator navigator = new GitHubSCMNavigator("cloudbeers");
         navigator.setCredentialsId(CREDENTIALS_ID);
 
-        StandardCredentials resolved = navigator.getCredentials(context, false);
+        StandardCredentials resolved = resolve(navigator, context);
         assertThat(password(resolved), is("first-secret"));
 
         store("second-secret");
-        assertThat(navigator.getCredentials(context, false), sameInstance(resolved));
+        assertThat(resolve(navigator, context), sameInstance(resolved));
 
-        Connector.credentialsTtlMillis = 0;
-        assertThat(password(navigator.getCredentials(context, false)), is("second-secret"));
+        expireTtl();
+        assertThat(password(resolve(navigator, context)), is("second-secret"));
+    }
+
+    @Test
+    public void staleOnlyOnceTheTtlHasElapsed() {
+        long now = System.currentTimeMillis();
+
+        Connector.credentialsTtlMillis = 60_000L;
+        assertFalse(Connector.isCredentialsStale(now));
+        assertTrue(Connector.isCredentialsStale(now - 60_000L));
+
+        Connector.credentialsTtlMillis = 0L;
+        assertTrue(Connector.isCredentialsStale(now));
+
+        Connector.credentialsTtlMillis = -1L;
+        assertFalse(Connector.isCredentialsStale(0L));
+    }
+
+    /**
+     * {@code getCredentials} is private on both classes, deliberately so per the review of #787, hence the
+     * reflection rather than widening it for this test.
+     */
+    private static StandardCredentials resolve(Object sourceOrNavigator, Item context) throws Exception {
+        Method method = sourceOrNavigator.getClass().getDeclaredMethod("getCredentials", Item.class, boolean.class);
+        method.setAccessible(true);
+        return (StandardCredentials) method.invoke(sourceOrNavigator, context, false);
+    }
+
+    /** Lets the TTL elapse for real, rather than exercising only the "resolve on every use" shortcut. */
+    private static void expireTtl() throws InterruptedException {
+        Connector.credentialsTtlMillis = 1L;
+        Thread.sleep(10L);
     }
 
     private static void store(String password) throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/CredentialsRefreshTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/CredentialsRefreshTest.java
@@ -28,6 +28,7 @@ package org.jenkinsci.plugins.github_branch_source;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -73,14 +74,14 @@ public class CredentialsRefreshTest {
         GitHubSCMSource source = new GitHubSCMSource("cloudbeers", "yolo", null, false);
         source.setCredentialsId(CREDENTIALS_ID);
 
-        StandardCredentials resolved = resolve(source, context);
+        StandardCredentials resolved = resolve(source, context, false);
         assertThat(password(resolved), is("first-secret"));
 
         store("second-secret");
-        assertThat(resolve(source, context), sameInstance(resolved));
+        assertThat(resolve(source, context, false), sameInstance(resolved));
 
         expireTtl();
-        assertThat(password(resolve(source, context)), is("second-secret"));
+        assertThat(password(resolve(source, context, false)), is("second-secret"));
     }
 
     @Test
@@ -91,14 +92,34 @@ public class CredentialsRefreshTest {
         GitHubSCMNavigator navigator = new GitHubSCMNavigator("cloudbeers");
         navigator.setCredentialsId(CREDENTIALS_ID);
 
-        StandardCredentials resolved = resolve(navigator, context);
+        StandardCredentials resolved = resolve(navigator, context, false);
         assertThat(password(resolved), is("first-secret"));
 
         store("second-secret");
-        assertThat(resolve(navigator, context), sameInstance(resolved));
+        assertThat(resolve(navigator, context, false), sameInstance(resolved));
 
         expireTtl();
-        assertThat(password(resolve(navigator, context)), is("second-secret"));
+        assertThat(password(resolve(navigator, context, false)), is("second-secret"));
+    }
+
+    @Test
+    public void forceRefreshResolvesInsideTheTtl() throws Exception {
+        Item context = r.createFolder("force");
+        store("first-secret");
+
+        GitHubSCMSource source = new GitHubSCMSource("cloudbeers", "yolo", null, false);
+        source.setCredentialsId(CREDENTIALS_ID);
+        assertThat(password(resolve(source, context, false)), is("first-secret"));
+
+        store("second-secret");
+        assertThat(password(resolve(source, context, true)), is("second-secret"));
+    }
+
+    @Test
+    public void negativeTtlSecondsMeansNoExpiry() {
+        assertEquals(-1L, Connector.credentialsTtlMillis(-1));
+        assertEquals(0L, Connector.credentialsTtlMillis(0));
+        assertEquals(60_000L, Connector.credentialsTtlMillis(60));
     }
 
     @Test
@@ -120,10 +141,11 @@ public class CredentialsRefreshTest {
      * {@code getCredentials} is private on both classes, deliberately so per the review of #787, hence the
      * reflection rather than widening it for this test.
      */
-    private static StandardCredentials resolve(Object sourceOrNavigator, Item context) throws Exception {
+    private static StandardCredentials resolve(Object sourceOrNavigator, Item context, boolean forceRefresh)
+            throws Exception {
         Method method = sourceOrNavigator.getClass().getDeclaredMethod("getCredentials", Item.class, boolean.class);
         method.setAccessible(true);
-        return (StandardCredentials) method.invoke(sourceOrNavigator, context, false);
+        return (StandardCredentials) method.invoke(sourceOrNavigator, context, forceRefresh);
     }
 
     /** Lets the TTL elapse for real, rather than exercising only the "resolve on every use" shortcut. */

--- a/src/test/java/org/jenkinsci/plugins/github_branch_source/CredentialsRefreshTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github_branch_source/CredentialsRefreshTest.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.github_branch_source;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.model.Item;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * A source and a navigator hold on to the credentials object they resolved, so a credential whose content
+ * changed reaches them only when that reference is dropped.
+ */
+public class CredentialsRefreshTest {
+
+    private static final String CREDENTIALS_ID = "github";
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    private final long originalTtl = Connector.credentialsTtlMillis;
+
+    @After
+    public void restoreTtl() {
+        Connector.credentialsTtlMillis = originalTtl;
+    }
+
+    @Test
+    public void sourceResolvesCredentialsAgainOnceTheTtlHasElapsed() throws Exception {
+        Item context = r.createFolder("source");
+        store("first-secret");
+
+        GitHubSCMSource source = new GitHubSCMSource("cloudbeers", "yolo", null, false);
+        source.setCredentialsId(CREDENTIALS_ID);
+
+        StandardCredentials resolved = source.getCredentials(context, false);
+        assertThat(password(resolved), is("first-secret"));
+
+        store("second-secret");
+        assertThat(source.getCredentials(context, false), sameInstance(resolved));
+
+        Connector.credentialsTtlMillis = 0;
+        assertThat(password(source.getCredentials(context, false)), is("second-secret"));
+    }
+
+    @Test
+    public void navigatorResolvesCredentialsAgainOnceTheTtlHasElapsed() throws Exception {
+        Item context = r.createFolder("navigator");
+        store("first-secret");
+
+        GitHubSCMNavigator navigator = new GitHubSCMNavigator("cloudbeers");
+        navigator.setCredentialsId(CREDENTIALS_ID);
+
+        StandardCredentials resolved = navigator.getCredentials(context, false);
+        assertThat(password(resolved), is("first-secret"));
+
+        store("second-secret");
+        assertThat(navigator.getCredentials(context, false), sameInstance(resolved));
+
+        Connector.credentialsTtlMillis = 0;
+        assertThat(password(navigator.getCredentials(context, false)), is("second-secret"));
+    }
+
+    private static void store(String password) throws Exception {
+        Credentials credentials =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, CREDENTIALS_ID, null, "user", password);
+        SystemCredentialsProvider.getInstance()
+                .setDomainCredentialsMap(Collections.singletonMap(Domain.global(), List.of(credentials)));
+    }
+
+    private static String password(StandardCredentials credentials) {
+        return ((StandardUsernamePasswordCredentials) credentials).getPassword().getPlainText();
+    }
+}


### PR DESCRIPTION
# Description

`GitHubSCMSource` and `GitHubSCMNavigator` cache the credentials object they resolved in a `transient volatile` field and only resolve it again when the caller asks for a refresh. Only the full-scan paths do that (`GitHubSCMSource#retrieve` when the observer is not `SCMHeadObserver.Any`, and `GitHubSCMNavigator#visitSources`); every per-build and per-head path passes `forceRefresh=false`.

The field has no expiry, so its lifetime is the source or navigator object: until the job configuration is saved or Jenkins restarts. A credential whose content changed under the same ID is therefore never picked up by builds on its own. A rescan is the only routine operation that clears it.

This is most visible with credentials backed by an external store (Azure Key Vault, HashiCorp Vault, AWS Secrets Manager), where refreshing the provider replaces the credentials object wholesale. Rotating a GitHub App there and reloading the provider cache leaves builds authenticating as the old app, with no indication that anything is stale: the credentials page shows the new value while builds keep using the old one. It also applies to plain stored credentials, where editing a secret in the UI creates a new object that cached references never see.

This bounds the reuse instead of removing it. `Connector.credentialsTtlMillis` defaults to 60 seconds and is configurable through the system property `org.jenkinsci.plugins.github_branch_source.Connector.credentialsTtlSeconds`; `0` resolves on every use, a negative value reuses indefinitely and so restores today's behaviour exactly. During a scan that means a handful of lookups per source rather than one per branch or PR, so the throughput win from [JENKINS-73172] / #787 is kept, while staleness is capped at a minute instead of unbounded.

Two notes for reviewers of #787 in particular:

- Both `getCredentials` methods stay private, per the review nits on that PR. The test reaches them by reflection rather than widening them; happy to swap that for package-private visibility if you prefer.
- It also bounds the case raised in [this comment](https://github.com/jenkinsci/github-branch-source-plugin/pull/787#discussion_r1601003231): the cached reference is keyed on nothing, so a change to `apiUri`, `credentialsId` or `repoOwner` on a live source is not noticed either. A TTL is not the keyed lookup suggested there, but it does put a bound on it.
- For credentials whose provider returns a fresh object per lookup, re-resolving discards the per-instance `AppInstallationToken` cache in `GitHubAppCredentials`, so a new installation token is minted at most once per TTL per source. Providers that cache internally (Azure Key Vault, HashiCorp Vault) return a stable object and are unaffected. Raising the default is easy if you think that trade is wrong.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Automated tests have been added to exercise the changes
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

No JIRA ticket filed yet, happy to open one if maintainers prefer that before review.

`CredentialsRefreshTest` covers both classes: resolve, replace the stored credential under the same ID, assert the cached object is still reused inside the TTL, then assert the new one is resolved once a real TTL has elapsed. Both fail without the production change. A third test asserts the `isCredentialsStale` contract directly, including the zero and negative settings.

Manual test:

1. Create a username/password credential `github` and a multibranch project using it.
2. Scan it, then build a branch.
3. Change the password on that credential.
4. Rebuild the same branch within a minute: the old password is still used, as before.
5. Rebuild after a minute: the new password is used. On master, it stays stale until a rescan.

# Reviewer checklist
- [ ] Run the changes and verify that the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# Documentation changes
- [x] No user-facing documentation change. The system property is an escape hatch for operators who want stricter or looser behaviour than the default.

# Users/aliases to notify

@Dohbedoh, as the author of #787.
